### PR TITLE
♻️ Ensure CI tests run after duster commits

### DIFF
--- a/.github/workflows/dust_test.yml
+++ b/.github/workflows/dust_test.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      commit_sha: ${{ steps.get_sha.outputs.sha }}
     steps:
       - name: Add reaction to comment
         if: github.event_name == 'issue_comment'
@@ -43,6 +45,10 @@ jobs:
           commit_user_name: GitHub Action
           commit_user_email: actions@github.com
 
+      - name: Get current commit SHA
+        id: get_sha
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
   ci:
     runs-on: ubuntu-latest
     environment: CI
@@ -69,7 +75,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5
         with:
-          ref: ${{ github.event_name == 'issue_comment' && steps.comment-branch.outputs.head_ref || '' }}
+          # Use the commit SHA from duster to ensure we test the code after any duster fixes
+          ref: ${{ needs.duster.outputs.commit_sha }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # v2


### PR DESCRIPTION
- Add commit_sha output to duster job to track the latest commit
- Update CI job checkout to use the commit SHA from duster
- This ensures tests run on code AFTER any duster fixes, not before

Fixes the issue where duster commits would complete but CI would test the old code instead of the fixed code, causing the workflow to get stuck.