### PR TITLE
:bug: Fix Google Calendar OAuth duplicate group creation

### DIFF
--- a/app/Http/Controllers/IntegrationController.php
+++ b/app/Http/Controllers/IntegrationController.php
@@ -276,6 +276,29 @@ class IntegrationController extends Controller
                 ]);
             }
 
+            // Check if the group was merged with an existing group (for duplicate account detection)
+            $mergedGroupId = $request->get('_merged_group_id');
+            if ($mergedGroupId) {
+                // Reload the group to get the existing one
+                $group = IntegrationGroup::find($mergedGroupId);
+                if (! $group) {
+                    Log::error('Merged group not found', [
+                        'merged_group_id' => $mergedGroupId,
+                        'service' => $service,
+                        'user_id' => $user->id,
+                    ]);
+
+                    return redirect()->route('integrations.index')
+                        ->with('error', 'Failed to complete integration setup');
+                }
+
+                Log::info('Using merged group after duplicate detection', [
+                    'service' => $service,
+                    'user_id' => $user->id,
+                    'merged_group_id' => $mergedGroupId,
+                ]);
+            }
+
             Log::info('Redirecting to onboarding', [
                 'service' => $service,
                 'user_id' => $user->id,

--- a/app/Integrations/GoogleCalendar/GoogleCalendarPlugin.php
+++ b/app/Integrations/GoogleCalendar/GoogleCalendarPlugin.php
@@ -368,6 +368,9 @@ class GoogleCalendarPlugin extends OAuthPlugin
 
         // Fetch account information
         $this->fetchAccountInfoForGroup($group);
+
+        // After fetching account info, check for duplicate groups
+        $this->handleDuplicateGroups($group);
     }
 
     /**
@@ -992,5 +995,73 @@ class GoogleCalendarPlugin extends OAuthPlugin
                 $event->delete();
             }
         }
+    }
+
+    /**
+     * Handle duplicate integration groups for the same Google account
+     *
+     * When a user completes OAuth for a Google account they've already connected,
+     * we want to reuse the existing group instead of creating a duplicate.
+     *
+     * @param  IntegrationGroup  $group  The newly created group from OAuth
+     * @return IntegrationGroup The group to use (either existing or new)
+     */
+    protected function handleDuplicateGroups(IntegrationGroup $group): IntegrationGroup
+    {
+        // Only proceed if we have an account_id
+        if (! $group->account_id) {
+            Log::warning('Google Calendar group has no account_id, cannot check for duplicates', [
+                'group_id' => $group->id,
+            ]);
+
+            return $group;
+        }
+
+        // Check if another group exists for this user, service, and account_id
+        $existingGroup = IntegrationGroup::query()
+            ->where('user_id', $group->user_id)
+            ->where('service', static::getIdentifier())
+            ->where('account_id', $group->account_id)
+            ->where('id', '!=', $group->id) // Exclude the current group
+            ->first();
+
+        if ($existingGroup) {
+            Log::info('Found existing Google Calendar group for this account, merging', [
+                'new_group_id' => $group->id,
+                'existing_group_id' => $existingGroup->id,
+                'account_id' => $group->account_id,
+                'user_id' => $group->user_id,
+            ]);
+
+            // Update the existing group with the latest tokens
+            // (they might have been refreshed during this OAuth flow)
+            $existingGroup->update([
+                'access_token' => $group->access_token,
+                'refresh_token' => $group->refresh_token ?? $existingGroup->refresh_token,
+                'expiry' => $group->expiry,
+                'refresh_expiry' => $group->refresh_expiry,
+            ]);
+
+            // Move any integrations from the new group to the existing group
+            // (this shouldn't happen in normal flow, but handle it just in case)
+            Integration::where('integration_group_id', $group->id)
+                ->update(['integration_group_id' => $existingGroup->id]);
+
+            // Delete the duplicate group
+            $group->delete();
+
+            Log::info('Deleted duplicate Google Calendar group', [
+                'deleted_group_id' => $group->id,
+                'using_group_id' => $existingGroup->id,
+            ]);
+
+            // Store the existing group ID in the request to update the redirect
+            request()->merge(['_merged_group_id' => $existingGroup->id]);
+
+            return $existingGroup;
+        }
+
+        // No duplicate found, use the new group
+        return $group;
     }
 }


### PR DESCRIPTION
When adding a second calendar instance from the same Google account, the system was creating a new empty IntegrationGroup instead of reusing the existing one. This resulted in duplicate groups and the user being unable to complete the onboarding flow.

**Changes:**
- Added `handleDuplicateGroups()` method in GoogleCalendarPlugin to detect and merge duplicate groups with the same account_id
- When a duplicate is detected:
  - Updates the existing group with the latest OAuth tokens
  - Migrates any integrations from the new group to the existing one
  - Deletes the duplicate group
  - Redirects to onboarding with the existing group
- Updated IntegrationController to handle the merged group ID and redirect to the correct onboarding page

**Fixes:**
- Users can now add multiple calendar instances from the same Google account
- No more empty integration groups being created
- Proper redirect to onboarding page for second and subsequent instances