### PR TITLE
🐛 Fix Spotify duplicate events and pluck error

### DIFF
--- a/app/Jobs/Data/Spotify/SpotifyListeningData.php
+++ b/app/Jobs/Data/Spotify/SpotifyListeningData.php
@@ -159,7 +159,7 @@ class SpotifyListeningData extends BaseProcessingJob
 
                 // Store additional track information in metadata (original simple design)
                 $metadata = $event->event_metadata ?? [];
-                $metadata['artists'] = $artistObjects->pluck('id')->toArray();
+                $metadata['artists'] = array_column($artistObjects, 'id');
                 if ($albumObject) {
                     $metadata['album'] = $albumObject->id;
                 }
@@ -206,10 +206,9 @@ class SpotifyListeningData extends BaseProcessingJob
     {
         $timestamp = is_string($playedAt) ? $playedAt : $playedAt->toISOString();
 
-        // Use a more robust approach to avoid collisions
-        // Include milliseconds for better uniqueness
-        $microtime = microtime(true);
-        $uniqueId = hash('sha256', $trackId . '_' . $timestamp . '_' . $microtime . '_' . $this->integration->id);
+        // Use deterministic ID based on track and timestamp only
+        // This ensures the same track play always generates the same source_id for proper deduplication
+        $uniqueId = hash('sha256', $trackId . '_' . $timestamp . '_' . $this->integration->id);
 
         return 'spotify_play_' . substr($uniqueId, 0, 32); // Keep it reasonable length
     }


### PR DESCRIPTION
## Issue
The Spotify integration was creating lots of duplicate events and throwing a pluck() error.

## Root Cause
1. **pluck() error**: upsertArtistObjects() returns a plain array, but line 162 was calling pluck('id') on it as if it were a Collection.

2. **Duplicate events**: The generateTrackPlaySourceId() method included microtime(true) in the hash, which meant the same track play would generate a different source_id every time it was processed, breaking deduplication.

## Fix
1. **Fixed pluck() error**: Replace artistObjects->pluck('id')->toArray() with array_column(artistObjects, 'id')

2. **Fixed deduplication**: Remove microtime() from source_id generation to make it deterministic based only on track ID, timestamp, and integration ID

## Testing
- All Spotify tests pass (15 tests, 69 assertions)
- Duplicate prevention test specifically passes
- Code passes all linting checks

The API logs show the same track played at 2025-09-04T17:36:26.046Z was being returned repeatedly, but now with deterministic source_id generation, these duplicates will be properly prevented.