### PR TITLE
🐛 Fix Block::getContent() return type and vector encoding errors

### DIFF
--- a/app/Models/Block.php
+++ b/app/Models/Block.php
@@ -364,7 +364,14 @@ class Block extends Model implements HasMedia
      */
     public function getContent(): ?string
     {
-        return $this->metadata['content'] ?? null;
+        $content = $this->metadata['content'] ?? null;
+
+        // Ensure we always return a string or null, never an array
+        if (is_array($content)) {
+            return json_encode($content);
+        }
+
+        return $content;
     }
 
     /**

--- a/app/Models/EventObject.php
+++ b/app/Models/EventObject.php
@@ -49,7 +49,6 @@ class EventObject extends Model implements HasMedia
     protected $casts = [
         'time' => 'datetime',
         'metadata' => 'array',
-        'embeddings' => 'array', // You may need a custom cast for vector fields
         'created_at' => 'datetime',
         'updated_at' => 'datetime',
         'deleted_at' => 'datetime',
@@ -500,5 +499,52 @@ class EventObject extends Model implements HasMedia
             ->event("tag_{$action}")
             ->withProperties(['tag' => $tagLabel, 'tag_name' => $tagName, 'tag_type' => $tagType])
             ->log("{$action} tag \"{$tagLabel}\"");
+    }
+
+    /**
+     * Set the embeddings attribute.
+     * Handles conversion to pgvector format.
+     */
+    public function setEmbeddingsAttribute($value)
+    {
+        if (is_null($value)) {
+            $this->attributes['embeddings'] = null;
+            return;
+        }
+
+        // If it's already a string in vector format [x,y,z], use it as-is
+        if (is_string($value)) {
+            // Remove any surrounding quotes if present
+            $value = trim($value, '"');
+            $this->attributes['embeddings'] = $value;
+            return;
+        }
+
+        // If it's an array, convert to vector format without quotes
+        if (is_array($value)) {
+            $this->attributes['embeddings'] = '[' . implode(',', $value) . ']';
+            return;
+        }
+
+        $this->attributes['embeddings'] = $value;
+    }
+
+    /**
+     * Get the embeddings attribute.
+     * Returns as array for easier usage.
+     */
+    public function getEmbeddingsAttribute($value)
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        // If it's already in vector format [x,y,z], parse it to array
+        if (is_string($value)) {
+            $value = trim($value, '[]');
+            return !empty($value) ? array_map('floatval', explode(',', $value)) : null;
+        }
+
+        return $value;
     }
 }

--- a/app/Models/EventObject.php
+++ b/app/Models/EventObject.php
@@ -475,6 +475,57 @@ class EventObject extends Model implements HasMedia
     }
 
     /**
+     * Set the embeddings attribute.
+     * Handles conversion to pgvector format.
+     */
+    public function setEmbeddingsAttribute($value)
+    {
+        if (is_null($value)) {
+            $this->attributes['embeddings'] = null;
+
+            return;
+        }
+
+        // If it's already a string in vector format [x,y,z], use it as-is
+        if (is_string($value)) {
+            // Remove any surrounding quotes if present
+            $value = trim($value, '"');
+            $this->attributes['embeddings'] = $value;
+
+            return;
+        }
+
+        // If it's an array, convert to vector format without quotes
+        if (is_array($value)) {
+            $this->attributes['embeddings'] = '[' . implode(',', $value) . ']';
+
+            return;
+        }
+
+        $this->attributes['embeddings'] = $value;
+    }
+
+    /**
+     * Get the embeddings attribute.
+     * Returns as array for easier usage.
+     */
+    public function getEmbeddingsAttribute($value)
+    {
+        if (is_null($value)) {
+            return null;
+        }
+
+        // If it's already in vector format [x,y,z], parse it to array
+        if (is_string($value)) {
+            $value = trim($value, '[]');
+
+            return ! empty($value) ? array_map('floatval', explode(',', $value)) : null;
+        }
+
+        return $value;
+    }
+
+    /**
      * Log tag activity to the activity log
      */
     private function logTagActivity(string|\Spatie\Tags\Tag $tag, ?string $type, string $action): void
@@ -499,52 +550,5 @@ class EventObject extends Model implements HasMedia
             ->event("tag_{$action}")
             ->withProperties(['tag' => $tagLabel, 'tag_name' => $tagName, 'tag_type' => $tagType])
             ->log("{$action} tag \"{$tagLabel}\"");
-    }
-
-    /**
-     * Set the embeddings attribute.
-     * Handles conversion to pgvector format.
-     */
-    public function setEmbeddingsAttribute($value)
-    {
-        if (is_null($value)) {
-            $this->attributes['embeddings'] = null;
-            return;
-        }
-
-        // If it's already a string in vector format [x,y,z], use it as-is
-        if (is_string($value)) {
-            // Remove any surrounding quotes if present
-            $value = trim($value, '"');
-            $this->attributes['embeddings'] = $value;
-            return;
-        }
-
-        // If it's an array, convert to vector format without quotes
-        if (is_array($value)) {
-            $this->attributes['embeddings'] = '[' . implode(',', $value) . ']';
-            return;
-        }
-
-        $this->attributes['embeddings'] = $value;
-    }
-
-    /**
-     * Get the embeddings attribute.
-     * Returns as array for easier usage.
-     */
-    public function getEmbeddingsAttribute($value)
-    {
-        if (is_null($value)) {
-            return null;
-        }
-
-        // If it's already in vector format [x,y,z], parse it to array
-        if (is_string($value)) {
-            $value = trim($value, '[]');
-            return !empty($value) ? array_map('floatval', explode(',', $value)) : null;
-        }
-
-        return $value;
     }
 }


### PR DESCRIPTION
- Fix Block::getContent() to always return ?string, handle array content
- Remove embeddings array cast from EventObject to prevent double-encoding
- Add custom setEmbeddingsAttribute/getEmbeddingsAttribute mutators for pgvector
- Mutators handle conversion between array and pgvector format [x,y,z]
- Strip extra quotes from embeddings to fix "invalid input syntax for type vector" error