### PR TITLE
Implement manual financial integration for offline accounts

### DIFF
--- a/app/Integrations/Base/ManualPlugin.php
+++ b/app/Integrations/Base/ManualPlugin.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace App\Integrations\Base;
+
+use App\Integrations\Contracts\IntegrationPlugin;
+use App\Models\Integration;
+use App\Models\IntegrationGroup;
+use App\Models\User;
+use Illuminate\Http\Request;
+
+abstract class ManualPlugin implements IntegrationPlugin
+{
+    public static function getServiceType(): string
+    {
+        return 'manual';
+    }
+
+    public function initialize(User $user): Integration
+    {
+        $group = $this->initializeGroup($user);
+
+        return Integration::create([
+            'user_id' => $user->id,
+            'integration_group_id' => $group->id,
+            'service' => static::getIdentifier(),
+            'name' => static::getDisplayName(),
+            'instance_type' => null,
+            'configuration' => [],
+        ]);
+    }
+
+    public function initializeGroup(User $user): IntegrationGroup
+    {
+        return IntegrationGroup::create([
+            'user_id' => $user->id,
+            'service' => static::getIdentifier(),
+            'account_id' => null,
+            'access_token' => null,
+            'refresh_token' => null,
+            'expiry' => null,
+            'refresh_expiry' => null,
+        ]);
+    }
+
+    public function createInstance(IntegrationGroup $group, string $instanceType, array $initialConfig = []): Integration
+    {
+        $defaultName = static::getDisplayName();
+        if (method_exists(static::class, 'getInstanceTypes')) {
+            try {
+                $types = static::getInstanceTypes();
+                $defaultName = $types[$instanceType]['label'] ?? ucfirst($instanceType);
+            } catch (\Throwable $e) {
+                $defaultName = ucfirst($instanceType);
+            }
+        } else {
+            $defaultName = ucfirst($instanceType);
+        }
+
+        return Integration::create([
+            'user_id' => $group->user_id,
+            'integration_group_id' => $group->id,
+            'service' => static::getIdentifier(),
+            'name' => $defaultName,
+            'instance_type' => $instanceType,
+            'configuration' => $initialConfig,
+        ]);
+    }
+
+    public function handleOAuthCallback(Request $request, IntegrationGroup $group): void
+    {
+        // Manual integrations don't use OAuth
+        throw new \Exception('OAuth is not supported for manual integrations');
+    }
+
+    public function handleWebhook(Request $request, Integration $integration): void
+    {
+        // Manual integrations don't use webhooks
+        throw new \Exception('Webhooks are not supported for manual integrations');
+    }
+
+    public function fetchData(Integration $integration): void
+    {
+        // Manual integrations don't fetch data automatically
+        // Data is added by the user through the UI
+    }
+
+    public function convertData(array $externalData, Integration $integration): array
+    {
+        // Manual integrations don't convert external data
+        return [];
+    }
+}

--- a/app/Integrations/Base/ManualPlugin.php
+++ b/app/Integrations/Base/ManualPlugin.php
@@ -7,9 +7,20 @@ use App\Models\Integration;
 use App\Models\IntegrationGroup;
 use App\Models\User;
 use Illuminate\Http\Request;
