### PR TITLE
Move embedding generation to separate queue with scaled concurrency

### DIFF
--- a/app/Jobs/GenerateBlockEmbeddingJob.php
+++ b/app/Jobs/GenerateBlockEmbeddingJob.php
@@ -26,7 +26,7 @@ class GenerateBlockEmbeddingJob implements ShouldQueue
      *
      * @var int
      */
-    public $tries = 3;
+    public $tries = 1;
 
     /**
      * The number of seconds to wait before retrying the job.

--- a/app/Jobs/GenerateBlockEmbeddingJob.php
+++ b/app/Jobs/GenerateBlockEmbeddingJob.php
@@ -15,6 +15,13 @@ class GenerateBlockEmbeddingJob implements ShouldQueue
     use Queueable;
 
     /**
+     * The name of the queue the job should be sent to.
+     *
+     * @var string
+     */
+    public $queue = 'embeddings';
+
+    /**
      * The number of times the job may be attempted.
      *
      * @var int

--- a/app/Jobs/GenerateEventEmbeddingJob.php
+++ b/app/Jobs/GenerateEventEmbeddingJob.php
@@ -15,6 +15,13 @@ class GenerateEventEmbeddingJob implements ShouldQueue
     use Queueable;
 
     /**
+     * The name of the queue the job should be sent to.
+     *
+     * @var string
+     */
+    public $queue = 'embeddings';
+
+    /**
      * The number of times the job may be attempted.
      *
      * @var int

--- a/app/Jobs/GenerateEventEmbeddingJob.php
+++ b/app/Jobs/GenerateEventEmbeddingJob.php
@@ -26,7 +26,7 @@ class GenerateEventEmbeddingJob implements ShouldQueue
      *
      * @var int
      */
-    public $tries = 3;
+    public $tries = 1;
 
     /**
      * The number of seconds to wait before retrying the job.

--- a/app/Jobs/GenerateObjectEmbeddingJob.php
+++ b/app/Jobs/GenerateObjectEmbeddingJob.php
@@ -15,6 +15,13 @@ class GenerateObjectEmbeddingJob implements ShouldQueue
     use Queueable;
 
     /**
+     * The name of the queue the job should be sent to.
+     *
+     * @var string
+     */
+    public $queue = 'embeddings';
+
+    /**
      * The number of times the job may be attempted.
      *
      * @var int

--- a/app/Jobs/GenerateObjectEmbeddingJob.php
+++ b/app/Jobs/GenerateObjectEmbeddingJob.php
@@ -26,7 +26,7 @@ class GenerateObjectEmbeddingJob implements ShouldQueue
      *
      * @var int
      */
-    public $tries = 3;
+    public $tries = 1;
 
     /**
      * The number of seconds to wait before retrying the job.

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -59,6 +59,14 @@ return [
                 'memory' => 256,
                 'tries' => 1,
             ],
+            'supervisor-3' => [
+                'connection' => 'redis',
+                'queue' => ['embeddings'],
+                'balance' => 'auto',
+                'maxProcesses' => 5,
+                'memory' => 256,
+                'tries' => 3,
+            ],
         ],
 
         'staging' => [
@@ -78,6 +86,14 @@ return [
                 'memory' => 256,
                 'tries' => 1,
             ],
+            'supervisor-3' => [
+                'connection' => 'redis',
+                'queue' => ['embeddings'],
+                'balance' => 'auto',
+                'maxProcesses' => 5,
+                'memory' => 256,
+                'tries' => 3,
+            ],
         ],
 
         'local' => [
@@ -96,6 +112,14 @@ return [
                 'maxProcesses' => 1,
                 'memory' => 256,
                 'tries' => 1,
+            ],
+            'supervisor-3' => [
+                'connection' => 'redis',
+                'queue' => ['embeddings'],
+                'balance' => 'auto',
+                'maxProcesses' => 5,
+                'memory' => 256,
+                'tries' => 3,
             ],
         ],
     ],

--- a/config/horizon.php
+++ b/config/horizon.php
@@ -65,7 +65,7 @@ return [
                 'balance' => 'auto',
                 'maxProcesses' => 5,
                 'memory' => 256,
-                'tries' => 3,
+                'tries' => 1,
             ],
         ],
 
@@ -92,7 +92,7 @@ return [
                 'balance' => 'auto',
                 'maxProcesses' => 5,
                 'memory' => 256,
-                'tries' => 3,
+                'tries' => 1,
             ],
         ],
 
@@ -119,7 +119,7 @@ return [
                 'balance' => 'auto',
                 'maxProcesses' => 5,
                 'memory' => 256,
-                'tries' => 3,
+                'tries' => 1,
             ],
         ],
     ],


### PR DESCRIPTION
- Added dedicated 'embeddings' queue in Horizon configuration
- Configured supervisor-3 with maxProcesses: 5 for all environments
- Updated GenerateObjectEmbeddingJob to use embeddings queue
- Updated GenerateBlockEmbeddingJob to use embeddings queue
- Updated GenerateEventEmbeddingJob to use embeddings queue

This improves performance by isolating embedding generation jobs and allowing up to 5 concurrent embedding processes.