### PR TITLE
Fix withoutEvents() closure signature - remove model parameter

### DIFF
--- a/app/Jobs/GenerateBlockEmbeddingJob.php
+++ b/app/Jobs/GenerateBlockEmbeddingJob.php
@@ -72,8 +72,8 @@ class GenerateBlockEmbeddingJob implements ShouldQueue
             // Store embedding and metadata in database
             // Use withoutEvents() to prevent BlockObserver from triggering on this internal update
             // This prevents a circular dependency where updating metadata triggers re-embedding
-            $this->block->withoutEvents(function ($block) use ($embedding, $metadata) {
-                $block->update([
+            $this->block->withoutEvents(function () use ($embedding, $metadata) {
+                $this->block->update([
                     'embeddings' => EmbeddingService::formatForPostgres($embedding),
                     'metadata' => $metadata,
                 ]);

--- a/app/Jobs/GenerateEventEmbeddingJob.php
+++ b/app/Jobs/GenerateEventEmbeddingJob.php
@@ -71,8 +71,8 @@ class GenerateEventEmbeddingJob implements ShouldQueue
 
             // Store embedding and metadata in database
             // Use withoutEvents() to prevent observers from triggering on this internal update
-            $this->event->withoutEvents(function ($event) use ($embedding, $metadata) {
-                $event->update([
+            $this->event->withoutEvents(function () use ($embedding, $metadata) {
+                $this->event->update([
                     'embeddings' => EmbeddingService::formatForPostgres($embedding),
                     'metadata' => $metadata,
                 ]);

--- a/app/Jobs/GenerateObjectEmbeddingJob.php
+++ b/app/Jobs/GenerateObjectEmbeddingJob.php
@@ -71,8 +71,8 @@ class GenerateObjectEmbeddingJob implements ShouldQueue
 
             // Store embedding and metadata in database
             // Use withoutEvents() to prevent observers from triggering on this internal update
-            $this->object->withoutEvents(function ($object) use ($embedding, $metadata) {
-                $object->update([
+            $this->object->withoutEvents(function () use ($embedding, $metadata) {
+                $this->object->update([
                     'embeddings' => EmbeddingService::formatForPostgres($embedding),
                     'metadata' => $metadata,
                 ]);


### PR DESCRIPTION
The withoutEvents() method doesn't pass the model to the closure, so we need to use the model from the outer scope instead.

Fixed ArgumentCountError: closure expected 1 parameter but got 0.