+use Exception;
 
 abstract class ManualPlugin implements IntegrationPlugin
 {
+    abstract public static function getIdentifier(): string;
+    
+    abstract public static function getDisplayName(): string;
+    
+    abstract public static function getDescription(): string;
+    
+    abstract public static function getConfigurationSchema(): array;
+    
+    abstract public static function getInstanceTypes(): array;
+    
     public static function getServiceType(): string
     {
         return 'manual';
@@ -69,13 +80,13 @@ abstract class ManualPlugin implements IntegrationPlugin
     public function handleOAuthCallback(Request $request, IntegrationGroup $group): void
     {
         // Manual integrations don't use OAuth
-        throw new \Exception('OAuth is not supported for manual integrations');
+        throw new Exception('OAuth is not supported for manual integrations');
     }
 
     public function handleWebhook(Request $request, Integration $integration): void
     {
         // Manual integrations don't use webhooks
-        throw new \Exception('Webhooks are not supported for manual integrations');
+        throw new Exception('Webhooks are not supported for manual integrations');
     }
 
     public function fetchData(Integration $integration): void

--- a/app/Integrations/Base/ManualPlugin.php
+++ b/app/Integrations/Base/ManualPlugin.php
@@ -6,25 +6,26 @@ use App\Integrations\Contracts\IntegrationPlugin;
 use App\Models\Integration;
 use App\Models\IntegrationGroup;
 use App\Models\User;
-use Illuminate\Http\Request;
 use Exception;
+use Illuminate\Http\Request;
+use Throwable;
 
 abstract class ManualPlugin implements IntegrationPlugin
 {
-    abstract public static function getIdentifier(): string;
-    
-    abstract public static function getDisplayName(): string;
-    
-    abstract public static function getDescription(): string;
-    
-    abstract public static function getConfigurationSchema(): array;
-    
-    abstract public static function getInstanceTypes(): array;
-    
     public static function getServiceType(): string
     {
         return 'manual';
     }
+
+    abstract public static function getIdentifier(): string;
+
+    abstract public static function getDisplayName(): string;
+
+    abstract public static function getDescription(): string;
+
+    abstract public static function getConfigurationSchema(): array;
+
+    abstract public static function getInstanceTypes(): array;
 
     public function initialize(User $user): Integration
     {
@@ -60,7 +61,7 @@ abstract class ManualPlugin implements IntegrationPlugin
             try {
                 $types = static::getInstanceTypes();
                 $defaultName = $types[$instanceType]['label'] ?? ucfirst($instanceType);
-            } catch (\Throwable $e) {
+            } catch (Throwable $e) {
                 $defaultName = ucfirst($instanceType);
             }
         } else {

--- a/app/Integrations/Manual/ManualFinancialPlugin.php
+++ b/app/Integrations/Manual/ManualFinancialPlugin.php
@@ -8,8 +8,6 @@ use App\Models\EventObject;
 use App\Models\Integration;
 use App\Models\IntegrationGroup;
 use App\Models\User;
-use Illuminate\Http\Request;
-use Illuminate\Support\Str;
 
 class ManualFinancialPlugin extends ManualPlugin
 {
@@ -129,42 +127,9 @@ class ManualFinancialPlugin extends ManualPlugin
         ];
     }
 
-    public function initializeGroup(User $user): IntegrationGroup
-    {
-        return IntegrationGroup::create([
-            'user_id' => $user->id,
-            'service' => static::getIdentifier(),
-            'account_id' => null,
-            'access_token' => null,
-            'refresh_token' => null,
-            'expiry' => null,
-            'refresh_expiry' => null,
-        ]);
-    }
 
-    public function createInstance(IntegrationGroup $group, string $instanceType, array $initialConfig = []): Integration
-    {
-        $defaultName = static::getDisplayName();
-        if (method_exists(static::class, 'getInstanceTypes')) {
-            try {
-                $types = static::getInstanceTypes();
-                $defaultName = $types[$instanceType]['label'] ?? ucfirst($instanceType);
-            } catch (\Throwable $e) {
-                $defaultName = ucfirst($instanceType);
-            }
-        } else {
-            $defaultName = ucfirst($instanceType);
-        }
 
-        return Integration::create([
-            'user_id' => $group->user_id,
-            'integration_group_id' => $group->id,
-            'service' => static::getIdentifier(),
-            'name' => $defaultName,
-            'instance_type' => $instanceType,
-            'configuration' => $initialConfig,
-        ]);
-    }
+
 
     public function fetchData(Integration $integration): void
     {

--- a/app/Integrations/Manual/ManualFinancialPlugin.php
+++ b/app/Integrations/Manual/ManualFinancialPlugin.php
@@ -1,0 +1,253 @@
+<?php
+
+namespace App\Integrations\Manual;
+
+use App\Integrations\Base\ManualPlugin;
+use App\Models\Event;
+use App\Models\EventObject;
+use App\Models\Integration;
+use App\Models\IntegrationGroup;
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+
+class ManualFinancialPlugin extends ManualPlugin
+{
+    public static function getIdentifier(): string
+    {
+        return 'manual-financial';
+    }
+
+    public static function getDisplayName(): string
+    {
+        return 'Manual Financial';
+    }
+
+    public static function getDescription(): string
+    {
+        return 'Manually track your financial accounts, including mortgages, savings accounts, and investments. Perfect for banks and providers without API support.';
+    }
+
+    public static function getServiceType(): string
+    {
+        return 'manual';
+    }
+
+    public static function getConfigurationSchema(): array
+    {
+        return [
+            'account_type' => [
+                'type' => 'select',
+                'label' => 'Account Type',
+                'description' => 'The type of financial account',
+                'options' => [
+                    'mortgage' => 'Mortgage',
+                    'savings' => 'Savings Account',
+                    'current' => 'Current Account',
+                    'investment' => 'Investment Account',
+                    'credit_card' => 'Credit Card',
+                    'loan' => 'Personal Loan',
+                    'pension' => 'Pension',
+                    'other' => 'Other',
+                ],
+                'required' => true,
+            ],
+            'provider_name' => [
+                'type' => 'text',
+                'label' => 'Provider Name',
+                'description' => 'The name of your bank or financial provider',
+                'required' => true,
+            ],
+            'account_number' => [
+                'type' => 'text',
+                'label' => 'Account Number',
+                'description' => 'Your account number or reference (optional)',
+                'required' => false,
+            ],
+            'currency' => [
+                'type' => 'select',
+                'label' => 'Currency',
+                'description' => 'The currency for this account',
+                'options' => [
+                    'GBP' => 'British Pound (£)',
+                    'EUR' => 'Euro (€)',
+                    'USD' => 'US Dollar ($)',
+                ],
+                'default' => 'GBP',
+                'required' => true,
+            ],
+            'interest_rate' => [
+                'type' => 'number',
+                'label' => 'Interest Rate (%)',
+                'description' => 'Annual interest rate (optional)',
+                'required' => false,
+                'step' => '0.01',
+                'min' => '0',
+                'max' => '100',
+            ],
+        ];
+    }
+
+    public static function getInstanceTypes(): array
+    {
+        return [
+            'accounts' => [
+                'label' => 'Financial Accounts',
+                'schema' => self::getConfigurationSchema(),
+            ],
+            'balances' => [
+                'label' => 'Balance Updates',
+                'schema' => [
+                    'account_id' => [
+                        'type' => 'select',
+                        'label' => 'Account',
+                        'description' => 'Select the account to update',
+                        'options' => [], // Will be populated dynamically
+                        'required' => true,
+                    ],
+                    'balance' => [
+                        'type' => 'number',
+                        'label' => 'Balance',
+                        'description' => 'Current account balance',
+                        'required' => true,
+                        'step' => '0.01',
+                    ],
+                    'date' => [
+                        'type' => 'date',
+                        'label' => 'Date',
+                        'description' => 'Date of this balance update',
+                        'required' => true,
+                    ],
+                    'notes' => [
+                        'type' => 'textarea',
+                        'label' => 'Notes',
+                        'description' => 'Optional notes about this update',
+                        'required' => false,
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function initializeGroup(User $user): IntegrationGroup
+    {
+        return IntegrationGroup::create([
+            'user_id' => $user->id,
+            'service' => static::getIdentifier(),
+            'account_id' => null,
+            'access_token' => null,
+            'refresh_token' => null,
+            'expiry' => null,
+            'refresh_expiry' => null,
+        ]);
+    }
+
+    public function createInstance(IntegrationGroup $group, string $instanceType, array $initialConfig = []): Integration
+    {
+        $defaultName = static::getDisplayName();
+        if (method_exists(static::class, 'getInstanceTypes')) {
+            try {
+                $types = static::getInstanceTypes();
+                $defaultName = $types[$instanceType]['label'] ?? ucfirst($instanceType);
+            } catch (\Throwable $e) {
+                $defaultName = ucfirst($instanceType);
+            }
+        } else {
+            $defaultName = ucfirst($instanceType);
+        }
+
+        return Integration::create([
+            'user_id' => $group->user_id,
+            'integration_group_id' => $group->id,
+            'service' => static::getIdentifier(),
+            'name' => $defaultName,
+            'instance_type' => $instanceType,
+            'configuration' => $initialConfig,
+        ]);
+    }
+
+    public function fetchData(Integration $integration): void
+    {
+        // Manual integrations don't fetch data automatically
+        // Data is added by the user through the UI
+    }
+
+    public function convertData(array $externalData, Integration $integration): array
+    {
+        // Manual integrations don't convert external data
+        return [];
+    }
+
+    public function createAccount(Integration $integration, array $accountData): EventObject
+    {
+        $account = EventObject::create([
+            'integration_id' => $integration->id,
+            'user_id' => $integration->user_id,
+            'concept' => 'financial_account',
+            'type' => 'account',
+            'title' => $accountData['provider_name'] . ' - ' . ucfirst($accountData['account_type']),
+            'content' => json_encode([
+                'account_type' => $accountData['account_type'],
+                'provider_name' => $accountData['provider_name'],
+                'account_number' => $accountData['account_number'] ?? null,
+                'currency' => $accountData['currency'],
+                'interest_rate' => $accountData['interest_rate'] ?? null,
+            ]),
+            'metadata' => [
+                'account_type' => $accountData['account_type'],
+                'provider_name' => $accountData['provider_name'],
+                'account_number' => $accountData['account_number'] ?? null,
+                'currency' => $accountData['currency'],
+                'interest_rate' => $accountData['interest_rate'] ?? null,
+                'created_at' => now()->toISOString(),
+            ],
+            'time' => now(),
+        ]);
+
+        return $account;
+    }
+
+    public function createBalanceUpdate(Integration $integration, array $balanceData): Event
+    {
+        $account = EventObject::find($balanceData['account_id']);
+        if (!$account) {
+            throw new \InvalidArgumentException('Account not found');
+        }
+
+        $event = Event::create([
+            'integration_id' => $integration->id,
+            'actor_id' => $account->id,
+            'service' => static::getIdentifier(),
+            'domain' => 'finance',
+            'action' => 'balance_update',
+            'value' => $balanceData['balance'],
+            'value_unit' => 'currency',
+            'time' => $balanceData['date'],
+            'event_metadata' => [
+                'account_id' => $balanceData['account_id'],
+                'notes' => $balanceData['notes'] ?? null,
+                'currency' => $account->metadata['currency'] ?? 'GBP',
+            ],
+        ]);
+
+        return $event;
+    }
+
+    public function getAccountsForUser(User $user): array
+    {
+        $accounts = EventObject::where('user_id', $user->id)
+            ->where('concept', 'financial_account')
+            ->where('type', 'account')
+            ->get();
+
+        return $accounts->map(function ($account) {
+            return [
+                'id' => $account->id,
+                'title' => $account->title,
+                'account_type' => $account->metadata['account_type'] ?? 'unknown',
+                'provider_name' => $account->metadata['provider_name'] ?? 'Unknown',
+                'currency' => $account->metadata['currency'] ?? 'GBP',
+            ];
+        })->toArray();
+    }
+}

--- a/app/Integrations/Manual/ManualFinancialPlugin.php
+++ b/app/Integrations/Manual/ManualFinancialPlugin.php
@@ -6,7 +6,6 @@ use App\Integrations\Base\ManualPlugin;
 use App\Models\Event;
 use App\Models\EventObject;
 use App\Models\Integration;
-use App\Models\IntegrationGroup;
 use App\Models\User;
 use InvalidArgumentException;
 
@@ -172,7 +171,7 @@ class ManualFinancialPlugin extends ManualPlugin
     public function createBalanceUpdate(Integration $integration, array $balanceData): Event
     {
         $account = EventObject::find($balanceData['account_id']);
-        if (!$account) {
+        if (! $account) {
             throw new InvalidArgumentException('Account not found');
         }
 

--- a/app/Integrations/Manual/ManualFinancialPlugin.php
+++ b/app/Integrations/Manual/ManualFinancialPlugin.php
@@ -127,10 +127,6 @@ class ManualFinancialPlugin extends ManualPlugin
         ];
     }
 
-
-
-
-
     public function fetchData(Integration $integration): void
     {
         // Manual integrations don't fetch data automatically

--- a/app/Integrations/Manual/ManualFinancialPlugin.php
+++ b/app/Integrations/Manual/ManualFinancialPlugin.php
@@ -8,6 +8,7 @@ use App\Models\EventObject;
 use App\Models\Integration;
 use App\Models\IntegrationGroup;
 use App\Models\User;
+use InvalidArgumentException;
 
 class ManualFinancialPlugin extends ManualPlugin
 {
@@ -172,7 +173,7 @@ class ManualFinancialPlugin extends ManualPlugin
     {
         $account = EventObject::find($balanceData['account_id']);
         if (!$account) {
-            throw new \InvalidArgumentException('Account not found');
+            throw new InvalidArgumentException('Account not found');
         }
 
         $event = Event::create([

--- a/app/Providers/IntegrationServiceProvider.php
+++ b/app/Providers/IntegrationServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use App\Integrations\GitHub\GitHubPlugin;
+use App\Integrations\Manual\ManualFinancialPlugin;
 use App\Integrations\Monzo\MonzoPlugin;
 use App\Integrations\Oura\OuraPlugin;
 use App\Integrations\PluginRegistry;
@@ -23,6 +24,7 @@ class IntegrationServiceProvider extends ServiceProvider
         PluginRegistry::register(SpotifyPlugin::class);
         PluginRegistry::register(OuraPlugin::class);
         PluginRegistry::register(MonzoPlugin::class);
+        PluginRegistry::register(ManualFinancialPlugin::class);
     }
 
     /**

--- a/docs/MANUAL_FINANCIAL_INTEGRATION.md
+++ b/docs/MANUAL_FINANCIAL_INTEGRATION.md
@@ -1,0 +1,1 @@
+# Manual Financial Integration

--- a/resources/views/livewire/integrations/index.blade.php
+++ b/resources/views/livewire/integrations/index.blade.php
@@ -314,21 +314,21 @@ new class extends Component {
                                         @if ($plugin['type'] === 'manual' && $integration['service'] === 'manual-financial')
                                             <div class="text-xs text-base-content/70 mb-2">
                                                 <div class="flex items-center gap-2">
-                                                    <x-button 
-                                                        label="Dashboard" 
-                                                        icon="o-home" 
+                                                    <x-button
+                                                        label="Dashboard"
+                                                        icon="o-home"
                                                         class="btn-xs btn-primary"
                                                         link="{{ route('manual-financial.dashboard', $integration['id']) }}"
                                                     />
-                                                    <x-button 
-                                                        label="Accounts" 
-                                                        icon="o-banknotes" 
+                                                    <x-button
+                                                        label="Accounts"
+                                                        icon="o-banknotes"
                                                         class="btn-xs btn-secondary"
                                                         link="{{ route('manual-financial.accounts', $integration['id']) }}"
                                                     />
-                                                    <x-button 
-                                                        label="Balances" 
-                                                        icon="o-chart-line" 
+                                                    <x-button
+                                                        label="Balances"
+                                                        icon="o-chart-line"
                                                         class="btn-xs btn-accent"
                                                         link="{{ route('manual-financial.balances', $integration['id']) }}"
                                                     />

--- a/resources/views/livewire/integrations/index.blade.php
+++ b/resources/views/livewire/integrations/index.blade.php
@@ -193,6 +193,8 @@ new class extends Component {
                                         <svg class="w-4 h-4 text-base-content" fill="currentColor" viewBox="0 0 24 24">
                                             <path d="M6.194 14.644c0 1.16-.943 2.107-2.107 2.107-1.164 0-2.107-.947-2.107-2.107 0-1.16.943-2.106 2.107-2.106 1.164 0 2.107.946 2.107 2.106zm5.882-2.107c-1.164 0-2.107.946-2.107 2.106 0 1.16.943 2.107 2.107 2.107 1.164 0 2.107-.947 2.107-2.107 0-1.16-.943-2.106-2.107-2.106zm2.107-5.882c0-1.164-.943-2.107-2.107-2.107-1.164 0-2.107.943-2.107 2.107 0 1.164.943 2.107 2.107 2.107 1.164 0 2.107-.943 2.107-2.107zm2.106 5.882c0-1.164-.943-2.107-2.107-2.107-1.164 0-2.107.943-2.107 2.107 0 1.164.943 2.107 2.107 2.107 1.164 0 2.107-.943 2.107-2.107zm5.882-2.107c-1.164 0-2.107.946-2.107 2.106 0 1.16.943 2.107 2.107 2.107 1.164 0 2.107-.947 2.107-2.107 0-1.16-.943-2.106-2.107-2.106z"/>
                                         </svg>
+                                    @elseif ($plugin['identifier'] === 'manual-financial')
+                                        <x-icon name="o-banknotes" class="w-4 h-4 text-primary" />
                                     @else
                                         <svg class="w-4 h-4 text-base-content" fill="currentColor" viewBox="0 0 20 20">
                                             <path fill-rule="evenodd" d="M3 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1zm0 4a1 1 0 011-1h12a1 1 0 110 2H4a1 1 0 01-1-1z" clip-rule="evenodd"></path>
@@ -306,6 +308,31 @@ new class extends Component {
                                                         Never updated
                                                     </div>
                                                 @endif
+                                            </div>
+                                        @endif
+
+                                        @if ($plugin['type'] === 'manual' && $integration['service'] === 'manual-financial')
+                                            <div class="text-xs text-base-content/70 mb-2">
+                                                <div class="flex items-center gap-2">
+                                                    <x-button 
+                                                        label="Dashboard" 
+                                                        icon="o-home" 
+                                                        class="btn-xs btn-primary"
+                                                        link="{{ route('manual-financial.dashboard', $integration['id']) }}"
+                                                    />
+                                                    <x-button 
+                                                        label="Accounts" 
+                                                        icon="o-banknotes" 
+                                                        class="btn-xs btn-secondary"
+                                                        link="{{ route('manual-financial.accounts', $integration['id']) }}"
+                                                    />
+                                                    <x-button 
+                                                        label="Balances" 
+                                                        icon="o-chart-line" 
+                                                        class="btn-xs btn-accent"
+                                                        link="{{ route('manual-financial.balances', $integration['id']) }}"
+                                                    />
+                                                </div>
                                             </div>
                                         @endif
 

--- a/resources/views/livewire/manual-financial/accounts.blade.php
+++ b/resources/views/livewire/manual-financial/accounts.blade.php
@@ -1,0 +1,264 @@
+<?php
+
+use App\Integrations\Manual\ManualFinancialPlugin;
+use App\Models\EventObject;
+use App\Models\Integration;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Volt\Component;
+use Mary\Traits\Toast;
+
+new class extends Component {
+    use Toast;
+
+    public Integration $integration;
+    public array $accounts = [];
+    public bool $showCreateForm = false;
+    public array $formData = [
+        'account_type' => '',
+        'provider_name' => '',
+        'account_number' => '',
+        'currency' => 'GBP',
+        'interest_rate' => '',
+    ];
+
+    public function mount(Integration $integration): void
+    {
+        $this->integration = $integration;
+        $this->loadAccounts();
+    }
+
+    public function loadAccounts(): void
+    {
+        $this->accounts = EventObject::where('user_id', Auth::id())
+            ->where('concept', 'financial_account')
+            ->where('type', 'account')
+            ->orderBy('created_at', 'desc')
+            ->get()
+            ->map(function ($account) {
+                return [
+                    'id' => $account->id,
+                    'title' => $account->title,
+                    'account_type' => $account->metadata['account_type'] ?? 'unknown',
+                    'provider_name' => $account->metadata['provider_name'] ?? 'Unknown',
+                    'currency' => $account->metadata['currency'] ?? 'GBP',
+                    'interest_rate' => $account->metadata['interest_rate'] ?? null,
+                    'created_at' => $account->created_at->format('d/m/Y'),
+                ];
+            })
+            ->toArray();
+    }
+
+    public function createAccount(): void
+    {
+        $this->validate([
+            'formData.account_type' => 'required|string',
+            'formData.provider_name' => 'required|string|max:255',
+            'formData.account_number' => 'nullable|string|max:255',
+            'formData.currency' => 'required|string|in:GBP,EUR,USD',
+            'formData.interest_rate' => 'nullable|numeric|min:0|max:100',
+        ]);
+
+        $plugin = new ManualFinancialPlugin();
+        $plugin->createAccount($this->integration, $this->formData);
+
+        $this->showCreateForm = false;
+        $this->resetForm();
+        $this->loadAccounts();
+        $this->success('Account created successfully!');
+    }
+
+    public function resetForm(): void
+    {
+        $this->formData = [
+            'account_type' => '',
+            'provider_name' => '',
+            'account_number' => '',
+            'currency' => 'GBP',
+            'interest_rate' => '',
+        ];
+    }
+
+    public function deleteAccount(string $accountId): void
+    {
+        $account = EventObject::find($accountId);
+        if ($account && $account->user_id === Auth::id()) {
+            $account->delete();
+            $this->loadAccounts();
+            $this->success('Account deleted successfully!');
+        }
+    }
+
+    public function getAccountTypeLabel(string $type): string
+    {
+        $types = [
+            'mortgage' => 'Mortgage',
+            'savings' => 'Savings Account',
+            'current' => 'Current Account',
+            'investment' => 'Investment Account',
+            'credit_card' => 'Credit Card',
+            'loan' => 'Personal Loan',
+            'pension' => 'Pension',
+            'other' => 'Other',
+        ];
+
+        return $types[$type] ?? ucfirst($type);
+    }
+
+    public function getCurrencySymbol(string $currency): string
+    {
+        return [
+            'GBP' => '£',
+            'EUR' => '€',
+            'USD' => '$',
+        ][$currency] ?? $currency;
+    }
+}; ?>
+
+<div>
+    <div class="flex justify-between items-center mb-6">
+        <h2 class="text-2xl font-bold">Financial Accounts</h2>
+        <x-button 
+            label="Add Account" 
+            icon="o-plus" 
+            class="btn-primary"
+            wire:click="$set('showCreateForm', true)"
+        />
+    </div>
+
+    @if($showCreateForm)
+        <x-card class="mb-6">
+            <h3 class="text-lg font-semibold mb-4">Create New Account</h3>
+            <form wire:submit="createAccount">
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <x-select 
+                        label="Account Type" 
+                        wire:model="formData.account_type"
+                        :options="[
+                            'mortgage' => 'Mortgage',
+                            'savings' => 'Savings Account',
+                            'current' => 'Current Account',
+                            'investment' => 'Investment Account',
+                            'credit_card' => 'Credit Card',
+                            'loan' => 'Personal Loan',
+                            'pension' => 'Pension',
+                            'other' => 'Other',
+                        ]"
+                        required
+                    />
+                    
+                    <x-input 
+                        label="Provider Name" 
+                        wire:model="formData.provider_name"
+                        placeholder="e.g. Barclays, Santander"
+                        required
+                    />
+                    
+                    <x-input 
+                        label="Account Number" 
+                        wire:model="formData.account_number"
+                        placeholder="Optional account reference"
+                    />
+                    
+                    <x-select 
+                        label="Currency" 
+                        wire:model="formData.currency"
+                        :options="[
+                            'GBP' => 'British Pound (£)',
+                            'EUR' => 'Euro (€)',
+                            'USD' => 'US Dollar ($)',
+                        ]"
+                        required
+                    />
+                    
+                    <x-input 
+                        label="Interest Rate (%)" 
+                        wire:model="formData.interest_rate"
+                        type="number"
+                        step="0.01"
+                        min="0"
+                        max="100"
+                        placeholder="Optional annual rate"
+                    />
+                </div>
+                
+                <div class="flex gap-2 mt-6">
+                    <x-button 
+                        type="submit" 
+                        label="Create Account" 
+                        class="btn-primary"
+                        spinner="createAccount"
+                    />
+                    <x-button 
+                        label="Cancel" 
+                        class="btn-ghost"
+                        wire:click="$set('showCreateForm', false)"
+                    />
+                </div>
+            </form>
+        </x-card>
+    @endif
+
+    @if(empty($accounts))
+        <x-card>
+            <div class="text-center py-8">
+                <x-icon name="o-banknotes" class="w-16 h-16 text-base-300 mx-auto mb-4" />
+                <h3 class="text-lg font-semibold mb-2">No accounts yet</h3>
+                <p class="text-base-content/70 mb-4">Create your first financial account to start tracking your finances.</p>
+                <x-button 
+                    label="Create Account" 
+                    icon="o-plus" 
+                    class="btn-primary"
+                    wire:click="$set('showCreateForm', true)"
+                />
+            </div>
+        </x-card>
+    @else
+        <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            @foreach($accounts as $account)
+                <x-card>
+                    <div class="flex justify-between items-start mb-3">
+                        <div class="flex-1">
+                            <h3 class="font-semibold text-lg">{{ $account['title'] }}</h3>
+                            <p class="text-sm text-base-content/70">{{ $account['provider_name'] }}</p>
+                        </div>
+                        <x-dropdown>
+                            <x-slot:trigger>
+                                <x-button icon="o-ellipsis-vertical" class="btn-ghost btn-sm" />
+                            </x-slot:trigger>
+                            <x-menu-item 
+                                title="Delete" 
+                                icon="o-trash" 
+                                class="text-error"
+                                wire:click="deleteAccount('{{ $account['id'] }}')"
+                            />
+                        </x-dropdown>
+                    </div>
+                    
+                    <div class="space-y-2">
+                        <div class="flex justify-between">
+                            <span class="text-sm text-base-content/70">Type:</span>
+                            <span class="text-sm font-medium">{{ $this->getAccountTypeLabel($account['account_type']) }}</span>
+                        </div>
+                        
+                        <div class="flex justify-between">
+                            <span class="text-sm text-base-content/70">Currency:</span>
+                            <span class="text-sm font-medium">{{ $account['currency'] }}</span>
+                        </div>
+                        
+                        @if($account['interest_rate'])
+                            <div class="flex justify-between">
+                                <span class="text-sm text-base-content/70">Interest Rate:</span>
+                                <span class="text-sm font-medium">{{ $account['interest_rate'] }}%</span>
+                            </div>
+                        @endif
+                        
+                        <div class="flex justify-between">
+                            <span class="text-sm text-base-content/70">Created:</span>
+                            <span class="text-sm text-base-content/70">{{ $account['created_at'] }}</span>
+                        </div>
+                    </div>
+                </x-card>
+            @endforeach
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/manual-financial/accounts.blade.php
+++ b/resources/views/livewire/manual-financial/accounts.blade.php
@@ -104,14 +104,7 @@ new class extends Component {
         return $types[$type] ?? ucfirst($type);
     }
 
-    public function getCurrencySymbol(string $currency): string
-    {
-        return [
-            'GBP' => '£',
-            'EUR' => '€',
-            'USD' => '$',
-        ][$currency] ?? $currency;
-    }
+
 }; ?>
 
 <div>

--- a/resources/views/livewire/manual-financial/accounts.blade.php
+++ b/resources/views/livewire/manual-financial/accounts.blade.php
@@ -110,21 +110,21 @@ new class extends Component {
 <div>
     <div class="flex justify-between items-center mb-6">
         <h2 class="text-2xl font-bold">Financial Accounts</h2>
-        <x-button 
-            label="Add Account" 
-            icon="o-plus" 
+        <x-button
+            label="Add Account"
+            icon="o-plus"
             class="btn-primary"
             wire:click="$set('showCreateForm', true)"
         />
     </div>
 
-    @if($showCreateForm)
+    @if ($showCreateForm)
         <x-card class="mb-6">
             <h3 class="text-lg font-semibold mb-4">Create New Account</h3>
             <form wire:submit="createAccount">
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <x-select 
-                        label="Account Type" 
+                    <x-select
+                        label="Account Type"
                         wire:model="formData.account_type"
                         :options="[
                             'mortgage' => 'Mortgage',
@@ -138,22 +138,22 @@ new class extends Component {
                         ]"
                         required
                     />
-                    
-                    <x-input 
-                        label="Provider Name" 
+
+                    <x-input
+                        label="Provider Name"
                         wire:model="formData.provider_name"
                         placeholder="e.g. Barclays, Santander"
                         required
                     />
-                    
-                    <x-input 
-                        label="Account Number" 
+
+                    <x-input
+                        label="Account Number"
                         wire:model="formData.account_number"
                         placeholder="Optional account reference"
                     />
-                    
-                    <x-select 
-                        label="Currency" 
+
+                    <x-select
+                        label="Currency"
                         wire:model="formData.currency"
                         :options="[
                             'GBP' => 'British Pound (£)',
@@ -162,9 +162,9 @@ new class extends Component {
                         ]"
                         required
                     />
-                    
-                    <x-input 
-                        label="Interest Rate (%)" 
+
+                    <x-input
+                        label="Interest Rate (%)"
                         wire:model="formData.interest_rate"
                         type="number"
                         step="0.01"
@@ -173,16 +173,16 @@ new class extends Component {
                         placeholder="Optional annual rate"
                     />
                 </div>
-                
+
                 <div class="flex gap-2 mt-6">
-                    <x-button 
-                        type="submit" 
-                        label="Create Account" 
+                    <x-button
+                        type="submit"
+                        label="Create Account"
                         class="btn-primary"
                         spinner="createAccount"
                     />
-                    <x-button 
-                        label="Cancel" 
+                    <x-button
+                        label="Cancel"
                         class="btn-ghost"
                         wire:click="$set('showCreateForm', false)"
                     />
@@ -191,15 +191,15 @@ new class extends Component {
         </x-card>
     @endif
 
-    @if(empty($accounts))
+    @if (empty($accounts))
         <x-card>
             <div class="text-center py-8">
                 <x-icon name="o-banknotes" class="w-16 h-16 text-base-300 mx-auto mb-4" />
                 <h3 class="text-lg font-semibold mb-2">No accounts yet</h3>
                 <p class="text-base-content/70 mb-4">Create your first financial account to start tracking your finances.</p>
-                <x-button 
-                    label="Create Account" 
-                    icon="o-plus" 
+                <x-button
+                    label="Create Account"
+                    icon="o-plus"
                     class="btn-primary"
                     wire:click="$set('showCreateForm', true)"
                 />
@@ -207,7 +207,7 @@ new class extends Component {
         </x-card>
     @else
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            @foreach($accounts as $account)
+            @foreach ($accounts as $account)
                 <x-card>
                     <div class="flex justify-between items-start mb-3">
                         <div class="flex-1">
@@ -218,33 +218,33 @@ new class extends Component {
                             <x-slot:trigger>
                                 <x-button icon="o-ellipsis-vertical" class="btn-ghost btn-sm" />
                             </x-slot:trigger>
-                            <x-menu-item 
-                                title="Delete" 
-                                icon="o-trash" 
+                            <x-menu-item
+                                title="Delete"
+                                icon="o-trash"
                                 class="text-error"
                                 wire:click="deleteAccount('{{ $account['id'] }}')"
                             />
                         </x-dropdown>
                     </div>
-                    
+
                     <div class="space-y-2">
                         <div class="flex justify-between">
                             <span class="text-sm text-base-content/70">Type:</span>
                             <span class="text-sm font-medium">{{ $this->getAccountTypeLabel($account['account_type']) }}</span>
                         </div>
-                        
+
                         <div class="flex justify-between">
                             <span class="text-sm text-base-content/70">Currency:</span>
                             <span class="text-sm font-medium">{{ $account['currency'] }}</span>
                         </div>
-                        
-                        @if($account['interest_rate'])
+
+                        @if ($account['interest_rate'])
                             <div class="flex justify-between">
                                 <span class="text-sm text-base-content/70">Interest Rate:</span>
                                 <span class="text-sm font-medium">{{ $account['interest_rate'] }}%</span>
                             </div>
                         @endif
-                        
+
                         <div class="flex justify-between">
                             <span class="text-sm text-base-content/70">Created:</span>
                             <span class="text-sm text-base-content/70">{{ $account['created_at'] }}</span>

--- a/resources/views/livewire/manual-financial/balances.blade.php
+++ b/resources/views/livewire/manual-financial/balances.blade.php
@@ -127,60 +127,60 @@ new class extends Component {
 <div>
     <div class="flex justify-between items-center mb-6">
         <h2 class="text-2xl font-bold">Balance Updates</h2>
-        <x-button 
-            label="Add Balance Update" 
-            icon="o-plus" 
+        <x-button
+            label="Add Balance Update"
+            icon="o-plus"
             class="btn-primary"
             wire:click="$set('showCreateForm', true)"
         />
     </div>
 
-    @if($showCreateForm)
+    @if ($showCreateForm)
         <x-card class="mb-6">
             <h3 class="text-lg font-semibold mb-4">Create New Balance Update</h3>
             <form wire:submit="createBalanceUpdate">
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-                    <x-select 
-                        label="Account" 
+                    <x-select
+                        label="Account"
                         wire:model="formData.account_id"
                         :options="collect($accounts)->pluck('title', 'id')->toArray()"
                         placeholder="Select an account"
                         required
                     />
-                    
-                    <x-input 
-                        label="Balance" 
+
+                    <x-input
+                        label="Balance"
                         wire:model="formData.balance"
                         type="number"
                         step="0.01"
                         placeholder="0.00"
                         required
                     />
-                    
-                    <x-input 
-                        label="Date" 
+
+                    <x-input
+                        label="Date"
                         wire:model="formData.date"
                         type="date"
                         required
                     />
-                    
-                    <x-textarea 
-                        label="Notes" 
+
+                    <x-textarea
+                        label="Notes"
                         wire:model="formData.notes"
                         placeholder="Optional notes about this update"
                         rows="3"
                     />
                 </div>
-                
+
                 <div class="flex gap-2 mt-6">
-                    <x-button 
-                        type="submit" 
-                        label="Create Update" 
+                    <x-button
+                        type="submit"
+                        label="Create Update"
                         class="btn-primary"
                         spinner="createBalanceUpdate"
                     />
-                    <x-button 
-                        label="Cancel" 
+                    <x-button
+                        label="Cancel"
                         class="btn-ghost"
                         wire:click="$set('showCreateForm', false)"
                     />
@@ -189,15 +189,15 @@ new class extends Component {
         </x-card>
     @endif
 
-    @if(empty($balances))
+    @if (empty($balances))
         <x-card>
             <div class="text-center py-8">
                 <x-icon name="o-chart-line" class="w-16 h-16 text-base-300 mx-auto mb-4" />
                 <h3 class="text-lg font-semibold mb-2">No balance updates yet</h3>
                 <p class="text-base-content/70 mb-4">Create your first balance update to start tracking your account balances over time.</p>
-                <x-button 
-                    label="Add Balance Update" 
-                    icon="o-plus" 
+                <x-button
+                    label="Add Balance Update"
+                    icon="o-plus"
                     class="btn-primary"
                     wire:click="$set('showCreateForm', true)"
                 />
@@ -205,7 +205,7 @@ new class extends Component {
         </x-card>
     @else
         <div class="space-y-4">
-            @foreach($balances as $balance)
+            @foreach ($balances as $balance)
                 <x-card>
                     <div class="flex justify-between items-start">
                         <div class="flex-1">
@@ -213,30 +213,30 @@ new class extends Component {
                                 <h3 class="font-semibold text-lg">{{ $balance['account_title'] }}</h3>
                                 <span class="badge badge-primary">{{ $balance['currency'] }}</span>
                             </div>
-                            
+
                             <div class="text-2xl font-bold text-primary mb-2">
                                 {{ $this->formatBalance($balance['balance'], $balance['currency']) }}
                             </div>
-                            
+
                             <div class="flex items-center gap-4 text-sm text-base-content/70">
                                 <span>Date: {{ $balance['date'] }}</span>
                                 <span>Added: {{ $balance['created_at'] }}</span>
                             </div>
-                            
-                            @if($balance['notes'])
+
+                            @if ($balance['notes'])
                                 <div class="mt-3 p-3 bg-base-200 rounded-lg">
                                     <p class="text-sm">{{ $balance['notes'] }}</p>
                                 </div>
                             @endif
                         </div>
-                        
+
                         <x-dropdown>
                             <x-slot:trigger>
                                 <x-button icon="o-ellipsis-vertical" class="btn-ghost btn-sm" />
                             </x-slot:trigger>
-                            <x-menu-item 
-                                title="Delete" 
-                                icon="o-trash" 
+                            <x-menu-item
+                                title="Delete"
+                                icon="o-trash"
                                 class="text-error"
                                 wire:click="deleteBalance('{{ $balance['id'] }}')"
                             />

--- a/resources/views/livewire/manual-financial/balances.blade.php
+++ b/resources/views/livewire/manual-financial/balances.blade.php
@@ -1,0 +1,249 @@
+<?php
+
+use App\Integrations\Manual\ManualFinancialPlugin;
+use App\Models\Event;
+use App\Models\EventObject;
+use App\Models\Integration;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Volt\Component;
+use Mary\Traits\Toast;
+
+new class extends Component {
+    use Toast;
+
+    public Integration $integration;
+    public array $accounts = [];
+    public array $balances = [];
+    public bool $showCreateForm = false;
+    public array $formData = [
+        'account_id' => '',
+        'balance' => '',
+        'date' => '',
+        'notes' => '',
+    ];
+
+    public function mount(Integration $integration): void
+    {
+        $this->integration = $integration;
+        $this->loadAccounts();
+        $this->loadBalances();
+        $this->formData['date'] = now()->format('Y-m-d');
+    }
+
+    public function loadAccounts(): void
+    {
+        $this->accounts = EventObject::where('user_id', Auth::id())
+            ->where('concept', 'financial_account')
+            ->where('type', 'account')
+            ->orderBy('title')
+            ->get()
+            ->map(function ($account) {
+                return [
+                    'id' => $account->id,
+                    'title' => $account->title,
+                    'currency' => $account->metadata['currency'] ?? 'GBP',
+                ];
+            })
+            ->toArray();
+    }
+
+    public function loadBalances(): void
+    {
+        $this->balances = Event::where('integration_id', $this->integration->id)
+            ->where('domain', 'finance')
+            ->where('action', 'balance_update')
+            ->with(['actor'])
+            ->orderBy('time', 'desc')
+            ->get()
+            ->map(function ($event) {
+                $account = $event->actor;
+                return [
+                    'id' => $event->id,
+                    'account_title' => $account ? $account->title : 'Unknown Account',
+                    'balance' => $event->value,
+                    'currency' => $event->event_metadata['currency'] ?? 'GBP',
+                    'date' => $event->time->format('d/m/Y'),
+                    'notes' => $event->event_metadata['notes'] ?? null,
+                    'created_at' => $event->created_at->format('d/m/Y H:i'),
+                ];
+            })
+            ->toArray();
+    }
+
+    public function createBalanceUpdate(): void
+    {
+        $this->validate([
+            'formData.account_id' => 'required|string|exists:objects,id',
+            'formData.balance' => 'required|numeric',
+            'formData.date' => 'required|date',
+            'formData.notes' => 'nullable|string|max:1000',
+        ]);
+
+        $plugin = new ManualFinancialPlugin();
+        $plugin->createBalanceUpdate($this->integration, $this->formData);
+
+        $this->showCreateForm = false;
+        $this->resetForm();
+        $this->loadBalances();
+        $this->success('Balance update created successfully!');
+    }
+
+    public function resetForm(): void
+    {
+        $this->formData = [
+            'account_id' => '',
+            'balance' => '',
+            'date' => now()->format('Y-m-d'),
+            'notes' => '',
+        ];
+    }
+
+    public function deleteBalance(string $balanceId): void
+    {
+        $balance = Event::find($balanceId);
+        if ($balance && $balance->integration_id === $this->integration->id) {
+            $balance->delete();
+            $this->loadBalances();
+            $this->success('Balance update deleted successfully!');
+        }
+    }
+
+    public function getCurrencySymbol(string $currency): string
+    {
+        return [
+            'GBP' => '£',
+            'EUR' => '€',
+            'USD' => '$',
+        ][$currency] ?? $currency;
+    }
+
+    public function formatBalance(float $balance, string $currency): string
+    {
+        $symbol = $this->getCurrencySymbol($currency);
+        return $symbol . number_format($balance, 2);
+    }
+}; ?>
+
+<div>
+    <div class="flex justify-between items-center mb-6">
+        <h2 class="text-2xl font-bold">Balance Updates</h2>
+        <x-button 
+            label="Add Balance Update" 
+            icon="o-plus" 
+            class="btn-primary"
+            wire:click="$set('showCreateForm', true)"
+        />
+    </div>
+
+    @if($showCreateForm)
+        <x-card class="mb-6">
+            <h3 class="text-lg font-semibold mb-4">Create New Balance Update</h3>
+            <form wire:submit="createBalanceUpdate">
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <x-select 
+                        label="Account" 
+                        wire:model="formData.account_id"
+                        :options="collect($accounts)->pluck('title', 'id')->toArray()"
+                        placeholder="Select an account"
+                        required
+                    />
+                    
+                    <x-input 
+                        label="Balance" 
+                        wire:model="formData.balance"
+                        type="number"
+                        step="0.01"
+                        placeholder="0.00"
+                        required
+                    />
+                    
+                    <x-input 
+                        label="Date" 
+                        wire:model="formData.date"
+                        type="date"
+                        required
+                    />
+                    
+                    <x-textarea 
+                        label="Notes" 
+                        wire:model="formData.notes"
+                        placeholder="Optional notes about this update"
+                        rows="3"
+                    />
+                </div>
+                
+                <div class="flex gap-2 mt-6">
+                    <x-button 
+                        type="submit" 
+                        label="Create Update" 
+                        class="btn-primary"
+                        spinner="createBalanceUpdate"
+                    />
+                    <x-button 
+                        label="Cancel" 
+                        class="btn-ghost"
+                        wire:click="$set('showCreateForm', false)"
+                    />
+                </div>
+            </form>
+        </x-card>
+    @endif
+
+    @if(empty($balances))
+        <x-card>
+            <div class="text-center py-8">
+                <x-icon name="o-chart-line" class="w-16 h-16 text-base-300 mx-auto mb-4" />
+                <h3 class="text-lg font-semibold mb-2">No balance updates yet</h3>
+                <p class="text-base-content/70 mb-4">Create your first balance update to start tracking your account balances over time.</p>
+                <x-button 
+                    label="Add Balance Update" 
+                    icon="o-plus" 
+                    class="btn-primary"
+                    wire:click="$set('showCreateForm', true)"
+                />
+            </div>
+        </x-card>
+    @else
+        <div class="space-y-4">
+            @foreach($balances as $balance)
+                <x-card>
+                    <div class="flex justify-between items-start">
+                        <div class="flex-1">
+                            <div class="flex items-center gap-3 mb-2">
+                                <h3 class="font-semibold text-lg">{{ $balance['account_title'] }}</h3>
+                                <span class="badge badge-primary">{{ $balance['currency'] }}</span>
+                            </div>
+                            
+                            <div class="text-2xl font-bold text-primary mb-2">
+                                {{ $this->formatBalance($balance['balance'], $balance['currency']) }}
+                            </div>
+                            
+                            <div class="flex items-center gap-4 text-sm text-base-content/70">
+                                <span>Date: {{ $balance['date'] }}</span>
+                                <span>Added: {{ $balance['created_at'] }}</span>
+                            </div>
+                            
+                            @if($balance['notes'])
+                                <div class="mt-3 p-3 bg-base-200 rounded-lg">
+                                    <p class="text-sm">{{ $balance['notes'] }}</p>
+                                </div>
+                            @endif
+                        </div>
+                        
+                        <x-dropdown>
+                            <x-slot:trigger>
+                                <x-button icon="o-ellipsis-vertical" class="btn-ghost btn-sm" />
+                            </x-slot:trigger>
+                            <x-menu-item 
+                                title="Delete" 
+                                icon="o-trash" 
+                                class="text-error"
+                                wire:click="deleteBalance('{{ $balance['id'] }}')"
+                            />
+                        </x-dropdown>
+                    </div>
+                </x-card>
+            @endforeach
+        </div>
+    @endif
+</div>

--- a/resources/views/livewire/manual-financial/dashboard.blade.php
+++ b/resources/views/livewire/manual-financial/dashboard.blade.php
@@ -1,0 +1,247 @@
+<?php
+
+use App\Models\Event;
+use App\Models\EventObject;
+use App\Models\Integration;
+use Illuminate\Support\Facades\Auth;
+use Livewire\Volt\Component;
+
+new class extends Component {
+    public Integration $integration;
+    public array $summary = [];
+    public array $recentBalances = [];
+
+    public function mount(Integration $integration): void
+    {
+        $this->integration = $integration;
+        $this->loadSummary();
+        $this->loadRecentBalances();
+    }
+
+    public function loadSummary(): void
+    {
+        $userId = Auth::id();
+        
+        // Get total accounts
+        $totalAccounts = EventObject::where('user_id', $userId)
+            ->where('concept', 'financial_account')
+            ->where('type', 'account')
+            ->count();
+        
+        // Get total balance updates
+        $totalUpdates = Event::where('integration_id', $this->integration->id)
+            ->where('domain', 'finance')
+            ->where('action', 'balance_update')
+            ->count();
+        
+        // Get latest balance for each account
+        $latestBalances = Event::where('integration_id', $this->integration->id)
+            ->where('domain', 'finance')
+            ->where('action', 'balance_update')
+            ->with(['actor'])
+            ->get()
+            ->groupBy('actor_id')
+            ->map(function ($events) {
+                return $events->sortByDesc('time')->first();
+            })
+            ->filter()
+            ->values();
+        
+        $totalValue = $latestBalances->sum('value');
+        
+        $this->summary = [
+            'total_accounts' => $totalAccounts,
+            'total_updates' => $totalUpdates,
+            'total_value' => $totalValue,
+            'currency' => 'GBP', // Default, could be made dynamic
+        ];
+    }
+
+    public function loadRecentBalances(): void
+    {
+        $this->recentBalances = Event::where('integration_id', $this->integration->id)
+            ->where('domain', 'finance')
+            ->where('action', 'balance_update')
+            ->with(['actor'])
+            ->orderBy('time', 'desc')
+            ->limit(5)
+            ->get()
+            ->map(function ($event) {
+                $account = $event->actor;
+                return [
+                    'id' => $event->id,
+                    'account_title' => $account ? $account->title : 'Unknown Account',
+                    'balance' => $event->value,
+                    'currency' => $event->event_metadata['currency'] ?? 'GBP',
+                    'date' => $event->time->format('d/m/Y'),
+                    'account_type' => $account ? ($account->metadata['account_type'] ?? 'unknown') : 'unknown',
+                ];
+            })
+            ->toArray();
+    }
+
+    public function getAccountTypeLabel(string $type): string
+    {
+        $types = [
+            'mortgage' => 'Mortgage',
+            'savings' => 'Savings',
+            'current' => 'Current',
+            'investment' => 'Investment',
+            'credit_card' => 'Credit Card',
+            'loan' => 'Loan',
+            'pension' => 'Pension',
+            'other' => 'Other',
+        ];
+
+        return $types[$type] ?? ucfirst($type);
+    }
+
+    public function getCurrencySymbol(string $currency): string
+    {
+        return [
+            'GBP' => '£',
+            'EUR' => '€',
+            'USD' => '$',
+        ][$currency] ?? $currency;
+    }
+
+    public function formatBalance(float $balance, string $currency): string
+    {
+        $symbol = $this->getCurrencySymbol($currency);
+        return $symbol . number_format($balance, 2);
+    }
+}; ?>
+
+<div>
+    <div class="mb-8">
+        <h1 class="text-3xl font-bold mb-2">Manual Financial Dashboard</h1>
+        <p class="text-base-content/70">Track your financial accounts and balances manually for banks without API support.</p>
+    </div>
+
+    <!-- Summary Cards -->
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-6 mb-8">
+        <x-card>
+            <div class="flex items-center gap-4">
+                <div class="p-3 bg-primary/10 rounded-lg">
+                    <x-icon name="o-banknotes" class="w-8 h-8 text-primary" />
+                </div>
+                <div>
+                    <p class="text-sm text-base-content/70">Total Accounts</p>
+                    <p class="text-2xl font-bold">{{ $summary['total_accounts'] }}</p>
+                </div>
+            </div>
+        </x-card>
+
+        <x-card>
+            <div class="flex items-center gap-4">
+                <div class="p-3 bg-secondary/10 rounded-lg">
+                    <x-icon name="o-chart-line" class="w-8 h-8 text-secondary" />
+                </div>
+                <div>
+                    <p class="text-sm text-base-content/70">Total Updates</p>
+                    <p class="text-2xl font-bold">{{ $summary['total_updates'] }}</p>
+                </div>
+            </div>
+        </x-card>
+
+        <x-card>
+            <div class="flex items-center gap-4">
+                <div class="p-3 bg-accent/10 rounded-lg">
+                    <x-icon name="o-currency-pound" class="w-8 h-8 text-accent" />
+                </div>
+                <div>
+                    <p class="text-sm text-base-content/70">Total Value</p>
+                    <p class="text-2xl font-bold">{{ $this->formatBalance($summary['total_value'], $summary['currency']) }}</p>
+                </div>
+            </div>
+        </x-card>
+    </div>
+
+    <!-- Quick Actions -->
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
+        <x-card>
+            <div class="text-center py-6">
+                <x-icon name="o-plus-circle" class="w-16 h-16 text-primary mx-auto mb-4" />
+                <h3 class="text-lg font-semibold mb-2">Add New Account</h3>
+                <p class="text-base-content/70 mb-4">Create a new financial account to start tracking.</p>
+                <x-button 
+                    label="Create Account" 
+                    icon="o-plus" 
+                    class="btn-primary"
+                    link="/integrations/{{ $integration->id }}/accounts"
+                />
+            </div>
+        </x-card>
+
+        <x-card>
+            <div class="text-center py-6">
+                <x-icon name="o-chart-line" class="w-16 h-16 text-secondary mx-auto mb-4" />
+                <h3 class="text-lg font-semibold mb-2">Update Balance</h3>
+                <p class="text-base-content/70 mb-4">Add a new balance update for any of your accounts.</p>
+                <x-button 
+                    label="Add Update" 
+                    icon="o-plus" 
+                    class="btn-secondary"
+                    link="/integrations/{{ $integration->id }}/balances"
+                />
+            </div>
+        </x-card>
+    </div>
+
+    <!-- Recent Balance Updates -->
+    @if(!empty($recentBalances))
+        <x-card>
+            <div class="flex justify-between items-center mb-6">
+                <h2 class="text-xl font-semibold">Recent Balance Updates</h2>
+                <x-button 
+                    label="View All" 
+                    icon="o-arrow-right" 
+                    class="btn-ghost"
+                    link="/integrations/{{ $integration->id }}/balances"
+                />
+            </div>
+            
+            <div class="space-y-4">
+                @foreach($recentBalances as $balance)
+                    <div class="flex items-center justify-between p-4 bg-base-100 rounded-lg border">
+                        <div class="flex items-center gap-4">
+                            <div class="w-10 h-10 bg-primary/10 rounded-full flex items-center justify-center">
+                                <x-icon name="o-banknotes" class="w-5 h-5 text-primary" />
+                            </div>
+                            <div>
+                                <h4 class="font-medium">{{ $balance['account_title'] }}</h4>
+                                <p class="text-sm text-base-content/70">
+                                    {{ $this->getAccountTypeLabel($balance['account_type']) }} • {{ $balance['date'] }}
+                                </p>
+                            </div>
+                        </div>
+                        <div class="text-right">
+                            <p class="text-lg font-bold text-primary">
+                                {{ $this->formatBalance($balance['balance'], $balance['currency']) }}
+                            </p>
+                        </div>
+                    </div>
+                @endforeach
+            </div>
+        </x-card>
+    @endif
+
+    <!-- Navigation -->
+    <div class="mt-8">
+        <h2 class="text-xl font-semibold mb-4">Manage Your Finances</h2>
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <x-button 
+                label="Manage Accounts" 
+                icon="o-banknotes" 
+                class="btn-outline btn-lg justify-start"
+                link="/integrations/{{ $integration->id }}/accounts"
+            />
+            <x-button 
+                label="Manage Balances" 
+                icon="o-chart-line" 
+                class="btn-outline btn-lg justify-start"
+                link="/integrations/{{ $integration->id }}/balances"
+            />
+        </div>
+    </div>
+</div>

--- a/resources/views/livewire/manual-financial/dashboard.blade.php
+++ b/resources/views/livewire/manual-financial/dashboard.blade.php
@@ -96,18 +96,16 @@ new class extends Component {
         return $types[$type] ?? ucfirst($type);
     }
 
-    public function getCurrencySymbol(string $currency): string
-    {
-        return [
-            'GBP' => '£',
-            'EUR' => '€',
-            'USD' => '$',
-        ][$currency] ?? $currency;
-    }
+
 
     public function formatBalance(float $balance, string $currency): string
     {
-        $symbol = $this->getCurrencySymbol($currency);
+        $symbols = [
+            'GBP' => '£',
+            'EUR' => '€',
+            'USD' => '$',
+        ];
+        $symbol = $symbols[$currency] ?? $currency;
         return $symbol . number_format($balance, 2);
     }
 }; ?>

--- a/resources/views/livewire/manual-financial/dashboard.blade.php
+++ b/resources/views/livewire/manual-financial/dashboard.blade.php
@@ -96,8 +96,6 @@ new class extends Component {
         return $types[$type] ?? ucfirst($type);
     }
 
-
-
     public function formatBalance(float $balance, string $currency): string
     {
         $symbols = [

--- a/resources/views/livewire/manual-financial/dashboard.blade.php
+++ b/resources/views/livewire/manual-financial/dashboard.blade.php
@@ -21,19 +21,19 @@ new class extends Component {
     public function loadSummary(): void
     {
         $userId = Auth::id();
-        
+
         // Get total accounts
         $totalAccounts = EventObject::where('user_id', $userId)
             ->where('concept', 'financial_account')
             ->where('type', 'account')
             ->count();
-        
+
         // Get total balance updates
         $totalUpdates = Event::where('integration_id', $this->integration->id)
             ->where('domain', 'finance')
             ->where('action', 'balance_update')
             ->count();
-        
+
         // Get latest balance for each account
         $latestBalances = Event::where('integration_id', $this->integration->id)
             ->where('domain', 'finance')
@@ -46,9 +46,9 @@ new class extends Component {
             })
             ->filter()
             ->values();
-        
+
         $totalValue = $latestBalances->sum('value');
-        
+
         $this->summary = [
             'total_accounts' => $totalAccounts,
             'total_updates' => $totalUpdates,
@@ -160,9 +160,9 @@ new class extends Component {
                 <x-icon name="o-plus-circle" class="w-16 h-16 text-primary mx-auto mb-4" />
                 <h3 class="text-lg font-semibold mb-2">Add New Account</h3>
                 <p class="text-base-content/70 mb-4">Create a new financial account to start tracking.</p>
-                <x-button 
-                    label="Create Account" 
-                    icon="o-plus" 
+                <x-button
+                    label="Create Account"
+                    icon="o-plus"
                     class="btn-primary"
                     link="/integrations/{{ $integration->id }}/accounts"
                 />
@@ -174,9 +174,9 @@ new class extends Component {
                 <x-icon name="o-chart-line" class="w-16 h-16 text-secondary mx-auto mb-4" />
                 <h3 class="text-lg font-semibold mb-2">Update Balance</h3>
                 <p class="text-base-content/70 mb-4">Add a new balance update for any of your accounts.</p>
-                <x-button 
-                    label="Add Update" 
-                    icon="o-plus" 
+                <x-button
+                    label="Add Update"
+                    icon="o-plus"
                     class="btn-secondary"
                     link="/integrations/{{ $integration->id }}/balances"
                 />
@@ -185,20 +185,20 @@ new class extends Component {
     </div>
 
     <!-- Recent Balance Updates -->
-    @if(!empty($recentBalances))
+    @if (!empty($recentBalances))
         <x-card>
             <div class="flex justify-between items-center mb-6">
                 <h2 class="text-xl font-semibold">Recent Balance Updates</h2>
-                <x-button 
-                    label="View All" 
-                    icon="o-arrow-right" 
+                <x-button
+                    label="View All"
+                    icon="o-arrow-right"
                     class="btn-ghost"
                     link="/integrations/{{ $integration->id }}/balances"
                 />
             </div>
-            
+
             <div class="space-y-4">
-                @foreach($recentBalances as $balance)
+                @foreach ($recentBalances as $balance)
                     <div class="flex items-center justify-between p-4 bg-base-100 rounded-lg border">
                         <div class="flex items-center gap-4">
                             <div class="w-10 h-10 bg-primary/10 rounded-full flex items-center justify-center">
@@ -226,15 +226,15 @@ new class extends Component {
     <div class="mt-8">
         <h2 class="text-xl font-semibold mb-4">Manage Your Finances</h2>
         <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <x-button 
-                label="Manage Accounts" 
-                icon="o-banknotes" 
+            <x-button
+                label="Manage Accounts"
+                icon="o-banknotes"
                 class="btn-outline btn-lg justify-start"
                 link="/integrations/{{ $integration->id }}/accounts"
             />
-            <x-button 
-                label="Manage Balances" 
-                icon="o-chart-line" 
+            <x-button
+                label="Manage Balances"
+                icon="o-chart-line"
                 class="btn-outline btn-lg justify-start"
                 link="/integrations/{{ $integration->id }}/balances"
             />

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,7 +42,7 @@ Route::middleware(['auth'])->group(function () {
         ->whereUuid('group')
         ->name('integrations.storeInstances');
     Volt::route('/integrations/{integration}/configure', 'integrations.configure')->name('integrations.configure');
-    
+
     // Manual Financial Integration routes
     Volt::route('/integrations/{integration}/manual-financial', 'manual-financial.dashboard')->name('manual-financial.dashboard');
     Volt::route('/integrations/{integration}/manual-financial/accounts', 'manual-financial.accounts')->name('manual-financial.accounts');

--- a/routes/web.php
+++ b/routes/web.php
@@ -42,6 +42,11 @@ Route::middleware(['auth'])->group(function () {
         ->whereUuid('group')
         ->name('integrations.storeInstances');
     Volt::route('/integrations/{integration}/configure', 'integrations.configure')->name('integrations.configure');
+    
+    // Manual Financial Integration routes
+    Volt::route('/integrations/{integration}/manual-financial', 'manual-financial.dashboard')->name('manual-financial.dashboard');
+    Volt::route('/integrations/{integration}/manual-financial/accounts', 'manual-financial.accounts')->name('manual-financial.accounts');
+    Volt::route('/integrations/{integration}/manual-financial/balances', 'manual-financial.balances')->name('manual-financial.balances');
 
 });
 

--- a/tests/Feature/ManualFinancialIntegrationTest.php
+++ b/tests/Feature/ManualFinancialIntegrationTest.php
@@ -1,0 +1,217 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Integrations\Manual\ManualFinancialPlugin;
+use App\Models\Event;
+use App\Models\EventObject;
+use App\Models\Integration;
+use App\Models\IntegrationGroup;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ManualFinancialIntegrationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+    private ManualFinancialPlugin $plugin;
+    private IntegrationGroup $group;
+    private Integration $integration;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        
+        $this->user = User::factory()->create();
+        $this->plugin = new ManualFinancialPlugin();
+        $this->group = $this->plugin->initializeGroup($this->user);
+        $this->integration = $this->plugin->createInstance($this->group, 'accounts');
+    }
+
+    public function test_plugin_identifier(): void
+    {
+        $this->assertEquals('manual-financial', ManualFinancialPlugin::getIdentifier());
+    }
+
+    public function test_plugin_display_name(): void
+    {
+        $this->assertEquals('Manual Financial', ManualFinancialPlugin::getDisplayName());
+    }
+
+    public function test_plugin_description(): void
+    {
+        $this->assertStringContainsString('Manually track your financial accounts', ManualFinancialPlugin::getDescription());
+    }
+
+    public function test_plugin_service_type(): void
+    {
+        $this->assertEquals('manual', ManualFinancialPlugin::getServiceType());
+    }
+
+    public function test_configuration_schema(): void
+    {
+        $schema = ManualFinancialPlugin::getConfigurationSchema();
+        
+        $this->assertArrayHasKey('account_type', $schema);
+        $this->assertArrayHasKey('provider_name', $schema);
+        $this->assertArrayHasKey('currency', $schema);
+        $this->assertArrayHasKey('interest_rate', $schema);
+        
+        $this->assertEquals('select', $schema['account_type']['type']);
+        $this->assertEquals('text', $schema['provider_name']['type']);
+        $this->assertEquals('select', $schema['currency']['type']);
+        $this->assertEquals('number', $schema['interest_rate']['type']);
+    }
+
+    public function test_instance_types(): void
+    {
+        $types = ManualFinancialPlugin::getInstanceTypes();
+        
+        $this->assertArrayHasKey('accounts', $types);
+        $this->assertArrayHasKey('balances', $types);
+        
+        $this->assertEquals('Financial Accounts', $types['accounts']['label']);
+        $this->assertEquals('Balance Updates', $types['balances']['label']);
+    }
+
+    public function test_initialize_group(): void
+    {
+        $group = $this->plugin->initializeGroup($this->user);
+        
+        $this->assertInstanceOf(IntegrationGroup::class, $group);
+        $this->assertEquals($this->user->id, $group->user_id);
+        $this->assertEquals('manual-financial', $group->service);
+        $this->assertNull($group->account_id);
+    }
+
+    public function test_create_instance(): void
+    {
+        $instance = $this->plugin->createInstance($this->group, 'accounts');
+        
+        $this->assertInstanceOf(Integration::class, $instance);
+        $this->assertEquals($this->user->id, $instance->user_id);
+        $this->assertEquals($this->group->id, $instance->integration_group_id);
+        $this->assertEquals('manual-financial', $instance->service);
+        $this->assertEquals('accounts', $instance->instance_type);
+    }
+
+    public function test_create_account(): void
+    {
+        $accountData = [
+            'account_type' => 'savings',
+            'provider_name' => 'Barclays',
+            'account_number' => '12345678',
+            'currency' => 'GBP',
+            'interest_rate' => 2.5,
+        ];
+
+        $account = $this->plugin->createAccount($this->integration, $accountData);
+        
+        $this->assertInstanceOf(EventObject::class, $account);
+        $this->assertEquals($this->integration->id, $account->integration_id);
+        $this->assertEquals($this->user->id, $account->user_id);
+        $this->assertEquals('financial_account', $account->concept);
+        $this->assertEquals('account', $account->type);
+        $this->assertEquals('Barclays - Savings', $account->title);
+        
+        $this->assertEquals('savings', $account->metadata['account_type']);
+        $this->assertEquals('Barclays', $account->metadata['provider_name']);
+        $this->assertEquals('12345678', $account->metadata['account_number']);
+        $this->assertEquals('GBP', $account->metadata['currency']);
+        $this->assertEquals(2.5, $account->metadata['interest_rate']);
+    }
+
+    public function test_create_balance_update(): void
+    {
+        // First create an account
+        $accountData = [
+            'account_type' => 'savings',
+            'provider_name' => 'Barclays',
+            'currency' => 'GBP',
+        ];
+        
+        $account = $this->plugin->createAccount($this->integration, $accountData);
+        
+        // Then create a balance update
+        $balanceData = [
+            'account_id' => $account->id,
+            'balance' => 5000.00,
+            'date' => '2024-01-15',
+            'notes' => 'Monthly statement balance',
+        ];
+        
+        $balance = $this->plugin->createBalanceUpdate($this->integration, $balanceData);
+        
+        $this->assertInstanceOf(Event::class, $balance);
+        $this->assertEquals($this->integration->id, $balance->integration_id);
+        $this->assertEquals($account->id, $balance->actor_id);
+        $this->assertEquals('manual-financial', $balance->service);
+        $this->assertEquals('finance', $balance->domain);
+        $this->assertEquals('balance_update', $balance->action);
+        $this->assertEquals(5000.00, $balance->value);
+        $this->assertEquals('currency', $balance->value_unit);
+        
+        $this->assertEquals($account->id, $balance->event_metadata['account_id']);
+        $this->assertEquals('Monthly statement balance', $balance->event_metadata['notes']);
+        $this->assertEquals('GBP', $balance->event_metadata['currency']);
+    }
+
+    public function test_create_balance_update_with_invalid_account(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Account not found');
+        
+        $balanceData = [
+            'account_id' => 'invalid-uuid',
+            'balance' => 5000.00,
+            'date' => '2024-01-15',
+        ];
+        
+        $this->plugin->createBalanceUpdate($this->integration, $balanceData);
+    }
+
+    public function test_get_accounts_for_user(): void
+    {
+        // Create multiple accounts
+        $accountData1 = [
+            'account_type' => 'savings',
+            'provider_name' => 'Barclays',
+            'currency' => 'GBP',
+        ];
+        
+        $accountData2 = [
+            'account_type' => 'mortgage',
+            'provider_name' => 'Santander',
+            'currency' => 'GBP',
+        ];
+        
+        $this->plugin->createAccount($this->integration, $accountData1);
+        $this->plugin->createAccount($this->integration, $accountData2);
+        
+        $accounts = $this->plugin->getAccountsForUser($this->user);
+        
+        $this->assertCount(2, $accounts);
+        $this->assertEquals('Barclays - Savings', $accounts[0]['title']);
+        $this->assertEquals('Santander - Mortgage', $accounts[1]['title']);
+        $this->assertEquals('savings', $accounts[0]['account_type']);
+        $this->assertEquals('mortgage', $accounts[1]['account_type']);
+    }
+
+    public function test_fetch_data_does_nothing(): void
+    {
+        // This should not throw any errors
+        $this->plugin->fetchData($this->integration);
+        
+        // No events should be created
+        $this->assertEquals(0, Event::count());
+    }
+
+    public function test_convert_data_returns_empty_array(): void
+    {
+        $result = $this->plugin->convertData(['some' => 'data'], $this->integration);
+        
+        $this->assertEquals([], $result);
+    }
+}

--- a/tests/Feature/ManualFinancialIntegrationTest.php
+++ b/tests/Feature/ManualFinancialIntegrationTest.php
@@ -9,6 +9,7 @@ use App\Models\Integration;
 use App\Models\IntegrationGroup;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use InvalidArgumentException;
 use Tests\TestCase;
 
 class ManualFinancialIntegrationTest extends TestCase
@@ -23,73 +24,97 @@ class ManualFinancialIntegrationTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-        
+
         $this->user = User::factory()->create();
-        $this->plugin = new ManualFinancialPlugin();
+        $this->plugin = new ManualFinancialPlugin;
         $this->group = $this->plugin->initializeGroup($this->user);
         $this->integration = $this->plugin->createInstance($this->group, 'accounts');
     }
 
-    public function test_plugin_identifier(): void
+    /**
+     * @test
+     */
+    public function plugin_identifier(): void
     {
         $this->assertEquals('manual-financial', ManualFinancialPlugin::getIdentifier());
     }
 
-    public function test_plugin_display_name(): void
+    /**
+     * @test
+     */
+    public function plugin_display_name(): void
     {
         $this->assertEquals('Manual Financial', ManualFinancialPlugin::getDisplayName());
     }
 
-    public function test_plugin_description(): void
+    /**
+     * @test
+     */
+    public function plugin_description(): void
     {
         $this->assertStringContainsString('Manually track your financial accounts', ManualFinancialPlugin::getDescription());
     }
 
-    public function test_plugin_service_type(): void
+    /**
+     * @test
+     */
+    public function plugin_service_type(): void
     {
         $this->assertEquals('manual', ManualFinancialPlugin::getServiceType());
     }
 
-    public function test_configuration_schema(): void
+    /**
+     * @test
+     */
+    public function configuration_schema(): void
     {
         $schema = ManualFinancialPlugin::getConfigurationSchema();
-        
+
         $this->assertArrayHasKey('account_type', $schema);
         $this->assertArrayHasKey('provider_name', $schema);
         $this->assertArrayHasKey('currency', $schema);
         $this->assertArrayHasKey('interest_rate', $schema);
-        
+
         $this->assertEquals('select', $schema['account_type']['type']);
         $this->assertEquals('text', $schema['provider_name']['type']);
         $this->assertEquals('select', $schema['currency']['type']);
         $this->assertEquals('number', $schema['interest_rate']['type']);
     }
 
-    public function test_instance_types(): void
+    /**
+     * @test
+     */
+    public function instance_types(): void
     {
         $types = ManualFinancialPlugin::getInstanceTypes();
-        
+
         $this->assertArrayHasKey('accounts', $types);
         $this->assertArrayHasKey('balances', $types);
-        
+
         $this->assertEquals('Financial Accounts', $types['accounts']['label']);
         $this->assertEquals('Balance Updates', $types['balances']['label']);
     }
 
-    public function test_initialize_group(): void
+    /**
+     * @test
+     */
+    public function initialize_group(): void
     {
         $group = $this->plugin->initializeGroup($this->user);
-        
+
         $this->assertInstanceOf(IntegrationGroup::class, $group);
         $this->assertEquals($this->user->id, $group->user_id);
         $this->assertEquals('manual-financial', $group->service);
         $this->assertNull($group->account_id);
     }
 
-    public function test_create_instance(): void
+    /**
+     * @test
+     */
+    public function create_instance(): void
     {
         $instance = $this->plugin->createInstance($this->group, 'accounts');
-        
+
         $this->assertInstanceOf(Integration::class, $instance);
         $this->assertEquals($this->user->id, $instance->user_id);
         $this->assertEquals($this->group->id, $instance->integration_group_id);
@@ -97,7 +122,10 @@ class ManualFinancialIntegrationTest extends TestCase
         $this->assertEquals('accounts', $instance->instance_type);
     }
 
-    public function test_create_account(): void
+    /**
+     * @test
+     */
+    public function create_account(): void
     {
         $accountData = [
             'account_type' => 'savings',
@@ -108,14 +136,14 @@ class ManualFinancialIntegrationTest extends TestCase
         ];
 
         $account = $this->plugin->createAccount($this->integration, $accountData);
-        
+
         $this->assertInstanceOf(EventObject::class, $account);
         $this->assertEquals($this->integration->id, $account->integration_id);
         $this->assertEquals($this->user->id, $account->user_id);
         $this->assertEquals('financial_account', $account->concept);
         $this->assertEquals('account', $account->type);
         $this->assertEquals('Barclays - Savings', $account->title);
-        
+
         $this->assertEquals('savings', $account->metadata['account_type']);
         $this->assertEquals('Barclays', $account->metadata['provider_name']);
         $this->assertEquals('12345678', $account->metadata['account_number']);
@@ -123,7 +151,10 @@ class ManualFinancialIntegrationTest extends TestCase
         $this->assertEquals(2.5, $account->metadata['interest_rate']);
     }
 
-    public function test_create_balance_update(): void
+    /**
+     * @test
+     */
+    public function create_balance_update(): void
     {
         // First create an account
         $accountData = [
@@ -131,9 +162,9 @@ class ManualFinancialIntegrationTest extends TestCase
             'provider_name' => 'Barclays',
             'currency' => 'GBP',
         ];
-        
+
         $account = $this->plugin->createAccount($this->integration, $accountData);
-        
+
         // Then create a balance update
         $balanceData = [
             'account_id' => $account->id,
@@ -141,9 +172,9 @@ class ManualFinancialIntegrationTest extends TestCase
             'date' => '2024-01-15',
             'notes' => 'Monthly statement balance',
         ];
-        
+
         $balance = $this->plugin->createBalanceUpdate($this->integration, $balanceData);
-        
+
         $this->assertInstanceOf(Event::class, $balance);
         $this->assertEquals($this->integration->id, $balance->integration_id);
         $this->assertEquals($account->id, $balance->actor_id);
@@ -152,27 +183,33 @@ class ManualFinancialIntegrationTest extends TestCase
         $this->assertEquals('balance_update', $balance->action);
         $this->assertEquals(5000.00, $balance->value);
         $this->assertEquals('currency', $balance->value_unit);
-        
+
         $this->assertEquals($account->id, $balance->event_metadata['account_id']);
         $this->assertEquals('Monthly statement balance', $balance->event_metadata['notes']);
         $this->assertEquals('GBP', $balance->event_metadata['currency']);
     }
 
-    public function test_create_balance_update_with_invalid_account(): void
+    /**
+     * @test
+     */
+    public function create_balance_update_with_invalid_account(): void
     {
-        $this->expectException(\InvalidArgumentException::class);
+        $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('Account not found');
-        
+
         $balanceData = [
             'account_id' => 'invalid-uuid',
             'balance' => 5000.00,
             'date' => '2024-01-15',
         ];
-        
+
         $this->plugin->createBalanceUpdate($this->integration, $balanceData);
     }
 
-    public function test_get_accounts_for_user(): void
+    /**
+     * @test
+     */
+    public function get_accounts_for_user(): void
     {
         // Create multiple accounts
         $accountData1 = [
@@ -180,18 +217,18 @@ class ManualFinancialIntegrationTest extends TestCase
             'provider_name' => 'Barclays',
             'currency' => 'GBP',
         ];
-        
+
         $accountData2 = [
             'account_type' => 'mortgage',
             'provider_name' => 'Santander',
             'currency' => 'GBP',
         ];
-        
+
         $this->plugin->createAccount($this->integration, $accountData1);
         $this->plugin->createAccount($this->integration, $accountData2);
-        
+
         $accounts = $this->plugin->getAccountsForUser($this->user);
-        
+
         $this->assertCount(2, $accounts);
         $this->assertEquals('Barclays - Savings', $accounts[0]['title']);
         $this->assertEquals('Santander - Mortgage', $accounts[1]['title']);
@@ -199,19 +236,25 @@ class ManualFinancialIntegrationTest extends TestCase
         $this->assertEquals('mortgage', $accounts[1]['account_type']);
     }
 
-    public function test_fetch_data_does_nothing(): void
+    /**
+     * @test
+     */
+    public function fetch_data_does_nothing(): void
     {
         // This should not throw any errors
         $this->plugin->fetchData($this->integration);
-        
+
         // No events should be created
         $this->assertEquals(0, Event::count());
     }
 
-    public function test_convert_data_returns_empty_array(): void
+    /**
+     * @test
+     */
+    public function convert_data_returns_empty_array(): void
     {
         $result = $this->plugin->convertData(['some' => 'data'], $this->integration);
-        
+
         $this->assertEquals([], $result);
     }
 }


### PR DESCRIPTION
Implement a new manual financial integration to allow users to track financial accounts and balances for providers without API support, with a focus on British English and UK financial terms.

---
<a href="https://cursor.com/background-agent?bcId=bc-f537f960-0964-4547-bb6e-2d7ed13554e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f537f960-0964-4547-bb6e-2d7ed13554e5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

