### PR TITLE
Fix Queueable trait property conflict by using onQueue method

### DIFF
--- a/app/Console/Commands/GenerateEmbeddings.php
+++ b/app/Console/Commands/GenerateEmbeddings.php
@@ -93,7 +93,7 @@ class GenerateEmbeddings extends Command
 
         $query->chunk($batchSize, function ($events) use (&$processed, $bar) {
             foreach ($events as $event) {
-                GenerateEventEmbeddingJob::dispatch($event);
+                GenerateEventEmbeddingJob::dispatch($event)->onQueue('embeddings');
                 $processed++;
                 $bar->advance();
             }
@@ -135,7 +135,7 @@ class GenerateEmbeddings extends Command
 
         $query->chunk($batchSize, function ($blocks) use (&$processed, $bar) {
             foreach ($blocks as $block) {
-                GenerateBlockEmbeddingJob::dispatch($block);
+                GenerateBlockEmbeddingJob::dispatch($block)->onQueue('embeddings');
                 $processed++;
                 $bar->advance();
             }
@@ -177,7 +177,7 @@ class GenerateEmbeddings extends Command
 
         $query->chunk($batchSize, function ($objects) use (&$processed, $bar) {
             foreach ($objects as $object) {
-                GenerateObjectEmbeddingJob::dispatch($object);
+                GenerateObjectEmbeddingJob::dispatch($object)->onQueue('embeddings');
                 $processed++;
                 $bar->advance();
             }

--- a/app/Console/Commands/RegenerateEmbeddings.php
+++ b/app/Console/Commands/RegenerateEmbeddings.php
@@ -186,7 +186,7 @@ class RegenerateEmbeddings extends Command
                     $job->handle(app(\App\Services\EmbeddingService::class));
                 } else {
                     // Queue job
-                    $jobClass::dispatch($record);
+                    $jobClass::dispatch($record)->onQueue('embeddings');
                 }
 
                 $processed++;

--- a/app/Jobs/GenerateBlockEmbeddingJob.php
+++ b/app/Jobs/GenerateBlockEmbeddingJob.php
@@ -15,13 +15,6 @@ class GenerateBlockEmbeddingJob implements ShouldQueue
     use Queueable;
 
     /**
-     * The name of the queue the job should be sent to.
-     *
-     * @var string
-     */
-    public $queue = 'embeddings';
-
-    /**
      * The number of times the job may be attempted.
      *
      * @var int

--- a/app/Jobs/GenerateEventEmbeddingJob.php
+++ b/app/Jobs/GenerateEventEmbeddingJob.php
@@ -15,13 +15,6 @@ class GenerateEventEmbeddingJob implements ShouldQueue
     use Queueable;
 
     /**
-     * The name of the queue the job should be sent to.
-     *
-     * @var string
-     */
-    public $queue = 'embeddings';
-
-    /**
      * The number of times the job may be attempted.
      *
      * @var int

--- a/app/Jobs/GenerateObjectEmbeddingJob.php
+++ b/app/Jobs/GenerateObjectEmbeddingJob.php
@@ -15,13 +15,6 @@ class GenerateObjectEmbeddingJob implements ShouldQueue
     use Queueable;
 
     /**
-     * The name of the queue the job should be sent to.
-     *
-     * @var string
-     */
-    public $queue = 'embeddings';
-
-    /**
      * The number of times the job may be attempted.
      *
      * @var int

--- a/app/Observers/BlockObserver.php
+++ b/app/Observers/BlockObserver.php
@@ -16,12 +16,12 @@ class BlockObserver
         // Only dispatch if embeddings are enabled (API key is configured)
         if (config('services.openai.api_key')) {
             // Dispatch job to generate embedding asynchronously
-            GenerateBlockEmbeddingJob::dispatch($block);
+            GenerateBlockEmbeddingJob::dispatch($block)->onQueue('embeddings');
 
             // If this is a summary/details block, regenerate parent event's embedding
             // This ensures events include AI-generated summaries in their embeddings
             if ($this->isSummaryOrDetailsBlock($block)) {
-                GenerateEventEmbeddingJob::dispatch($block->event);
+                GenerateEventEmbeddingJob::dispatch($block->event)->onQueue('embeddings');
             }
         }
     }
@@ -36,11 +36,11 @@ class BlockObserver
             // Check if relevant fields changed that would affect the embedding
             if ($block->wasChanged(['title', 'metadata', 'url', 'value', 'value_unit'])) {
                 // Dispatch job to regenerate embedding
-                GenerateBlockEmbeddingJob::dispatch($block);
+                GenerateBlockEmbeddingJob::dispatch($block)->onQueue('embeddings');
 
                 // If this is a summary/details block, also regenerate parent event's embedding
                 if ($this->isSummaryOrDetailsBlock($block)) {
-                    GenerateEventEmbeddingJob::dispatch($block->event);
+                    GenerateEventEmbeddingJob::dispatch($block->event)->onQueue('embeddings');
                 }
             }
         }

--- a/app/Observers/EventObjectObserver.php
+++ b/app/Observers/EventObjectObserver.php
@@ -14,7 +14,7 @@ class EventObjectObserver
     {
         // Only dispatch if embeddings are enabled (API key is configured)
         if (config('services.openai.api_key')) {
-            GenerateObjectEmbeddingJob::dispatch($object);
+            GenerateObjectEmbeddingJob::dispatch($object)->onQueue('embeddings');
         }
     }
 
@@ -28,7 +28,7 @@ class EventObjectObserver
             // Check if relevant fields changed that would affect the embedding
             if ($object->wasChanged(['concept', 'type', 'title', 'content', 'url'])) {
                 // Dispatch job to regenerate embedding
-                GenerateObjectEmbeddingJob::dispatch($object);
+                GenerateObjectEmbeddingJob::dispatch($object)->onQueue('embeddings');
             }
         }
     }

--- a/app/Observers/EventObserver.php
+++ b/app/Observers/EventObserver.php
@@ -14,7 +14,7 @@ class EventObserver
     {
         // Only dispatch if embeddings are enabled (API key is configured)
         if (config('services.openai.api_key')) {
-            GenerateEventEmbeddingJob::dispatch($event);
+            GenerateEventEmbeddingJob::dispatch($event)->onQueue('embeddings');
         }
     }
 
@@ -28,7 +28,7 @@ class EventObserver
             // Check if relevant fields changed that would affect the embedding
             if ($event->wasChanged(['service', 'domain', 'action', 'value', 'value_unit'])) {
                 // Dispatch job to regenerate embedding
-                GenerateEventEmbeddingJob::dispatch($event);
+                GenerateEventEmbeddingJob::dispatch($event)->onQueue('embeddings');
             }
         }
     }


### PR DESCRIPTION
- Removed $queue property from embedding job classes (conflicts with Queueable trait)
- Updated all observers to dispatch embedding jobs using ->onQueue('embeddings')
- Updated GenerateEmbeddings command to dispatch to embeddings queue
- Updated RegenerateEmbeddings command to dispatch to embeddings queue

This resolves the PHP Fatal error where the $queue property was being defined twice - once in Queueable trait and once in the job class.