### PR TITLE
:wrench: Fix GitHub Actions workflows rate limits and improve caching

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,6 +40,18 @@ jobs:
           tools: composer:v2
           coverage: xdebug
 
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
@@ -47,7 +59,7 @@ jobs:
           cache: "npm"
 
       - name: Install Node Dependencies
-        run: npm i
+        run: npm ci
 
       - name: Add Wire Credentials Loaded From ENV
         run: composer config http-basic.wire-elements-pro.composer.sh ${{ secrets.WIRE_SECRET}}
@@ -158,7 +170,8 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
-          node-version: "lts/*"
+          node-version: "22"
+          cache: "npm"
       - name: Install dependencies
         run: npm clean-install
       - name: Verify the integrity of provenance attestations and registry signatures for installed dependencies
@@ -208,6 +221,18 @@ jobs:
         uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # v2
         with:
           php-version: "8.2"
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
 
       - name: Add Wire Credentials Loaded From ENV
         run: composer config http-basic.wire-elements-pro.composer.sh ${{ secrets.WIRE_SECRET}}
@@ -281,6 +306,18 @@ jobs:
         uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # v2
         with:
           php-version: "8.2"
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
 
       - name: Add Wire Credentials Loaded From ENV
         run: composer config http-basic.wire-elements-pro.composer.sh ${{ secrets.WIRE_SECRET}}

--- a/.github/workflows/dust_test.yml
+++ b/.github/workflows/dust_test.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: read
     outputs:
       commit_sha: ${{ steps.get_sha.outputs.sha }}
     steps:
@@ -53,6 +54,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: CI
     needs: duster
+    permissions:
+      contents: read
+      pull-requests: write
 
     services:
       postgres:
@@ -85,6 +89,18 @@ jobs:
           tools: composer:v2
           coverage: xdebug
 
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
       - name: Setup Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
@@ -92,16 +108,13 @@ jobs:
           cache: "npm"
 
       - name: Install Node Dependencies
-        run: npm i
+        run: npm ci
 
       - name: Add Wire Credentials Loaded From ENV
         run: composer config http-basic.wire-elements-pro.composer.sh ${{ secrets.WIRE_SECRET}}
 
       - name: Copy Environment File
         run: cp .env.example .env
-
-      - name: Update composer
-        run: composer update
 
       - name: Install Dependencies
         run: composer install --no-interaction --prefer-dist --optimize-autoloader


### PR DESCRIPTION
- Use specific Node version (22) instead of lts/* in version step to avoid GitHub API rate limits when resolving the latest LTS version
- Add pull-requests: read/write permissions to enable comment-triggered tests
- Switch from npm install to npm ci for reproducible builds
- Add Composer dependency caching using actions/cache to speed up builds
- Remove redundant composer update step from dust_test workflow