### PR TITLE
🐛 Fix media gallery S3 signed URLs and UUID routing

### DIFF
--- a/app/Livewire/Media/Show.php
+++ b/app/Livewire/Media/Show.php
@@ -128,6 +128,35 @@ class Show extends Component
         }
     }
 
+    /**
+     * Check if we're using S3 storage
+     */
+    public function isS3(): bool
+    {
+        return config('media-library.disk_name') === 's3';
+    }
+
+    /**
+     * Get URL for media (signed for S3, direct for local)
+     */
+    public function getMediaUrl(?string $conversion = null): string
+    {
+        if ($this->isS3()) {
+            $expiry = now()->addMinutes(60);
+
+            return $conversion
+                ? $this->media->getTemporaryUrl($expiry, $conversion)
+                : $this->media->getTemporaryUrl($expiry);
+        }
+
+        return $conversion
+            ? $this->media->getUrl($conversion)
+            : $this->media->getUrl();
+    }
+
+    /**
+     * Get conversions with appropriate URLs
+     */
     public function getConversions()
     {
         $conversions = [];
@@ -137,7 +166,7 @@ class Show extends Component
             if ($this->media->hasGeneratedConversion($conversion)) {
                 $conversions[] = [
                     'name' => $conversion,
-                    'url' => $this->media->getUrl($conversion),
+                    'url' => $this->getMediaUrl($conversion),
                     'path' => $this->media->getPath($conversion),
                 ];
             }
@@ -150,6 +179,8 @@ class Show extends Component
     {
         return view('livewire.media.show', [
             'conversions' => $this->getConversions(),
+            'mediaUrl' => $this->getMediaUrl(),
+            'isS3' => $this->isS3(),
         ]);
     }
 }

--- a/resources/views/components/media-card.blade.php
+++ b/resources/views/components/media-card.blade.php
@@ -1,5 +1,26 @@
 @props(['media'])
 
+@php
+    // Use temporary URLs for S3 (private bucket), regular URLs for local storage
+    $isS3 = config('media-library.disk_name') === 's3';
+    $urlExpiry = now()->addMinutes(60);
+
+    $thumbnailUrl = null;
+    $fullUrl = null;
+
+    if ($isS3) {
+        $thumbnailUrl = $media->hasGeneratedConversion('thumbnail')
+            ? $media->getTemporaryUrl($urlExpiry, 'thumbnail')
+            : $media->getTemporaryUrl($urlExpiry);
+        $fullUrl = $media->getTemporaryUrl($urlExpiry);
+    } else {
+        $thumbnailUrl = $media->hasGeneratedConversion('thumbnail')
+            ? $media->getUrl('thumbnail')
+            : $media->getUrl();
+        $fullUrl = $media->getUrl();
+    }
+@endphp
+
 <div class="card bg-base-200 shadow hover:shadow-lg transition-all group">
     <div class="card-body p-4 gap-3">
         {{-- Header: Collection Badge and Date --}}
@@ -22,14 +43,14 @@
         </div>
 
         {{-- Media Preview --}}
-        <a href="{{ route('media.show', $media->id) }}" wire:navigate class="block">
+        <a href="{{ route('media.show', $media->uuid) }}" wire:navigate class="block">
             <div class="w-full h-48 rounded-lg overflow-hidden bg-base-300 relative">
                 @if (str_starts_with($media->mime_type, 'video/'))
                     {{-- Video Preview --}}
                     <div class="relative w-full h-full">
                         @if ($media->hasGeneratedConversion('thumbnail'))
                             <img
-                                src="{{ $media->getUrl('thumbnail') }}"
+                                src="{{ $thumbnailUrl }}"
                                 alt="{{ $media->name }}"
                                 class="w-full h-full object-cover"
                                 loading="lazy"
@@ -47,21 +68,12 @@
                     </div>
                 @elseif (str_starts_with($media->mime_type, 'image/'))
                     {{-- Image Preview --}}
-                    @if ($media->hasGeneratedConversion('thumbnail'))
-                        <img
-                            src="{{ $media->getUrl('thumbnail') }}"
-                            alt="{{ $media->name }}"
-                            class="w-full h-full object-cover group-hover:scale-105 transition-transform"
-                            loading="lazy"
-                        />
-                    @else
-                        <img
-                            src="{{ $media->getUrl() }}"
-                            alt="{{ $media->name }}"
-                            class="w-full h-full object-cover group-hover:scale-105 transition-transform"
-                            loading="lazy"
-                        />
-                    @endif
+                    <img
+                        src="{{ $thumbnailUrl }}"
+                        alt="{{ $media->name }}"
+                        class="w-full h-full object-cover group-hover:scale-105 transition-transform"
+                        loading="lazy"
+                    />
                 @elseif (str_starts_with($media->mime_type, 'application/pdf'))
                     {{-- PDF Preview --}}
                     <div class="flex flex-col items-center justify-center w-full h-full">
@@ -80,7 +92,7 @@
 
         {{-- Title --}}
         <h3 class="font-semibold text-sm leading-snug line-clamp-2">
-            <a href="{{ route('media.show', $media->id) }}" wire:navigate class="link link-hover">
+            <a href="{{ route('media.show', $media->uuid) }}" wire:navigate class="link link-hover">
                 {{ $media->name ?: $media->file_name }}
             </a>
         </h3>
@@ -106,7 +118,7 @@
 
             {{-- Quick Download --}}
             <a
-                href="{{ $media->getUrl() }}"
+                href="{{ $fullUrl }}"
                 download="{{ $media->file_name }}"
                 class="btn btn-ghost btn-xs btn-square"
                 title="Download"
