### PR TITLE
Add manual trigger support to deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - dev
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.ref }}


### PR DESCRIPTION
Enable workflow_dispatch event to allow manual triggering of the deploy workflow from the GitHub Actions tab.