### PR TITLE
Fix circular dependency in embedding processing

### DIFF
--- a/app/Jobs/GenerateBlockEmbeddingJob.php
+++ b/app/Jobs/GenerateBlockEmbeddingJob.php
@@ -70,10 +70,14 @@ class GenerateBlockEmbeddingJob implements ShouldQueue
             $metadata = array_merge($metadata, $embeddingMetadata);
 
             // Store embedding and metadata in database
-            $this->block->update([
-                'embeddings' => EmbeddingService::formatForPostgres($embedding),
-                'metadata' => $metadata,
-            ]);
+            // Use withoutEvents() to prevent BlockObserver from triggering on this internal update
+            // This prevents a circular dependency where updating metadata triggers re-embedding
+            $this->block->withoutEvents(function ($block) use ($embedding, $metadata) {
+                $block->update([
+                    'embeddings' => EmbeddingService::formatForPostgres($embedding),
+                    'metadata' => $metadata,
+                ]);
+            });
 
             Log::info('Generated embedding for block', [
                 'block_id' => $this->block->id,

--- a/app/Jobs/GenerateEventEmbeddingJob.php
+++ b/app/Jobs/GenerateEventEmbeddingJob.php
@@ -70,10 +70,13 @@ class GenerateEventEmbeddingJob implements ShouldQueue
             $metadata = array_merge($metadata, $embeddingMetadata);
 
             // Store embedding and metadata in database
-            $this->event->update([
-                'embeddings' => EmbeddingService::formatForPostgres($embedding),
-                'metadata' => $metadata,
-            ]);
+            // Use withoutEvents() to prevent observers from triggering on this internal update
+            $this->event->withoutEvents(function ($event) use ($embedding, $metadata) {
+                $event->update([
+                    'embeddings' => EmbeddingService::formatForPostgres($embedding),
+                    'metadata' => $metadata,
+                ]);
+            });
 
             Log::info('Generated embedding for event', [
                 'event_id' => $this->event->id,

--- a/app/Jobs/GenerateObjectEmbeddingJob.php
+++ b/app/Jobs/GenerateObjectEmbeddingJob.php
@@ -70,10 +70,13 @@ class GenerateObjectEmbeddingJob implements ShouldQueue
             $metadata = array_merge($metadata, $embeddingMetadata);
 
             // Store embedding and metadata in database
-            $this->object->update([
-                'embeddings' => EmbeddingService::formatForPostgres($embedding),
-                'metadata' => $metadata,
-            ]);
+            // Use withoutEvents() to prevent observers from triggering on this internal update
+            $this->object->withoutEvents(function ($object) use ($embedding, $metadata) {
+                $object->update([
+                    'embeddings' => EmbeddingService::formatForPostgres($embedding),
+                    'metadata' => $metadata,
+                ]);
+            });
 
             Log::info('Generated embedding for object', [
                 'object_id' => $this->object->id,


### PR DESCRIPTION
Prevents infinite loop where BlockObserver triggers on metadata changes caused by embedding updates, which in turn trigger more embedding updates.

Changes:
- Use withoutEvents() in all embedding job updates
- Prevents observers from firing during internal embedding metadata updates
- Applied consistently across Block, Event, and EventObject embedding jobs

This fixes the server crash caused by the circular processing loop:
1. Block updated → Observer fires
2. Job updates embeddings + metadata
3. Observer fires again (metadata changed) → infinite loop

The withoutEvents() wrapper ensures internal embedding updates don't trigger observers while still allowing user-initiated changes to work.