@@ -121,7 +133,7 @@
                 </label>
                 <ul tabindex="0" class="dropdown-content z-[1] menu p-2 shadow-lg bg-base-100 rounded-box w-52">
                     <li>
-                        <a href="{{ route('media.show', $media->id) }}" wire:navigate class="text-sm gap-2">
+                        <a href="{{ route('media.show', $media->uuid) }}" wire:navigate class="text-sm gap-2">
                             <x-icon name="o-eye" class="w-4 h-4" />
                             View Details
                         </a>
@@ -147,21 +159,15 @@
                         </li>
                     @endif
                     <li>
-                        <a href="{{ $media->getUrl() }}" target="_blank" class="text-sm gap-2">
+                        <a href="{{ $fullUrl }}" target="_blank" class="text-sm gap-2">
                             <x-icon name="o-arrow-top-right-on-square" class="w-4 h-4" />
                             Open in New Tab
                         </a>
                     </li>
                     <li>
-                        <button onclick="navigator.clipboard.writeText('{{ $media->getUrl() }}')" class="text-sm gap-2">
-                            <x-icon name="o-clipboard" class="w-4 h-4" />
-                            Copy URL
-                        </button>
-                    </li>
-                    <li>
-                        <button onclick="navigator.clipboard.writeText('{{ $media->id }}')" class="text-sm gap-2">
+                        <button onclick="navigator.clipboard.writeText('{{ $media->uuid }}')" class="text-sm gap-2">
                             <x-icon name="o-hashtag" class="w-4 h-4" />
-                            Copy ID
+                            Copy UUID
                         </button>
                     </li>
                 </ul>

--- a/resources/views/livewire/media/show.blade.php
+++ b/resources/views/livewire/media/show.blade.php
@@ -16,7 +16,7 @@
                             <x-button
                                 icon="o-arrow-down-tray"
                                 class="btn-ghost btn-sm"
-                                link="{{ $this->media->getUrl() }}"
+                                link="{{ $mediaUrl }}"
                                 external
                                 title="Download"
                             />
@@ -102,7 +102,7 @@
                         @if (str_starts_with($this->media->mime_type, 'video/'))
                             {{-- Video Player --}}
                             <video
-                                src="{{ $this->media->getUrl() }}"
+                                src="{{ $mediaUrl }}"
                                 class="max-w-full max-h-[600px] rounded-lg"
                                 controls
                             ></video>
@@ -110,7 +110,7 @@
                             {{-- Image Preview --}}
                             <div class="relative">
                                 <img
-                                    src="{{ $this->media->getUrl() }}"
+                                    src="{{ $mediaUrl }}"
                                     alt="{{ $this->media->name }}"
                                     class="max-w-full max-h-[600px] rounded-lg"
                                 />
@@ -124,7 +124,7 @@
                             {{-- PDF Preview --}}
                             <div class="w-full">
                                 <iframe
-                                    src="{{ $this->media->getUrl() }}"
+                                    src="{{ $mediaUrl }}"
                                     class="w-full h-[600px] rounded-lg border border-base-300"
                                 ></iframe>
                             </div>
@@ -133,7 +133,7 @@
                             <div class="flex flex-col items-center justify-center py-12">
                                 <x-icon name="o-document" class="w-16 h-16 text-base-content/30 mb-4" />
                                 <p class="text-base-content/70 mb-4">Preview not available for this file type</p>
-                                <a href="{{ $this->media->getUrl() }}" target="_blank" class="btn btn-primary btn-sm">
+                                <a href="{{ $mediaUrl }}" target="_blank" class="btn btn-primary btn-sm">
                                     <x-icon name="o-arrow-top-right-on-square" class="w-4 h-4" />
                                     Open in New Tab
                                 </a>
@@ -309,8 +309,12 @@
                                 <div>
                                     <span class="text-base-content/60">URL:</span>
                                     <div class="font-mono text-xs break-all mt-1">
-                                        <a href="{{ $this->media->getUrl() }}" target="_blank" class="link">
-                                            {{ $this->media->getUrl() }}
+                                        <a href="{{ $mediaUrl }}" target="_blank" class="link">
+                                            @if ($isS3)
+                                                <span class="text-warning">[Signed URL - expires in 60 min]</span>
+                                            @else
+                                                {{ $this->media->getUrl() }}
+                                            @endif
                                         </a>
                                     </div>
                                 </div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -48,7 +48,7 @@ Route::middleware(['auth'])->group(function () {
 
     // Media routes
     Route::get('media', \App\Livewire\Media\Index::class)->name('media.index');
-    Route::get('media/{media}', \App\Livewire\Media\Show::class)->whereUuid('media')->name('media.show');
+    Route::get('media/{media:uuid}', \App\Livewire\Media\Show::class)->name('media.show');
 
     // Metrics routes
     Route::get('metrics', \App\Livewire\MetricsOverview::class)->name('metrics.index');


### PR DESCRIPTION
- Update route to use media:uuid for UUID-based routing (Spatie Media Library uses UUIDs)
- Update media-card component to use temporary signed URLs for S3 private buckets
- Update media show page to use signed URLs with 60-minute expiry
- Add isS3() helper method to detect S3 storage configuration
- Add getMediaUrl() helper for consistent URL generation across storage types
- Show signed URL indicator in technical details sidebar for S3 storage
- Update all links to use media UUID instead of integer ID

This fixes AccessDenied errors when viewing media stored in private S3 buckets and 404 errors from incorrect routing (integer vs UUID).