### PR TITLE
:recycle: Gocardless: improve account data handling and provider derivation

### DIFF
--- a/app/Jobs/Data/GoCardless/GoCardlessBalanceData.php
+++ b/app/Jobs/Data/GoCardless/GoCardlessBalanceData.php
@@ -254,13 +254,34 @@ class GoCardlessBalanceData extends BaseProcessingJob
                 'metadata' => [
                     'integration_id' => $this->integration->id,
                     'name' => $accountName,
-                    'provider' => 'GoCardless',
+                    'provider' => $this->deriveProviderName(),
                     'account_type' => 'current_account',
                     'currency' => $balance['balanceAmount']['currency'] ?? 'EUR',
                     'account_number' => $accountId,
                 ],
             ]
         );
+    }
+
+    /**
+     * Prefer the human-readable institution name stored on the integration group
+     */
+    protected function deriveProviderName(): string
+    {
+        $group = $this->integration->group;
+        if ($group && is_array($group->auth_metadata)) {
+            $name = $group->auth_metadata['gocardless_institution_name'] ?? null;
+            if (is_string($name) && $name !== '') {
+                return $name;
+            }
+
+            $alt = $group->auth_metadata['institution_name'] ?? null;
+            if (is_string($alt) && $alt !== '') {
+                return $alt;
+            }
+        }
+
+        return 'GoCardless';
     }
 
     private function processBalances(array $balances): void

--- a/resources/views/livewire/money/index.blade.php
+++ b/resources/views/livewire/money/index.blade.php
@@ -85,7 +85,7 @@
                     <!-- Archived Pots Toggle -->
                     <div class="form-control">
                         <label class="label cursor-pointer">
-                            <span class="label-text">Show Archived Pots</span>
+                            <span class="label-text">Show Archived</span>
                             <input
                                 type="checkbox"
                                 wire:model.live="showArchivedPots"
@@ -107,7 +107,7 @@
             </div>
         </div>
         <div class="lg:hidden">
-            <x-collapse separator class="bg-base-200">
+            <x-collapse separator class="bg-base-200 mb-4">
                 <x-slot:heading>Filters</x-slot:heading>
                 <x-slot:content>
                     <div class="flex flex-col gap-4">
@@ -208,11 +208,11 @@
 
                                         // Get account type label
                                         $accountTypeLabels = [
-                                            'current_account' => 'Current Account',
-                                            'savings_account' => 'Savings Account',
+                                            'current_account' => 'Current',
+                                            'savings_account' => 'Savings',
                                             'mortgage' => 'Mortgage',
-                                            'investment_account' => 'Investment Account',
-                                            'credit_card' => 'Credit Card',
+                                            'investment_account' => 'Investment',
+                                            'credit_card' => 'Credit',
                                             'loan' => 'Loan',
                                             'pension' => 'Pension',
                                             'other' => 'Other',


### PR DESCRIPTION
This commit refactors the GoCardless integration to improve account data handling, provider name derivation, and UI consistency across all data processing jobs.

**Account Type Mapping:**
- Standardized account type mapping using ISO 20022 ExternalCashAccountType1Code
- Added comprehensive mapping for CACC, TRAN, SVGS, LLSV, ONDP, CHAR, LOAN, ODFT, MOMA, MGLD, TRAS codes
- Improved fallback handling for descriptive account type strings

**Account Number Derivation:**
- Enhanced account number extraction with priority: IBAN → maskedPan → BBAN → resourceId
- Added support for nested account fields (debtorAccount/creditorAccount)
- Improved privacy by using last 8 characters of IBAN/resourceId

**Provider Name Derivation:**
- Prioritize human-readable institution names from integration group metadata
- Fallback to institution_id from payload, then generic "GoCardless"
- Consistent provider naming across all GoCardless data jobs
