### PR TITLE
Fix json_decode TypeError on objects/show page

### DIFF
--- a/resources/views/livewire/objects/show.blade.php
+++ b/resources/views/livewire/objects/show.blade.php
@@ -75,7 +75,7 @@ new class extends Component {
         // Use semantic search if embeddings exist
         if (!empty($this->object->embeddings)) {
             try {
-                $embedding = json_decode($this->object->embeddings, true);
+                $embedding = $this->object->embeddings;
 
                 if (is_array($embedding) && count($embedding) > 0) {
                     // Get user's integration IDs for security
@@ -119,7 +119,7 @@ new class extends Component {
         // Use semantic search if embeddings exist
         if (!empty($this->object->embeddings)) {
             try {
-                $embedding = json_decode($this->object->embeddings, true);
+                $embedding = $this->object->embeddings;
 
                 if (is_array($embedding) && count($embedding) > 0) {
                     // Get user's integration IDs for security


### PR DESCRIPTION
The EventObject model's getEmbeddingsAttribute accessor already returns embeddings as an array, so calling json_decode() on it causes a TypeError. Removed unnecessary json_decode() calls in getRelatedEvents() and getRelatedBlocks() methods.