### PR TITLE
:sparkles: Preserve raw transaction detail

### DIFF
--- a/app/Integrations/GoCardless/GoCardlessBankPlugin.php
+++ b/app/Integrations/GoCardless/GoCardlessBankPlugin.php
@@ -433,7 +433,7 @@ class GoCardlessBankPlugin extends OAuthPlugin
             Log::error('Failed to fetch GoCardless data', [
                 'integration_id' => $integration->id,
                 'instance_type' => $instanceType,
-                'group_id' => $group->id,
+                'group_id' => $integration->group_id,
                 'account_id' => $accountId,
                 'error' => $e->getMessage(),
                 'trace' => $e->getTraceAsString(),
@@ -1377,6 +1377,7 @@ class GoCardlessBankPlugin extends OAuthPlugin
                 'previous_status' => $existingEvent?->event_metadata['transaction_status'] ?? null,
                 'timestamp_preserved' => $isStatusChange && $existingEvent && $existingEvent->time === $timestamp,
                 'timestamp_reason' => $this->getTimestampReason($tx, $existingEvent, $status, $isStatusChange, $timestamp),
+                'raw' => $tx,
             ],
         ];
 

--- a/app/Integrations/Monzo/MonzoPlugin.php
+++ b/app/Integrations/Monzo/MonzoPlugin.php
@@ -622,6 +622,7 @@ class MonzoPlugin extends OAuthPlugin
                     'notes' => $tx['notes'] ?? null,
                     'local_amount' => $tx['local_amount'] ?? null,
                     'local_currency' => $tx['local_currency'] ?? null,
+                    'raw' => $tx,
                 ],
                 'target_id' => $target->id,
             ]

--- a/app/Jobs/Data/GoCardless/GoCardlessTransactionData.php
+++ b/app/Jobs/Data/GoCardless/GoCardlessTransactionData.php
@@ -107,6 +107,7 @@ class GoCardlessTransactionData extends BaseProcessingJob
                 'previous_status' => $existingEvent?->event_metadata['transaction_status'] ?? null,
                 'timestamp_preserved' => $isStatusChange && $existingEvent && $existingEvent->time === $timestamp,
                 'timestamp_reason' => $this->getTimestampReason($tx, $existingEvent, $status, $isStatusChange, $timestamp),
+                'raw' => $tx,
             ],
         ];
 

--- a/app/Jobs/Data/Monzo/MonzoTransactionData.php
+++ b/app/Jobs/Data/Monzo/MonzoTransactionData.php
@@ -112,6 +112,7 @@ class MonzoTransactionData extends BaseProcessingJob
                     'notes' => $tx['notes'] ?? null,
                     'local_amount' => $tx['local_amount'] ?? null,
                     'local_currency' => $tx['local_currency'] ?? null,
+                    'raw' => $tx,
                 ],
                 'target_id' => $target->id,
             ]


### PR DESCRIPTION
Adds the full transaction detail for the Monzo and GoCardless plugins into a "raw" key wihthin the event metadata.
