### PR TITLE
:sparkles: Add automated transaction linking system

### DIFF
--- a/app/Console/Commands/LinkTransactions.php
+++ b/app/Console/Commands/LinkTransactions.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Event;
+use App\Models\User;
+use App\Services\TransactionLinking\TransactionLinkingService;
+use Illuminate\Console\Command;
+
+class LinkTransactions extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'transactions:link
+                            {--user= : User ID to process (leave empty for all users)}
+                            {--threshold=85 : Confidence threshold for auto-approval (0-100)}
+                            {--batch=100 : Number of records to process in each batch}
+                            {--limit= : Maximum number of events to process}
+                            {--dry-run : Show what would be linked without creating relationships}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Find and link related transactions across accounts';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(TransactionLinkingService $linkingService): int
+    {
+        $userId = $this->option('user');
+        $threshold = (float) $this->option('threshold');
+        $batchSize = (int) $this->option('batch');
+        $limit = $this->option('limit') ? (int) $this->option('limit') : null;
+        $dryRun = $this->option('dry-run');
+
+        $this->info('Starting transaction linking...');
+        $this->info('Threshold: ' . $threshold . '%');
+        $this->info('Batch size: ' . $batchSize);
+
+        if ($dryRun) {
+            $this->warn('DRY RUN - No relationships will be created');
+        }
+
+        // Get users to process
+        $users = $userId
+            ? User::where('id', $userId)->get()
+            : User::all();
+
+        if ($users->isEmpty()) {
+            $this->error('No users found to process');
+
+            return Command::FAILURE;
+        }
+
+        $this->info('Processing ' . $users->count() . ' user(s)');
+
+        $totalStats = ['created' => 0, 'pending' => 0, 'skipped' => 0, 'processed' => 0];
+
+        foreach ($users as $user) {
+            $this->info("\nProcessing user: {$user->email}");
+
+            if ($dryRun) {
+                $stats = $this->dryRunForUser($user, $linkingService, $batchSize, $limit);
+            } else {
+                $stats = $linkingService->processAllEventsForUser(
+                    $user->id,
+                    $limit,
+                    $threshold
+                );
+            }
+
+            $this->table(
+                ['Metric', 'Count'],
+                [
+                    ['Events Processed', $stats['processed']],
+                    ['Links Created', $stats['created']],
+                    ['Pending Review', $stats['pending']],
+                    ['Skipped', $stats['skipped']],
+                ]
+            );
+
+            $totalStats['created'] += $stats['created'];
+            $totalStats['pending'] += $stats['pending'];
+            $totalStats['skipped'] += $stats['skipped'];
+            $totalStats['processed'] += $stats['processed'];
+        }
+
+        $this->newLine();
+        $this->info('=== SUMMARY ===');
+        $this->table(
+            ['Metric', 'Total'],
+            [
+                ['Events Processed', $totalStats['processed']],
+                ['Links Created', $totalStats['created']],
+                ['Pending Review', $totalStats['pending']],
+                ['Skipped', $totalStats['skipped']],
+            ]
+        );
+
+        if ($totalStats['pending'] > 0) {
+            $this->info("\nVisit /admin/pending-links to review pending matches");
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Perform a dry run for a user.
+     */
+    private function dryRunForUser(
+        User $user,
+        TransactionLinkingService $linkingService,
+        int $batchSize,
+        ?int $limit
+    ): array {
+        $stats = ['created' => 0, 'pending' => 0, 'skipped' => 0, 'processed' => 0];
+
+        $query = Event::whereHas('integration', function ($q) use ($user) {
+            $q->where('user_id', $user->id);
+        })
+            ->where('domain', 'money')
+            ->orderBy('time', 'desc');
+
+        if ($limit) {
+            $query->limit($limit);
+        }
+
+        $bar = $this->output->createProgressBar($query->count());
+        $bar->start();
+
+        $query->chunk($batchSize, function ($events) use (&$stats, $linkingService, $bar) {
+            foreach ($events as $event) {
+                $event->loadMissing('integration');
+
+                foreach ($linkingService->getStrategies() as $strategy) {
+                    if (! $strategy->canProcess($event)) {
+                        continue;
+                    }
+
+                    $links = $strategy->findLinks($event);
+
+                    foreach ($links as $link) {
+                        if ($link['confidence'] >= 85) {
+                            $this->newLine();
+                            $this->line(sprintf(
+                                '  [WOULD CREATE] %s -> %s (%s, %.1f%%)',
+                                $event->source_id,
+                                $link['target_event']->source_id,
+                                $link['relationship_type'],
+                                $link['confidence']
+                            ));
+                            $stats['created']++;
+                        } else {
+                            $stats['pending']++;
+                        }
+                    }
+                }
+
+                $stats['processed']++;
+                $bar->advance();
+            }
+        });
+
+        $bar->finish();
+        $this->newLine();
+
+        return $stats;
+    }
+}

--- a/app/Jobs/LinkTransactionsJob.php
+++ b/app/Jobs/LinkTransactionsJob.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\Event;
+use App\Services\TransactionLinking\TransactionLinkingService;
+use Exception;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Queue\Queueable;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+class LinkTransactionsJob implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * The number of times the job may be attempted.
+     */
+    public int $tries = 3;
+
+    /**
+     * The number of seconds to wait before retrying the job.
+     */
+    public int $backoff = 30;
+
+    /**
+     * Delete the job if its models no longer exist.
+     */
+    public bool $deleteWhenMissingModels = true;
+
+    /**
+     * Create a new job instance.
+     */
+    public function __construct(
+        public Event $event,
+        public float $autoApproveThreshold = TransactionLinkingService::DEFAULT_AUTO_APPROVE_THRESHOLD
+    ) {}
+
+    /**
+     * Execute the job.
+     */
+    public function handle(TransactionLinkingService $linkingService): void
+    {
+        // Only process money domain events
+        if ($this->event->domain !== 'money') {
+            return;
+        }
+
+        try {
+            $stats = $linkingService->processEvent($this->event, $this->autoApproveThreshold);
+
+            if ($stats['created'] > 0 || $stats['pending'] > 0) {
+                Log::info('Transaction linking completed for event', [
+                    'event_id' => $this->event->id,
+                    'source_id' => $this->event->source_id,
+                    'created' => $stats['created'],
+                    'pending' => $stats['pending'],
+                    'skipped' => $stats['skipped'],
+                ]);
+            }
+        } catch (Exception $e) {
+            Log::error('Failed to link transactions for event', [
+                'event_id' => $this->event->id,
+                'error' => $e->getMessage(),
+            ]);
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Handle a job failure.
+     */
+    public function failed(?Throwable $exception): void
+    {
+        Log::error('LinkTransactionsJob failed after all retries', [
+            'event_id' => $this->event->id,
+            'error' => $exception?->getMessage(),
+        ]);
+    }
+
+    /**
+     * Get the unique ID for the job.
+     */
+    public function uniqueId(): string
+    {
+        return 'link-transactions-' . $this->event->id;
+    }
+}

--- a/app/Models/PendingTransactionLink.php
+++ b/app/Models/PendingTransactionLink.php
@@ -1,0 +1,201 @@
+<?php
+
+namespace App\Models;
+
+use App\Services\RelationshipTypeRegistry;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class PendingTransactionLink extends Model
+{
+    use HasFactory;
+    use HasUuids;
+
+    public const STATUS_PENDING = 'pending';
+
+    public const STATUS_APPROVED = 'approved';
+
+    public const STATUS_REJECTED = 'rejected';
+
+    public const STATUS_AUTO_APPROVED = 'auto_approved';
+
+    protected $fillable = [
+        'user_id',
+        'source_event_id',
+        'target_event_id',
+        'relationship_type',
+        'confidence',
+        'detection_strategy',
+        'matching_criteria',
+        'status',
+        'value',
+        'value_multiplier',
+        'value_unit',
+        'metadata',
+        'created_relationship_id',
+        'reviewed_at',
+    ];
+
+    protected $casts = [
+        'confidence' => 'decimal:2',
+        'matching_criteria' => 'array',
+        'metadata' => 'array',
+        'value' => 'integer',
+        'value_multiplier' => 'integer',
+        'created_at' => 'datetime',
+        'updated_at' => 'datetime',
+        'reviewed_at' => 'datetime',
+    ];
+
+    protected $attributes = [
+        'status' => self::STATUS_PENDING,
+        'value_multiplier' => 1,
+    ];
+
+    /**
+     * The user who owns this pending link.
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class)->withTrashed();
+    }
+
+    /**
+     * The source event in the potential relationship.
+     */
+    public function sourceEvent(): BelongsTo
+    {
+        return $this->belongsTo(Event::class, 'source_event_id');
+    }
+
+    /**
+     * The target event in the potential relationship.
+     */
+    public function targetEvent(): BelongsTo
+    {
+        return $this->belongsTo(Event::class, 'target_event_id');
+    }
+
+    /**
+     * The created relationship (if approved).
+     */
+    public function createdRelationship(): BelongsTo
+    {
+        return $this->belongsTo(Relationship::class, 'created_relationship_id');
+    }
+
+    /**
+     * Approve this pending link and create the relationship.
+     */
+    public function approve(): Relationship
+    {
+        $relationship = Relationship::createRelationship([
+            'user_id' => $this->user_id,
+            'from_type' => Event::class,
+            'from_id' => $this->source_event_id,
+            'to_type' => Event::class,
+            'to_id' => $this->target_event_id,
+            'type' => $this->relationship_type,
+            'value' => $this->value,
+            'value_multiplier' => $this->value_multiplier,
+            'value_unit' => $this->value_unit,
+            'metadata' => array_merge($this->metadata ?? [], [
+                'auto_linked' => true,
+                'detection_strategy' => $this->detection_strategy,
+                'confidence' => $this->confidence,
+                'matching_criteria' => $this->matching_criteria,
+            ]),
+        ]);
+
+        $this->update([
+            'status' => self::STATUS_APPROVED,
+            'created_relationship_id' => $relationship->id,
+            'reviewed_at' => now(),
+        ]);
+
+        return $relationship;
+    }
+
+    /**
+     * Reject this pending link.
+     */
+    public function reject(): void
+    {
+        $this->update([
+            'status' => self::STATUS_REJECTED,
+            'reviewed_at' => now(),
+        ]);
+    }
+
+    /**
+     * Check if this pending link is still pending.
+     */
+    public function isPending(): bool
+    {
+        return $this->status === self::STATUS_PENDING;
+    }
+
+    /**
+     * Check if this pending link was approved.
+     */
+    public function isApproved(): bool
+    {
+        return in_array($this->status, [self::STATUS_APPROVED, self::STATUS_AUTO_APPROVED]);
+    }
+
+    /**
+     * Check if this pending link was rejected.
+     */
+    public function isRejected(): bool
+    {
+        return $this->status === self::STATUS_REJECTED;
+    }
+
+    /**
+     * Get the relationship type configuration.
+     */
+    public function getTypeConfig(): ?array
+    {
+        return RelationshipTypeRegistry::getType($this->relationship_type);
+    }
+
+    /**
+     * Get the formatted value (divided by multiplier).
+     */
+    public function getFormattedValueAttribute(): ?float
+    {
+        if ($this->value === null) {
+            return null;
+        }
+
+        $multiplier = $this->value_multiplier ?? 1;
+
+        return $this->value / $multiplier;
+    }
+
+    /**
+     * Scope to get pending links only.
+     */
+    public function scopePending($query)
+    {
+        return $query->where('status', self::STATUS_PENDING);
+    }
+
+    /**
+     * Scope to get links above a confidence threshold.
+     */
+    public function scopeAboveConfidence($query, float $threshold)
+    {
+        return $query->where('confidence', '>=', $threshold);
+    }
+
+    /**
+     * Scope to get links for a specific detection strategy.
+     */
+    public function scopeForStrategy($query, string $strategy)
+    {
+        return $query->where('detection_strategy', $strategy);
+    }
+}

--- a/app/Services/RelationshipTypeRegistry.php
+++ b/app/Services/RelationshipTypeRegistry.php
@@ -55,6 +55,36 @@ class RelationshipTypeRegistry
                 'supports_value' => true,
                 'default_value_unit' => 'GBP',
             ],
+            'triggered_by' => [
+                'display_name' => 'Triggered By',
+                'icon' => 'o-bolt',
+                'is_directional' => true,
+                'description' => 'Transaction was automatically triggered by another (e.g., coin jar, rewards)',
+                'supports_value' => false,
+            ],
+            'funded_by' => [
+                'display_name' => 'Funded By',
+                'icon' => 'o-currency-pound',
+                'is_directional' => true,
+                'description' => 'Transaction was funded by a pot withdrawal or transfer',
+                'supports_value' => true,
+                'default_value_unit' => 'GBP',
+            ],
+            'payment_for' => [
+                'display_name' => 'Payment For',
+                'icon' => 'o-credit-card',
+                'is_directional' => true,
+                'description' => 'Cross-provider payment relationship (e.g., direct debit paying off credit card)',
+                'supports_value' => true,
+                'default_value_unit' => 'GBP',
+            ],
+            'settles' => [
+                'display_name' => 'Settles',
+                'icon' => 'o-check-circle',
+                'is_directional' => true,
+                'description' => 'Transaction settles a pending authorisation',
+                'supports_value' => false,
+            ],
         ];
     }
 

--- a/app/Services/TransactionLinking/Contracts/LinkingStrategy.php
+++ b/app/Services/TransactionLinking/Contracts/LinkingStrategy.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Services\TransactionLinking\Contracts;
+
+use App\Models\Event;
+use Illuminate\Support\Collection;
+
+interface LinkingStrategy
+{
+    /**
+     * Get the unique identifier for this strategy.
+     */
+    public function getIdentifier(): string;
+
+    /**
+     * Get a human-readable name for this strategy.
+     */
+    public function getName(): string;
+
+    /**
+     * Find potential linked transactions for the given event.
+     *
+     * @return Collection<int, array{
+     *     target_event: Event,
+     *     relationship_type: string,
+     *     confidence: float,
+     *     matching_criteria: array,
+     *     value: int|null,
+     *     value_multiplier: int|null,
+     *     value_unit: string|null
+     * }>
+     */
+    public function findLinks(Event $event): Collection;
+
+    /**
+     * Check if this strategy can process the given event.
+     */
+    public function canProcess(Event $event): bool;
+}

--- a/app/Services/TransactionLinking/Strategies/BacsRecordStrategy.php
+++ b/app/Services/TransactionLinking/Strategies/BacsRecordStrategy.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace App\Services\TransactionLinking\Strategies;
+
+use App\Models\Event;
+use App\Services\TransactionLinking\Contracts\LinkingStrategy;
+use Illuminate\Support\Collection;
+
+/**
+ * Strategy for finding links between direct debits and pot withdrawals via BACS record IDs.
+ *
+ * Handles: bacs_record_id embedded in external_id for pot withdrawals
+ */
+class BacsRecordStrategy implements LinkingStrategy
+{
+    public function getIdentifier(): string
+    {
+        return 'bacs_record';
+    }
+
+    public function getName(): string
+    {
+        return 'BACS Record Matching';
+    }
+
+    public function canProcess(Event $event): bool
+    {
+        // Can process Monzo transactions with BACS-related metadata
+        if ($event->service !== 'monzo') {
+            return false;
+        }
+
+        $metadata = $event->event_metadata ?? [];
+        $rawMetadata = data_get($metadata, 'raw.metadata', []);
+
+        // Check if this is a direct debit with bacs_record_id
+        $hasBacsRecordId = ! empty($rawMetadata['bacs_record_id']);
+
+        // Or a pot transaction with external_id containing BACS reference
+        $externalId = $rawMetadata['external_id'] ?? '';
+        $hasBacsInExternalId = str_contains($externalId, 'bacsrcd_');
+
+        return $hasBacsRecordId || $hasBacsInExternalId;
+    }
+
+    public function findLinks(Event $event): Collection
+    {
+        $links = collect();
+        $metadata = $event->event_metadata ?? [];
+        $rawMetadata = data_get($metadata, 'raw.metadata', []);
+
+        // Case 1: This is a direct debit with bacs_record_id
+        $bacsRecordId = $rawMetadata['bacs_record_id'] ?? null;
+        if ($bacsRecordId) {
+            $potWithdrawals = $this->findPotWithdrawalsForBacsRecord($event, $bacsRecordId);
+            $links = $links->merge($potWithdrawals);
+        }
+
+        // Case 2: This is a pot transaction referencing a BACS record
+        $externalId = $rawMetadata['external_id'] ?? '';
+        if (str_contains($externalId, 'bacsrcd_')) {
+            $directDebits = $this->findDirectDebitsForExternalId($event, $externalId);
+            $links = $links->merge($directDebits);
+        }
+
+        return $links->unique(fn ($link) => $link['target_event']->id);
+    }
+
+    /**
+     * Find pot withdrawals that reference the given BACS record ID.
+     */
+    private function findPotWithdrawalsForBacsRecord(Event $event, string $bacsRecordId): Collection
+    {
+        $links = collect();
+
+        // Search for pot transactions with external_id containing this bacs_record_id
+        $potWithdrawals = Event::whereHas('integration', function ($q) use ($event) {
+            $q->where('user_id', $event->integration->user_id);
+        })
+            ->where('id', '!=', $event->id)
+            ->where('service', 'monzo')
+            ->whereIn('action', ['pot_withdrawal_to', 'pot_transfer_from'])
+            ->whereRaw("event_metadata->'raw'->'metadata'->>'external_id' LIKE ?", ['%' . $bacsRecordId . '%'])
+            ->get();
+
+        foreach ($potWithdrawals as $potWithdrawal) {
+            $links->push([
+                'target_event' => $potWithdrawal,
+                'relationship_type' => 'funded_by',
+                'confidence' => 100.0,
+                'matching_criteria' => [
+                    'type' => 'bacs_record_in_external_id',
+                    'bacs_record_id' => $bacsRecordId,
+                    'external_id' => data_get($potWithdrawal->event_metadata, 'raw.metadata.external_id'),
+                ],
+                'value' => $potWithdrawal->value,
+                'value_multiplier' => $potWithdrawal->value_multiplier,
+                'value_unit' => $potWithdrawal->value_unit,
+            ]);
+        }
+
+        return $links;
+    }
+
+    /**
+     * Find direct debits that match the BACS record ID in the external_id.
+     */
+    private function findDirectDebitsForExternalId(Event $event, string $externalId): Collection
+    {
+        $links = collect();
+
+        // Extract the bacs_record_id from external_id
+        // Format is like: "dd-withdrawal:bacsrcd_XXXX#pot_XXXX#bacspaymentevent_XXXX"
+        if (preg_match('/bacsrcd_[A-Za-z0-9]+/', $externalId, $matches)) {
+            $bacsRecordId = $matches[0];
+
+            $directDebits = Event::whereHas('integration', function ($q) use ($event) {
+                $q->where('user_id', $event->integration->user_id);
+            })
+                ->where('id', '!=', $event->id)
+                ->where('service', 'monzo')
+                ->where('action', 'direct_debit_to')
+                ->whereRaw("event_metadata->'raw'->'metadata'->>'bacs_record_id' = ?", [$bacsRecordId])
+                ->get();
+
+            foreach ($directDebits as $directDebit) {
+                $links->push([
+                    'target_event' => $directDebit,
+                    'relationship_type' => 'funded_by',
+                    'confidence' => 100.0,
+                    'matching_criteria' => [
+                        'type' => 'bacs_record_match',
+                        'bacs_record_id' => $bacsRecordId,
+                        'external_id' => $externalId,
+                    ],
+                    'value' => $event->value,
+                    'value_multiplier' => $event->value_multiplier,
+                    'value_unit' => $event->value_unit,
+                ]);
+            }
+        }
+
+        return $links;
+    }
+}

--- a/app/Services/TransactionLinking/Strategies/CrossProviderStrategy.php
+++ b/app/Services/TransactionLinking/Strategies/CrossProviderStrategy.php
@@ -1,0 +1,220 @@
+<?php
+
+namespace App\Services\TransactionLinking\Strategies;
+
+use App\Models\Event;
+use App\Models\EventObject;
+use App\Services\TransactionLinking\Contracts\LinkingStrategy;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
+
+/**
+ * Strategy for matching payments across different bank providers.
+ *
+ * Handles: Direct debit from one account matching credit on another (e.g., paying off credit card)
+ */
+class CrossProviderStrategy implements LinkingStrategy
+{
+    /**
+     * Known credit card provider merchant names to look for.
+     */
+    private const CREDIT_CARD_PROVIDERS = [
+        'American Express' => ['amex', 'american express'],
+        'Barclaycard' => ['barclaycard'],
+        'HSBC' => ['hsbc'],
+        'NatWest' => ['natwest'],
+        'Lloyds' => ['lloyds'],
+        'Nationwide' => ['nationwide'],
+        'Monzo' => ['monzo flex'],
+    ];
+
+    /**
+     * Maximum days between debit and credit for matching.
+     */
+    private const MAX_SETTLEMENT_DAYS = 3;
+
+    public function getIdentifier(): string
+    {
+        return 'cross_provider';
+    }
+
+    public function getName(): string
+    {
+        return 'Cross-Provider Payment';
+    }
+
+    public function canProcess(Event $event): bool
+    {
+        // Only process direct debits or bank transfers that might be credit card payments
+        if (! in_array($event->action, ['direct_debit_to', 'bank_transfer_to', 'faster_payment_to'])) {
+            return false;
+        }
+
+        // Check if target is a known credit card provider
+        return $this->isCreditCardPayment($event);
+    }
+
+    public function findLinks(Event $event): Collection
+    {
+        $links = collect();
+
+        // Extract card identification from the event
+        $cardId = $this->extractCardIdentification($event);
+        if (! $cardId) {
+            return $links;
+        }
+
+        // Find credit card accounts that match this card ID
+        $creditCardAccounts = $this->findMatchingCreditCardAccounts($event, $cardId);
+        if ($creditCardAccounts->isEmpty()) {
+            return $links;
+        }
+
+        // Search for matching credits on those accounts
+        $eventDate = Carbon::parse($event->time);
+        $startDate = $eventDate->copy()->subDay();
+        $endDate = $eventDate->copy()->addDays(self::MAX_SETTLEMENT_DAYS);
+
+        foreach ($creditCardAccounts as $account) {
+            $matchingCredits = $this->findMatchingCredits($event, $account, $startDate, $endDate);
+
+            foreach ($matchingCredits as $credit) {
+                $confidence = $this->calculateConfidence($event, $credit, $cardId);
+
+                $links->push([
+                    'target_event' => $credit,
+                    'relationship_type' => 'payment_for',
+                    'confidence' => $confidence,
+                    'matching_criteria' => [
+                        'type' => 'cross_provider_payment',
+                        'debit_amount' => $event->value,
+                        'credit_amount' => $credit->value,
+                        'card_identification' => $cardId,
+                        'account_id' => $account->id,
+                        'days_apart' => abs($eventDate->diffInDays(Carbon::parse($credit->time))),
+                    ],
+                    'value' => $event->value,
+                    'value_multiplier' => $event->value_multiplier,
+                    'value_unit' => $event->value_unit,
+                ]);
+            }
+        }
+
+        return $links;
+    }
+
+    /**
+     * Check if this event appears to be a credit card payment.
+     */
+    private function isCreditCardPayment(Event $event): bool
+    {
+        // Check merchant name against known providers
+        $targetName = strtolower($event->target?->title ?? '');
+        $description = strtolower(data_get($event->event_metadata, 'raw.description', ''));
+
+        foreach (self::CREDIT_CARD_PROVIDERS as $keywords) {
+            foreach ($keywords as $keyword) {
+                if (str_contains($targetName, $keyword) || str_contains($description, $keyword)) {
+                    return true;
+                }
+            }
+        }
+
+        // Also check if category is "transfers" and merchant looks like a bank
+        $category = data_get($event->event_metadata, 'category', '');
+
+        return $category === 'transfers' && $this->extractCardIdentification($event) !== null;
+    }
+
+    /**
+     * Extract card identification (masked PAN) from the event.
+     */
+    private function extractCardIdentification(Event $event): ?string
+    {
+        // Check description/notes for masked card number pattern
+        $description = data_get($event->event_metadata, 'raw.description', '');
+        $notes = data_get($event->event_metadata, 'raw.notes', '');
+
+        // Look for patterns like "************4006" or "***********1002"
+        foreach ([$description, $notes] as $text) {
+            if (preg_match('/\*+(\d{4})/', $text, $matches)) {
+                return $matches[1];  // Return last 4 digits
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Find credit card accounts that match the given card identification.
+     */
+    private function findMatchingCreditCardAccounts(Event $event, string $cardId): Collection
+    {
+        $userId = $event->integration->user_id;
+
+        return EventObject::where('user_id', $userId)
+            ->where('concept', 'account')
+            ->where(function ($q) {
+                $q->where('type', 'bank_account')
+                    ->orWhere('type', 'credit_card');
+            })
+            ->where(function ($q) use ($cardId) {
+                // Match on masked PAN in metadata
+                $q->whereRaw("metadata->>'account_number' LIKE ?", ['%' . $cardId])
+                    ->orWhereRaw("metadata->'raw'->>'maskedPan' LIKE ?", ['%' . $cardId]);
+            })
+            ->get();
+    }
+
+    /**
+     * Find matching credit events on the given account.
+     */
+    private function findMatchingCredits(Event $event, EventObject $account, Carbon $startDate, Carbon $endDate): Collection
+    {
+        return Event::where('actor_id', $account->id)
+            ->where('id', '!=', $event->id)
+            ->where('value', $event->value)  // Exact amount match
+            ->whereBetween('time', [$startDate, $endDate])
+            ->where('value', '>', 0)  // Credits are positive
+            ->whereHas('integration', function ($q) use ($event) {
+                $q->where('user_id', $event->integration->user_id);
+            })
+            ->get();
+    }
+
+    /**
+     * Calculate confidence score for a potential match.
+     */
+    private function calculateConfidence(Event $debit, Event $credit, string $cardId): float
+    {
+        $confidence = 0.0;
+
+        // Amount match (exact) = 40%
+        if ($debit->value === $credit->value) {
+            $confidence += 40.0;
+        }
+
+        // Date proximity
+        $debitDate = Carbon::parse($debit->time);
+        $creditDate = Carbon::parse($credit->time);
+        $daysDiff = abs($debitDate->diffInDays($creditDate));
+
+        if ($daysDiff === 0) {
+            $confidence += 30.0;  // Same day
+        } elseif ($daysDiff === 1) {
+            $confidence += 20.0;  // Next day
+        } elseif ($daysDiff <= 3) {
+            $confidence += 10.0;  // Within 3 days
+        }
+
+        // Card ID match in account = 30%
+        $accountNumber = $credit->actor?->metadata['account_number'] ?? '';
+        $maskedPan = data_get($credit->actor?->metadata, 'raw.maskedPan', '');
+
+        if (str_ends_with($accountNumber, $cardId) || str_ends_with($maskedPan, $cardId)) {
+            $confidence += 30.0;
+        }
+
+        return min($confidence, 100.0);
+    }
+}

--- a/app/Services/TransactionLinking/Strategies/ExplicitReferenceStrategy.php
+++ b/app/Services/TransactionLinking/Strategies/ExplicitReferenceStrategy.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace App\Services\TransactionLinking\Strategies;
+
+use App\Models\Event;
+use App\Services\TransactionLinking\Contracts\LinkingStrategy;
+use Illuminate\Support\Collection;
+
+/**
+ * Strategy for finding links via explicit transaction ID references in metadata.
+ *
+ * Handles: transaction_id, triggered_by, coin_jar_transaction
+ */
+class ExplicitReferenceStrategy implements LinkingStrategy
+{
+    /**
+     * Metadata paths to check for transaction ID references.
+     */
+    private const REFERENCE_PATHS = [
+        'transaction_id' => [
+            'relationship_type' => 'triggered_by',
+            'paths' => [
+                'raw.metadata.transaction_id',
+            ],
+        ],
+        'triggered_by' => [
+            'relationship_type' => 'triggered_by',
+            'paths' => [
+                'raw.metadata.triggered_by',
+            ],
+        ],
+        'coin_jar_transaction' => [
+            'relationship_type' => 'triggered_by',
+            'paths' => [
+                'raw.metadata.coin_jar_transaction',
+            ],
+        ],
+    ];
+
+    public function getIdentifier(): string
+    {
+        return 'explicit_reference';
+    }
+
+    public function getName(): string
+    {
+        return 'Explicit Reference';
+    }
+
+    public function canProcess(Event $event): bool
+    {
+        // Can process any Monzo transaction with metadata
+        return $event->service === 'monzo' && ! empty($event->event_metadata);
+    }
+
+    public function findLinks(Event $event): Collection
+    {
+        $links = collect();
+        $metadata = $event->event_metadata ?? [];
+
+        foreach (self::REFERENCE_PATHS as $refType => $config) {
+            foreach ($config['paths'] as $path) {
+                $referencedId = data_get($metadata, $path);
+
+                if (! $referencedId || ! is_string($referencedId)) {
+                    continue;
+                }
+
+                // Skip if it's not a transaction ID format (e.g., "direct-debit" is not a tx ID)
+                if (! str_starts_with($referencedId, 'tx_')) {
+                    continue;
+                }
+
+                // Find the referenced event
+                $targetEvent = Event::where('source_id', $referencedId)
+                    ->whereHas('integration', function ($q) use ($event) {
+                        $q->where('user_id', $event->integration->user_id);
+                    })
+                    ->first();
+
+                if ($targetEvent && $targetEvent->id !== $event->id) {
+                    $links->push([
+                        'target_event' => $targetEvent,
+                        'relationship_type' => $config['relationship_type'],
+                        'confidence' => 100.0,
+                        'matching_criteria' => [
+                            'type' => $refType,
+                            'path' => $path,
+                            'referenced_id' => $referencedId,
+                        ],
+                        'value' => null,
+                        'value_multiplier' => null,
+                        'value_unit' => null,
+                    ]);
+                }
+            }
+        }
+
+        // Also check reverse: does this event's source_id appear in other events' metadata?
+        $reverseLinks = $this->findReverseLinks($event);
+        $links = $links->merge($reverseLinks);
+
+        return $links->unique(fn ($link) => $link['target_event']->id);
+    }
+
+    /**
+     * Find events that reference this event's source_id in their metadata.
+     */
+    private function findReverseLinks(Event $event): Collection
+    {
+        $links = collect();
+        $sourceId = $event->source_id;
+
+        if (! $sourceId) {
+            return $links;
+        }
+
+        // Find events that might reference this one via coin_jar_transaction
+        $coinJarEvents = Event::whereHas('integration', function ($q) use ($event) {
+            $q->where('user_id', $event->integration->user_id);
+        })
+            ->where('id', '!=', $event->id)
+            ->whereRaw("event_metadata->'raw'->'metadata'->>'coin_jar_transaction' = ?", [$sourceId])
+            ->get();
+
+        foreach ($coinJarEvents as $coinJarEvent) {
+            $links->push([
+                'target_event' => $coinJarEvent,
+                'relationship_type' => 'triggered_by',
+                'confidence' => 100.0,
+                'matching_criteria' => [
+                    'type' => 'coin_jar_reverse',
+                    'path' => 'raw.metadata.coin_jar_transaction',
+                    'referenced_id' => $sourceId,
+                ],
+                'value' => null,
+                'value_multiplier' => null,
+                'value_unit' => null,
+            ]);
+        }
+
+        return $links;
+    }
+}

--- a/app/Services/TransactionLinking/TransactionLinkingService.php
+++ b/app/Services/TransactionLinking/TransactionLinkingService.php
@@ -1,0 +1,239 @@
+<?php
+
+namespace App\Services\TransactionLinking;
+
+use App\Models\Event;
+use App\Models\PendingTransactionLink;
+use App\Models\Relationship;
+use App\Services\TransactionLinking\Contracts\LinkingStrategy;
+use App\Services\TransactionLinking\Strategies\BacsRecordStrategy;
+use App\Services\TransactionLinking\Strategies\CrossProviderStrategy;
+use App\Services\TransactionLinking\Strategies\ExplicitReferenceStrategy;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\Log;
+
+class TransactionLinkingService
+{
+    /**
+     * Default confidence threshold for auto-approval.
+     */
+    public const DEFAULT_AUTO_APPROVE_THRESHOLD = 85.0;
+
+    /**
+     * Registered linking strategies.
+     *
+     * @var array<LinkingStrategy>
+     */
+    private array $strategies = [];
+
+    public function __construct()
+    {
+        // Register default strategies
+        $this->registerStrategy(new ExplicitReferenceStrategy);
+        $this->registerStrategy(new BacsRecordStrategy);
+        $this->registerStrategy(new CrossProviderStrategy);
+    }
+
+    /**
+     * Register a linking strategy.
+     */
+    public function registerStrategy(LinkingStrategy $strategy): self
+    {
+        $this->strategies[$strategy->getIdentifier()] = $strategy;
+
+        return $this;
+    }
+
+    /**
+     * Get all registered strategies.
+     *
+     * @return array<string, LinkingStrategy>
+     */
+    public function getStrategies(): array
+    {
+        return $this->strategies;
+    }
+
+    /**
+     * Find and process potential links for an event.
+     *
+     * @return array{created: int, pending: int, skipped: int}
+     */
+    public function processEvent(Event $event, float $autoApproveThreshold = self::DEFAULT_AUTO_APPROVE_THRESHOLD): array
+    {
+        $stats = ['created' => 0, 'pending' => 0, 'skipped' => 0];
+
+        // Ensure the event has integration loaded
+        $event->loadMissing('integration');
+
+        if (! $event->integration) {
+            return $stats;
+        }
+
+        $userId = $event->integration->user_id;
+
+        foreach ($this->strategies as $strategy) {
+            if (! $strategy->canProcess($event)) {
+                continue;
+            }
+
+            try {
+                $links = $strategy->findLinks($event);
+
+                foreach ($links as $link) {
+                    $result = $this->processLink($event, $link, $userId, $strategy, $autoApproveThreshold);
+                    $stats[$result]++;
+                }
+            } catch (\Exception $e) {
+                Log::error('Transaction linking strategy failed', [
+                    'strategy' => $strategy->getIdentifier(),
+                    'event_id' => $event->id,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+
+        return $stats;
+    }
+
+    /**
+     * Process a single potential link.
+     */
+    private function processLink(
+        Event $sourceEvent,
+        array $link,
+        string $userId,
+        LinkingStrategy $strategy,
+        float $autoApproveThreshold
+    ): string {
+        $targetEvent = $link['target_event'];
+
+        // Check if relationship already exists
+        $existingRelationship = Relationship::where('user_id', $userId)
+            ->where('from_type', Event::class)
+            ->where('from_id', $sourceEvent->id)
+            ->where('to_type', Event::class)
+            ->where('to_id', $targetEvent->id)
+            ->where('type', $link['relationship_type'])
+            ->exists();
+
+        if ($existingRelationship) {
+            return 'skipped';
+        }
+
+        // Check if pending link already exists
+        $existingPending = PendingTransactionLink::where('user_id', $userId)
+            ->where('source_event_id', $sourceEvent->id)
+            ->where('target_event_id', $targetEvent->id)
+            ->where('relationship_type', $link['relationship_type'])
+            ->exists();
+
+        if ($existingPending) {
+            return 'skipped';
+        }
+
+        // Auto-approve high confidence links
+        if ($link['confidence'] >= $autoApproveThreshold) {
+            Relationship::createRelationship([
+                'user_id' => $userId,
+                'from_type' => Event::class,
+                'from_id' => $sourceEvent->id,
+                'to_type' => Event::class,
+                'to_id' => $targetEvent->id,
+                'type' => $link['relationship_type'],
+                'value' => $link['value'],
+                'value_multiplier' => $link['value_multiplier'],
+                'value_unit' => $link['value_unit'],
+                'metadata' => [
+                    'auto_linked' => true,
+                    'detection_strategy' => $strategy->getIdentifier(),
+                    'confidence' => $link['confidence'],
+                    'matching_criteria' => $link['matching_criteria'],
+                ],
+            ]);
+
+            return 'created';
+        }
+
+        // Create pending link for manual review
+        PendingTransactionLink::create([
+            'user_id' => $userId,
+            'source_event_id' => $sourceEvent->id,
+            'target_event_id' => $targetEvent->id,
+            'relationship_type' => $link['relationship_type'],
+            'confidence' => $link['confidence'],
+            'detection_strategy' => $strategy->getIdentifier(),
+            'matching_criteria' => $link['matching_criteria'],
+            'value' => $link['value'],
+            'value_multiplier' => $link['value_multiplier'],
+            'value_unit' => $link['value_unit'],
+        ]);
+
+        return 'pending';
+    }
+
+    /**
+     * Process all events for a user (batch operation).
+     *
+     * @return array{created: int, pending: int, skipped: int, processed: int}
+     */
+    public function processAllEventsForUser(
+        string $userId,
+        ?int $limit = null,
+        float $autoApproveThreshold = self::DEFAULT_AUTO_APPROVE_THRESHOLD
+    ): array {
+        $stats = ['created' => 0, 'pending' => 0, 'skipped' => 0, 'processed' => 0];
+
+        $query = Event::whereHas('integration', function ($q) use ($userId) {
+            $q->where('user_id', $userId);
+        })
+            ->where('domain', 'money')
+            ->orderBy('time', 'desc');
+
+        if ($limit) {
+            $query->limit($limit);
+        }
+
+        $query->chunk(100, function ($events) use (&$stats, $autoApproveThreshold) {
+            foreach ($events as $event) {
+                $result = $this->processEvent($event, $autoApproveThreshold);
+                $stats['created'] += $result['created'];
+                $stats['pending'] += $result['pending'];
+                $stats['skipped'] += $result['skipped'];
+                $stats['processed']++;
+            }
+        });
+
+        return $stats;
+    }
+
+    /**
+     * Get statistics about pending links for a user.
+     */
+    public function getPendingStats(string $userId): array
+    {
+        return [
+            'total' => PendingTransactionLink::where('user_id', $userId)->pending()->count(),
+            'by_strategy' => PendingTransactionLink::where('user_id', $userId)
+                ->pending()
+                ->selectRaw('detection_strategy, COUNT(*) as count')
+                ->groupBy('detection_strategy')
+                ->pluck('count', 'detection_strategy')
+                ->toArray(),
+            'by_confidence' => [
+                'high' => PendingTransactionLink::where('user_id', $userId)
+                    ->pending()
+                    ->where('confidence', '>=', 80)
+                    ->count(),
+                'medium' => PendingTransactionLink::where('user_id', $userId)
+                    ->pending()
+                    ->whereBetween('confidence', [50, 80])
+                    ->count(),
+                'low' => PendingTransactionLink::where('user_id', $userId)
+                    ->pending()
+                    ->where('confidence', '<', 50)
+                    ->count(),
+            ],
+        ];
+    }
+}

--- a/app/Services/TransactionLinking/TransactionLinkingService.php
+++ b/app/Services/TransactionLinking/TransactionLinkingService.php
@@ -9,7 +9,7 @@ use App\Services\TransactionLinking\Contracts\LinkingStrategy;
 use App\Services\TransactionLinking\Strategies\BacsRecordStrategy;
 use App\Services\TransactionLinking\Strategies\CrossProviderStrategy;
 use App\Services\TransactionLinking\Strategies\ExplicitReferenceStrategy;
-use Illuminate\Support\Collection;
+use Exception;
 use Illuminate\Support\Facades\Log;
 
 class TransactionLinkingService
@@ -84,7 +84,7 @@ class TransactionLinkingService
                     $result = $this->processLink($event, $link, $userId, $strategy, $autoApproveThreshold);
                     $stats[$result]++;
                 }
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 Log::error('Transaction linking strategy failed', [
                     'strategy' => $strategy->getIdentifier(),
                     'event_id' => $event->id,
@@ -94,6 +94,71 @@ class TransactionLinkingService
         }
 
         return $stats;
+    }
+
+    /**
+     * Process all events for a user (batch operation).
+     *
+     * @return array{created: int, pending: int, skipped: int, processed: int}
+     */
+    public function processAllEventsForUser(
+        string $userId,
+        ?int $limit = null,
+        float $autoApproveThreshold = self::DEFAULT_AUTO_APPROVE_THRESHOLD
+    ): array {
+        $stats = ['created' => 0, 'pending' => 0, 'skipped' => 0, 'processed' => 0];
+
+        $query = Event::whereHas('integration', function ($q) use ($userId) {
+            $q->where('user_id', $userId);
+        })
+            ->where('domain', 'money')
+            ->orderBy('time', 'desc');
+
+        if ($limit) {
+            $query->limit($limit);
+        }
+
+        $query->chunk(100, function ($events) use (&$stats, $autoApproveThreshold) {
+            foreach ($events as $event) {
+                $result = $this->processEvent($event, $autoApproveThreshold);
+                $stats['created'] += $result['created'];
+                $stats['pending'] += $result['pending'];
+                $stats['skipped'] += $result['skipped'];
+                $stats['processed']++;
+            }
+        });
+
+        return $stats;
+    }
+
+    /**
+     * Get statistics about pending links for a user.
+     */
+    public function getPendingStats(string $userId): array
+    {
+        return [
+            'total' => PendingTransactionLink::where('user_id', $userId)->pending()->count(),
+            'by_strategy' => PendingTransactionLink::where('user_id', $userId)
+                ->pending()
+                ->selectRaw('detection_strategy, COUNT(*) as count')
+                ->groupBy('detection_strategy')
+                ->pluck('count', 'detection_strategy')
+                ->toArray(),
+            'by_confidence' => [
+                'high' => PendingTransactionLink::where('user_id', $userId)
+                    ->pending()
+                    ->where('confidence', '>=', 80)
+                    ->count(),
+                'medium' => PendingTransactionLink::where('user_id', $userId)
+                    ->pending()
+                    ->whereBetween('confidence', [50, 80])
+                    ->count(),
+                'low' => PendingTransactionLink::where('user_id', $userId)
+                    ->pending()
+                    ->where('confidence', '<', 50)
+                    ->count(),
+            ],
+        ];
     }
 
     /**
@@ -170,70 +235,5 @@ class TransactionLinkingService
         ]);
 
         return 'pending';
-    }
-
-    /**
-     * Process all events for a user (batch operation).
-     *
-     * @return array{created: int, pending: int, skipped: int, processed: int}
-     */
-    public function processAllEventsForUser(
-        string $userId,
-        ?int $limit = null,
-        float $autoApproveThreshold = self::DEFAULT_AUTO_APPROVE_THRESHOLD
-    ): array {
-        $stats = ['created' => 0, 'pending' => 0, 'skipped' => 0, 'processed' => 0];
-
-        $query = Event::whereHas('integration', function ($q) use ($userId) {
-            $q->where('user_id', $userId);
-        })
-            ->where('domain', 'money')
-            ->orderBy('time', 'desc');
-
-        if ($limit) {
-            $query->limit($limit);
-        }
-
-        $query->chunk(100, function ($events) use (&$stats, $autoApproveThreshold) {
-            foreach ($events as $event) {
-                $result = $this->processEvent($event, $autoApproveThreshold);
-                $stats['created'] += $result['created'];
-                $stats['pending'] += $result['pending'];
-                $stats['skipped'] += $result['skipped'];
-                $stats['processed']++;
-            }
-        });
-
-        return $stats;
-    }
-
-    /**
-     * Get statistics about pending links for a user.
-     */
-    public function getPendingStats(string $userId): array
-    {
-        return [
-            'total' => PendingTransactionLink::where('user_id', $userId)->pending()->count(),
-            'by_strategy' => PendingTransactionLink::where('user_id', $userId)
-                ->pending()
-                ->selectRaw('detection_strategy, COUNT(*) as count')
-                ->groupBy('detection_strategy')
-                ->pluck('count', 'detection_strategy')
-                ->toArray(),
-            'by_confidence' => [
-                'high' => PendingTransactionLink::where('user_id', $userId)
-                    ->pending()
-                    ->where('confidence', '>=', 80)
-                    ->count(),
-                'medium' => PendingTransactionLink::where('user_id', $userId)
-                    ->pending()
-                    ->whereBetween('confidence', [50, 80])
-                    ->count(),
-                'low' => PendingTransactionLink::where('user_id', $userId)
-                    ->pending()
-                    ->where('confidence', '<', 50)
-                    ->count(),
-            ],
-        ];
     }
 }

--- a/database/migrations/2025_11_22_105408_create_pending_transaction_links_table.php
+++ b/database/migrations/2025_11_22_105408_create_pending_transaction_links_table.php
@@ -1,0 +1,96 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('pending_transaction_links', function (Blueprint $table) {
+            // Primary key
+            $table->uuid('id')->primary()->default(DB::raw('gen_random_uuid()'));
+
+            // User ownership
+            $table->uuid('user_id');
+
+            // Source event
+            $table->uuid('source_event_id');
+
+            // Target event
+            $table->uuid('target_event_id');
+
+            // Proposed relationship type
+            $table->string('relationship_type');
+
+            // Confidence score (0-100)
+            $table->decimal('confidence', 5, 2);
+
+            // Detection strategy that found this match
+            $table->string('detection_strategy');
+
+            // Matching criteria used (e.g., which fields matched)
+            $table->json('matching_criteria');
+
+            // Status: pending, approved, rejected, auto_approved
+            $table->string('status')->default('pending');
+
+            // Value fields (for monetary relationships)
+            $table->bigInteger('value')->nullable();
+            $table->integer('value_multiplier')->nullable()->default(1);
+            $table->string('value_unit')->nullable();
+
+            // Additional metadata
+            $table->json('metadata')->nullable();
+
+            // If approved, reference to the created relationship
+            $table->uuid('created_relationship_id')->nullable();
+
+            // Timestamps
+            $table->timestampTz('created_at')->default(DB::raw("(now() AT TIME ZONE 'utc')"));
+            $table->timestampTz('updated_at')->default(DB::raw("(now() AT TIME ZONE 'utc')"));
+            $table->timestampTz('reviewed_at')->nullable();
+
+            // Foreign keys
+            $table->foreign('user_id')
+                ->references('id')
+                ->on('users')
+                ->cascadeOnDelete();
+
+            $table->foreign('source_event_id')
+                ->references('id')
+                ->on('events')
+                ->cascadeOnDelete();
+
+            $table->foreign('target_event_id')
+                ->references('id')
+                ->on('events')
+                ->cascadeOnDelete();
+
+            $table->foreign('created_relationship_id')
+                ->references('id')
+                ->on('relationships')
+                ->nullOnDelete();
+
+            // Indexes
+            $table->index('user_id');
+            $table->index('status');
+            $table->index('confidence');
+            $table->index('detection_strategy');
+            $table->index(['user_id', 'status']);
+
+            // Unique constraint: prevent duplicate pending links
+            $table->unique(
+                ['user_id', 'source_event_id', 'target_event_id', 'relationship_type'],
+                'pending_links_unique'
+            );
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('pending_transaction_links');
+    }
+};

--- a/resources/views/livewire/admin/pending-links.blade.php
+++ b/resources/views/livewire/admin/pending-links.blade.php
@@ -1,0 +1,462 @@
+<?php
+
+use App\Models\PendingTransactionLink;
+use App\Services\RelationshipTypeRegistry;
+use App\Services\TransactionLinking\TransactionLinkingService;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Str;
+use Livewire\Volt\Component;
+use Livewire\WithPagination;
+use Mary\Traits\Toast;
+
+use function Livewire\Volt\layout;
+
+layout('components.layouts.app');
+
+new class extends Component
+{
+    use Toast, WithPagination;
+
+    public string $search = '';
+    public string $statusFilter = 'pending';
+    public string $strategyFilter = '';
+    public string $confidenceFilter = '';
+    public array $selectedLinks = [];
+    public int $perPage = 25;
+    public array $sortBy = ['column' => 'confidence', 'direction' => 'desc'];
+
+    protected $queryString = [
+        'search' => ['except' => ''],
+        'statusFilter' => ['except' => 'pending'],
+        'strategyFilter' => ['except' => ''],
+        'confidenceFilter' => ['except' => ''],
+        'sortBy' => ['except' => ['column' => 'confidence', 'direction' => 'desc']],
+        'perPage' => ['except' => 25],
+        'page' => ['except' => 1],
+    ];
+
+    public function mount(): void
+    {
+        // Initialize
+    }
+
+    public function updatedSearch(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatedStatusFilter(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatedStrategyFilter(): void
+    {
+        $this->resetPage();
+    }
+
+    public function updatedConfidenceFilter(): void
+    {
+        $this->resetPage();
+    }
+
+    public function clearFilters(): void
+    {
+        $this->reset(['search', 'statusFilter', 'strategyFilter', 'confidenceFilter']);
+        $this->statusFilter = 'pending';
+        $this->resetPage();
+    }
+
+    public function headers(): array
+    {
+        return [
+            ['key' => 'confidence', 'label' => 'Confidence', 'sortable' => true, 'class' => 'w-24'],
+            ['key' => 'source', 'label' => 'Source Transaction', 'sortable' => false],
+            ['key' => 'type', 'label' => 'Link Type', 'sortable' => false, 'class' => 'w-32'],
+            ['key' => 'target', 'label' => 'Target Transaction', 'sortable' => false],
+            ['key' => 'strategy', 'label' => 'Strategy', 'sortable' => true, 'class' => 'hidden lg:table-cell'],
+            ['key' => 'actions', 'label' => 'Actions', 'sortable' => false, 'class' => 'w-32'],
+        ];
+    }
+
+    public function approveLink(string $linkId): void
+    {
+        try {
+            $link = PendingTransactionLink::findOrFail($linkId);
+
+            if (!$link->isPending()) {
+                $this->warning('This link has already been processed.');
+                return;
+            }
+
+            $link->approve();
+            $this->success('Link approved and relationship created!');
+        } catch (\Exception $e) {
+            $this->error('Failed to approve link: ' . $e->getMessage());
+        }
+    }
+
+    public function rejectLink(string $linkId): void
+    {
+        try {
+            $link = PendingTransactionLink::findOrFail($linkId);
+
+            if (!$link->isPending()) {
+                $this->warning('This link has already been processed.');
+                return;
+            }
+
+            $link->reject();
+            $this->success('Link rejected.');
+        } catch (\Exception $e) {
+            $this->error('Failed to reject link: ' . $e->getMessage());
+        }
+    }
+
+    public function bulkApprove(): void
+    {
+        if (empty($this->selectedLinks)) {
+            $this->error('No links selected.');
+            return;
+        }
+
+        $approved = 0;
+        foreach ($this->selectedLinks as $linkId) {
+            try {
+                $link = PendingTransactionLink::find($linkId);
+                if ($link && $link->isPending()) {
+                    $link->approve();
+                    $approved++;
+                }
+            } catch (\Exception $e) {
+                // Continue with next
+            }
+        }
+
+        $this->success("Approved {$approved} link(s).");
+        $this->selectedLinks = [];
+    }
+
+    public function bulkReject(): void
+    {
+        if (empty($this->selectedLinks)) {
+            $this->error('No links selected.');
+            return;
+        }
+
+        $rejected = 0;
+        foreach ($this->selectedLinks as $linkId) {
+            try {
+                $link = PendingTransactionLink::find($linkId);
+                if ($link && $link->isPending()) {
+                    $link->reject();
+                    $rejected++;
+                }
+            } catch (\Exception $e) {
+                // Continue with next
+            }
+        }
+
+        $this->success("Rejected {$rejected} link(s).");
+        $this->selectedLinks = [];
+    }
+
+    public function getPendingLinks()
+    {
+        $query = PendingTransactionLink::with(['sourceEvent.actor', 'sourceEvent.target', 'targetEvent.actor', 'targetEvent.target'])
+            ->where('user_id', Auth::id());
+
+        // Apply status filter
+        if ($this->statusFilter) {
+            $query->where('status', $this->statusFilter);
+        }
+
+        // Apply strategy filter
+        if ($this->strategyFilter) {
+            $query->where('detection_strategy', $this->strategyFilter);
+        }
+
+        // Apply confidence filter
+        if ($this->confidenceFilter) {
+            match ($this->confidenceFilter) {
+                'high' => $query->where('confidence', '>=', 80),
+                'medium' => $query->whereBetween('confidence', [50, 80]),
+                'low' => $query->where('confidence', '<', 50),
+                default => null,
+            };
+        }
+
+        // Apply search
+        if ($this->search) {
+            $query->where(function ($q) {
+                $q->whereHas('sourceEvent', function ($eq) {
+                    $eq->where('action', 'ilike', '%' . $this->search . '%')
+                        ->orWhereRaw("event_metadata::text ilike ?", ['%' . $this->search . '%']);
+                })
+                ->orWhereHas('targetEvent', function ($eq) {
+                    $eq->where('action', 'ilike', '%' . $this->search . '%')
+                        ->orWhereRaw("event_metadata::text ilike ?", ['%' . $this->search . '%']);
+                });
+            });
+        }
+
+        // Apply sorting
+        $sortColumn = $this->sortBy['column'] ?? 'confidence';
+        $sortDirection = $this->sortBy['direction'] ?? 'desc';
+        $query->orderBy($sortColumn, $sortDirection);
+
+        return $query->paginate($this->perPage);
+    }
+
+    public function getStats(): array
+    {
+        $linkingService = app(TransactionLinkingService::class);
+        return $linkingService->getPendingStats(Auth::id());
+    }
+
+    public function getUniqueStrategies()
+    {
+        return PendingTransactionLink::where('user_id', Auth::id())
+            ->distinct()
+            ->pluck('detection_strategy')
+            ->filter()
+            ->sort()
+            ->values();
+    }
+
+    public function formatTransactionTitle($event): string
+    {
+        if (!$event) {
+            return '-';
+        }
+
+        $action = Str::title(str_replace('_', ' ', $event->action));
+        $value = $event->value ? '£' . number_format($event->value / ($event->value_multiplier ?? 100), 2) : '';
+        $target = $event->target?->title ?? '';
+
+        if ($target) {
+            return "{$action} - {$target}" . ($value ? " ({$value})" : '');
+        }
+
+        return $action . ($value ? " ({$value})" : '');
+    }
+
+    public function formatStrategy(string $strategy): string
+    {
+        return Str::title(str_replace('_', ' ', $strategy));
+    }
+
+    public function getTypeDisplayName(string $type): string
+    {
+        return RelationshipTypeRegistry::getDisplayName($type) ?? Str::title(str_replace('_', ' ', $type));
+    }
+
+    public function getConfidenceBadgeClass(float $confidence): string
+    {
+        if ($confidence >= 80) {
+            return 'badge-success';
+        }
+        if ($confidence >= 50) {
+            return 'badge-warning';
+        }
+        return 'badge-error';
+    }
+};
+
+?>
+
+<div>
+    <x-header title="Pending Transaction Links" subtitle="Review and approve potential transaction relationships" separator>
+        <x-slot:actions>
+            <div class="flex items-center gap-2">
+                @if (count($selectedLinks) > 0)
+                <button class="btn btn-success btn-sm" wire:click="bulkApprove">
+                    <x-icon name="o-check" class="w-4 h-4 mr-1" />
+                    Approve ({{ count($selectedLinks) }})
+                </button>
+                <button class="btn btn-error btn-sm" wire:click="bulkReject">
+                    <x-icon name="o-x-mark" class="w-4 h-4 mr-1" />
+                    Reject ({{ count($selectedLinks) }})
+                </button>
+                @endif
+            </div>
+        </x-slot:actions>
+    </x-header>
+
+    <div class="space-y-4 lg:space-y-6">
+        <!-- Stats Cards -->
+        @php $stats = $this->getStats(); @endphp
+        <div class="stats stats-vertical lg:stats-horizontal shadow bg-base-200 w-full">
+            <div class="stat">
+                <div class="stat-figure text-primary">
+                    <x-icon name="o-clock" class="w-8 h-8" />
+                </div>
+                <div class="stat-title">Pending Review</div>
+                <div class="stat-value text-primary">{{ $stats['total'] }}</div>
+            </div>
+            <div class="stat">
+                <div class="stat-figure text-success">
+                    <x-icon name="o-check-circle" class="w-8 h-8" />
+                </div>
+                <div class="stat-title">High Confidence</div>
+                <div class="stat-value text-success">{{ $stats['by_confidence']['high'] ?? 0 }}</div>
+                <div class="stat-desc">≥80% confidence</div>
+            </div>
+            <div class="stat">
+                <div class="stat-figure text-warning">
+                    <x-icon name="o-exclamation-triangle" class="w-8 h-8" />
+                </div>
+                <div class="stat-title">Medium Confidence</div>
+                <div class="stat-value text-warning">{{ $stats['by_confidence']['medium'] ?? 0 }}</div>
+                <div class="stat-desc">50-80% confidence</div>
+            </div>
+            <div class="stat">
+                <div class="stat-figure text-error">
+                    <x-icon name="o-question-mark-circle" class="w-8 h-8" />
+                </div>
+                <div class="stat-title">Low Confidence</div>
+                <div class="stat-value text-error">{{ $stats['by_confidence']['low'] ?? 0 }}</div>
+                <div class="stat-desc"><50% confidence</div>
+            </div>
+        </div>
+
+        <!-- Filters -->
+        <div class="card bg-base-200 shadow">
+            <div class="card-body">
+                <div class="flex flex-col lg:flex-row gap-4">
+                    <div class="form-control flex-1">
+                        <label class="label"><span class="label-text">Search</span></label>
+                        <input type="text" class="input input-bordered w-full" placeholder="Search transactions..." wire:model.live.debounce.300ms="search" />
+                    </div>
+                    <div class="form-control">
+                        <label class="label"><span class="label-text">Status</span></label>
+                        <select class="select select-bordered" wire:model.live="statusFilter">
+                            <option value="">All</option>
+                            <option value="pending">Pending</option>
+                            <option value="approved">Approved</option>
+                            <option value="rejected">Rejected</option>
+                            <option value="auto_approved">Auto-Approved</option>
+                        </select>
+                    </div>
+                    <div class="form-control">
+                        <label class="label"><span class="label-text">Strategy</span></label>
+                        <select class="select select-bordered" wire:model.live="strategyFilter">
+                            <option value="">All Strategies</option>
+                            @foreach ($this->getUniqueStrategies() as $strategy)
+                            <option value="{{ $strategy }}">{{ $this->formatStrategy($strategy) }}</option>
+                            @endforeach
+                        </select>
+                    </div>
+                    <div class="form-control">
+                        <label class="label"><span class="label-text">Confidence</span></label>
+                        <select class="select select-bordered" wire:model.live="confidenceFilter">
+                            <option value="">All</option>
+                            <option value="high">High (≥80%)</option>
+                            <option value="medium">Medium (50-80%)</option>
+                            <option value="low">Low (<50%)</option>
+                        </select>
+                    </div>
+                    @if ($search || $statusFilter !== 'pending' || $strategyFilter || $confidenceFilter)
+                    <div class="form-control content-end">
+                        <label class="label"><span class="label-text">&nbsp;</span></label>
+                        <button class="btn btn-outline" wire:click="clearFilters">
+                            <x-icon name="o-x-mark" class="w-4 h-4" />
+                            Clear
+                        </button>
+                    </div>
+                    @endif
+                </div>
+            </div>
+        </div>
+
+        <!-- Pending Links Table -->
+        <div class="card bg-base-200 shadow">
+            <div class="card-body">
+                <x-table
+                    :headers="$this->headers()"
+                    :rows="$this->getPendingLinks()"
+                    :sort-by="$sortBy"
+                    with-pagination
+                    per-page="perPage"
+                    :per-page-values="[10, 25, 50, 100]"
+                    selectable
+                    selectable-key="id"
+                    wire:model.live="selectedLinks"
+                    striped>
+                    <x-slot:empty>
+                        <div class="text-center py-12">
+                            <x-icon name="o-link" class="w-16 h-16 mx-auto mb-4 text-base-content/70" />
+                            <h3 class="text-lg font-medium text-base-content mb-2">No pending links</h3>
+                            <p class="text-base-content/70">
+                                @if ($search || $statusFilter !== 'pending' || $strategyFilter || $confidenceFilter)
+                                Try adjusting your filters
+                                @else
+                                All transaction links have been reviewed!
+                                @endif
+                            </p>
+                        </div>
+                    </x-slot:empty>
+
+                    @scope('cell_confidence', $link)
+                    <div class="badge {{ $this->getConfidenceBadgeClass($link->confidence) }}">
+                        {{ number_format($link->confidence, 1) }}%
+                    </div>
+                    @endscope
+
+                    @scope('cell_source', $link)
+                    <div class="flex flex-col gap-1">
+                        <a href="{{ route('events.show', $link->sourceEvent) }}" class="link link-hover text-sm font-medium">
+                            {{ $this->formatTransactionTitle($link->sourceEvent) }}
+                        </a>
+                        <div class="flex gap-2 text-xs text-base-content/70">
+                            <span>{{ $link->sourceEvent?->actor?->title ?? 'Unknown' }}</span>
+                            <span>•</span>
+                            <span>{{ $link->sourceEvent?->time?->format('M j, Y H:i') }}</span>
+                        </div>
+                    </div>
+                    @endscope
+
+                    @scope('cell_type', $link)
+                    <div class="badge badge-outline">
+                        {{ $this->getTypeDisplayName($link->relationship_type) }}
+                    </div>
+                    @endscope
+
+                    @scope('cell_target', $link)
+                    <div class="flex flex-col gap-1">
+                        <a href="{{ route('events.show', $link->targetEvent) }}" class="link link-hover text-sm font-medium">
+                            {{ $this->formatTransactionTitle($link->targetEvent) }}
+                        </a>
+                        <div class="flex gap-2 text-xs text-base-content/70">
+                            <span>{{ $link->targetEvent?->actor?->title ?? 'Unknown' }}</span>
+                            <span>•</span>
+                            <span>{{ $link->targetEvent?->time?->format('M j, Y H:i') }}</span>
+                        </div>
+                    </div>
+                    @endscope
+
+                    @scope('cell_strategy', $link)
+                    <span class="text-sm">{{ $this->formatStrategy($link->detection_strategy) }}</span>
+                    @endscope
+
+                    @scope('cell_actions', $link)
+                    @if ($link->isPending())
+                    <div class="flex gap-1">
+                        <button class="btn btn-success btn-xs" wire:click="approveLink('{{ $link->id }}')" title="Approve">
+                            <x-icon name="o-check" class="w-4 h-4" />
+                        </button>
+                        <button class="btn btn-error btn-xs" wire:click="rejectLink('{{ $link->id }}')" title="Reject">
+                            <x-icon name="o-x-mark" class="w-4 h-4" />
+                        </button>
+                    </div>
+                    @else
+                    <span class="badge badge-ghost badge-sm">
+                        {{ ucfirst(str_replace('_', ' ', $link->status)) }}
+                    </span>
+                    @endif
+                    @endscope
+                </x-table>
+            </div>
+        </div>
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -268,6 +268,7 @@ Route::middleware(['auth', 'verified'])->prefix('admin')->name('admin.')->group(
     Volt::route('objects', 'admin.objects')->name('objects.index');
     Volt::route('blocks', 'admin.blocks')->name('blocks.index');
     Volt::route('relationships', 'admin.relationships')->name('relationships.index');
+    Volt::route('pending-links', 'admin.pending-links')->name('pending-links.index');
     Volt::route('bin', 'admin.bin')->name('bin.index');
     Volt::route('sense-check', 'admin.sense-check')->name('sense-check.index');
     Volt::route('search', 'admin.search')->name('search.index');

--- a/tests/Feature/TransactionLinkingTest.php
+++ b/tests/Feature/TransactionLinkingTest.php
@@ -155,14 +155,23 @@ class TransactionLinkingTest extends TestCase
     }
 
     /** @test */
-    public function explicit_strategy_only_processes_monzo_events(): void
+    public function explicit_strategy_only_processes_monzo_events_with_metadata(): void
     {
         $strategy = new ExplicitReferenceStrategy;
 
-        $monzoEvent = $this->createMonzoEvent();
-        $otherEvent = $this->createEvent(['service' => 'other_service']);
+        $monzoEventWithMetadata = $this->createMonzoEvent([
+            'event_metadata' => ['raw' => ['some' => 'data']],
+        ]);
+        $monzoEventWithoutMetadata = $this->createMonzoEvent([
+            'event_metadata' => [],
+        ]);
+        $otherEvent = $this->createEvent([
+            'service' => 'other_service',
+            'event_metadata' => ['raw' => ['some' => 'data']],
+        ]);
 
-        $this->assertTrue($strategy->canProcess($monzoEvent));
+        $this->assertTrue($strategy->canProcess($monzoEventWithMetadata));
+        $this->assertFalse($strategy->canProcess($monzoEventWithoutMetadata));
         $this->assertFalse($strategy->canProcess($otherEvent));
     }
 

--- a/tests/Feature/TransactionLinkingTest.php
+++ b/tests/Feature/TransactionLinkingTest.php
@@ -1,0 +1,593 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Event;
+use App\Models\EventObject;
+use App\Models\Integration;
+use App\Models\PendingTransactionLink;
+use App\Models\Relationship;
+use App\Models\User;
+use App\Services\TransactionLinking\Strategies\BacsRecordStrategy;
+use App\Services\TransactionLinking\Strategies\CrossProviderStrategy;
+use App\Services\TransactionLinking\Strategies\ExplicitReferenceStrategy;
+use App\Services\TransactionLinking\TransactionLinkingService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use ReflectionClass;
+use Tests\TestCase;
+
+class TransactionLinkingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    private Integration $integration;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+        $this->integration = Integration::factory()->create(['user_id' => $this->user->id]);
+    }
+
+    // ==========================================
+    // ExplicitReferenceStrategy Tests
+    // ==========================================
+
+    /** @test */
+    public function explicit_strategy_finds_transaction_id_reference(): void
+    {
+        $strategy = new ExplicitReferenceStrategy;
+
+        // Create the target event
+        $targetEvent = $this->createMonzoEvent([
+            'source_id' => 'tx_00001234',
+            'action' => 'card_payment_to',
+            'value' => -1000,
+        ]);
+
+        // Create the referencing event (e.g., cashback)
+        $sourceEvent = $this->createMonzoEvent([
+            'action' => 'cashback_reward_from',
+            'value' => 100,
+            'event_metadata' => [
+                'raw' => [
+                    'metadata' => [
+                        'transaction_id' => 'tx_00001234',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($strategy->canProcess($sourceEvent));
+
+        $links = $strategy->findLinks($sourceEvent);
+
+        $this->assertCount(1, $links);
+        $this->assertEquals($targetEvent->id, $links->first()['target_event']->id);
+        $this->assertEquals('triggered_by', $links->first()['relationship_type']);
+        $this->assertEquals(100.0, $links->first()['confidence']);
+    }
+
+    /** @test */
+    public function explicit_strategy_finds_coin_jar_reference(): void
+    {
+        $strategy = new ExplicitReferenceStrategy;
+
+        // Create the original card payment
+        $cardPayment = $this->createMonzoEvent([
+            'source_id' => 'tx_original_payment',
+            'action' => 'card_payment_to',
+            'value' => -1299,
+        ]);
+
+        // Create the coin jar transaction referencing it
+        $coinJar = $this->createMonzoEvent([
+            'action' => 'pot_deposit_from',
+            'value' => -1,
+            'event_metadata' => [
+                'raw' => [
+                    'metadata' => [
+                        'coin_jar_transaction' => 'tx_original_payment',
+                    ],
+                ],
+            ],
+        ]);
+
+        $links = $strategy->findLinks($coinJar);
+
+        $this->assertCount(1, $links);
+        $this->assertEquals($cardPayment->id, $links->first()['target_event']->id);
+    }
+
+    /** @test */
+    public function explicit_strategy_finds_triggered_by_reference(): void
+    {
+        $strategy = new ExplicitReferenceStrategy;
+
+        // Create the triggering transaction
+        $trigger = $this->createMonzoEvent([
+            'source_id' => 'tx_trigger_event',
+            'action' => 'card_payment_to',
+            'value' => -500,
+        ]);
+
+        // Create the triggered transaction
+        $triggered = $this->createMonzoEvent([
+            'action' => 'reward_from',
+            'value' => 50,
+            'event_metadata' => [
+                'raw' => [
+                    'metadata' => [
+                        'triggered_by' => 'tx_trigger_event',
+                    ],
+                ],
+            ],
+        ]);
+
+        $links = $strategy->findLinks($triggered);
+
+        $this->assertCount(1, $links);
+        $this->assertEquals($trigger->id, $links->first()['target_event']->id);
+    }
+
+    /** @test */
+    public function explicit_strategy_ignores_non_tx_references(): void
+    {
+        $strategy = new ExplicitReferenceStrategy;
+
+        // Create event with non-tx reference (should be ignored)
+        $event = $this->createMonzoEvent([
+            'event_metadata' => [
+                'raw' => [
+                    'metadata' => [
+                        'triggered_by' => 'direct-debit', // Not a tx_ ID
+                    ],
+                ],
+            ],
+        ]);
+
+        $links = $strategy->findLinks($event);
+
+        $this->assertCount(0, $links);
+    }
+
+    /** @test */
+    public function explicit_strategy_only_processes_monzo_events(): void
+    {
+        $strategy = new ExplicitReferenceStrategy;
+
+        $monzoEvent = $this->createMonzoEvent();
+        $otherEvent = $this->createEvent(['service' => 'other_service']);
+
+        $this->assertTrue($strategy->canProcess($monzoEvent));
+        $this->assertFalse($strategy->canProcess($otherEvent));
+    }
+
+    // ==========================================
+    // BacsRecordStrategy Tests
+    // ==========================================
+
+    /** @test */
+    public function bacs_strategy_finds_pot_withdrawal_for_direct_debit(): void
+    {
+        $strategy = new BacsRecordStrategy;
+
+        // Create direct debit with bacs_record_id
+        $directDebit = $this->createMonzoEvent([
+            'action' => 'direct_debit_to',
+            'value' => -5000,
+            'event_metadata' => [
+                'raw' => [
+                    'metadata' => [
+                        'bacs_record_id' => 'bacsrcd_ABC123',
+                    ],
+                ],
+            ],
+        ]);
+
+        // Create pot withdrawal referencing the BACS record
+        $potWithdrawal = $this->createMonzoEvent([
+            'action' => 'pot_withdrawal_to',
+            'value' => 5000,
+            'event_metadata' => [
+                'raw' => [
+                    'metadata' => [
+                        'external_id' => 'dd-withdrawal:bacsrcd_ABC123#pot_XYZ#bacspaymentevent_123',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($strategy->canProcess($directDebit));
+
+        $links = $strategy->findLinks($directDebit);
+
+        $this->assertCount(1, $links);
+        $this->assertEquals($potWithdrawal->id, $links->first()['target_event']->id);
+        $this->assertEquals('funded_by', $links->first()['relationship_type']);
+        $this->assertEquals(100.0, $links->first()['confidence']);
+    }
+
+    /** @test */
+    public function bacs_strategy_finds_direct_debit_from_pot_withdrawal(): void
+    {
+        $strategy = new BacsRecordStrategy;
+
+        // Create direct debit with bacs_record_id
+        $directDebit = $this->createMonzoEvent([
+            'action' => 'direct_debit_to',
+            'value' => -5000,
+            'event_metadata' => [
+                'raw' => [
+                    'metadata' => [
+                        'bacs_record_id' => 'bacsrcd_DEF456',
+                    ],
+                ],
+            ],
+        ]);
+
+        // Create pot withdrawal referencing the BACS record
+        $potWithdrawal = $this->createMonzoEvent([
+            'action' => 'pot_withdrawal_to',
+            'value' => 5000,
+            'event_metadata' => [
+                'raw' => [
+                    'metadata' => [
+                        'external_id' => 'dd-withdrawal:bacsrcd_DEF456#pot_XYZ',
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($strategy->canProcess($potWithdrawal));
+
+        $links = $strategy->findLinks($potWithdrawal);
+
+        $this->assertCount(1, $links);
+        $this->assertEquals($directDebit->id, $links->first()['target_event']->id);
+    }
+
+    /** @test */
+    public function bacs_strategy_only_processes_monzo_with_bacs_metadata(): void
+    {
+        $strategy = new BacsRecordStrategy;
+
+        $eventWithBacs = $this->createMonzoEvent([
+            'event_metadata' => [
+                'raw' => [
+                    'metadata' => [
+                        'bacs_record_id' => 'bacsrcd_TEST',
+                    ],
+                ],
+            ],
+        ]);
+
+        $eventWithExternalId = $this->createMonzoEvent([
+            'event_metadata' => [
+                'raw' => [
+                    'metadata' => [
+                        'external_id' => 'dd-withdrawal:bacsrcd_TEST',
+                    ],
+                ],
+            ],
+        ]);
+
+        $eventWithoutBacs = $this->createMonzoEvent([
+            'event_metadata' => [
+                'raw' => [
+                    'metadata' => [],
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($strategy->canProcess($eventWithBacs));
+        $this->assertTrue($strategy->canProcess($eventWithExternalId));
+        $this->assertFalse($strategy->canProcess($eventWithoutBacs));
+    }
+
+    // ==========================================
+    // CrossProviderStrategy Tests
+    // ==========================================
+
+    /** @test */
+    public function cross_provider_strategy_identifies_credit_card_payment(): void
+    {
+        $strategy = new CrossProviderStrategy;
+
+        $amexPayment = $this->createEvent([
+            'action' => 'direct_debit_to',
+            'event_metadata' => [
+                'raw' => [
+                    'description' => 'AMERICAN EXPRESS ************4006',
+                ],
+            ],
+        ]);
+
+        $this->assertTrue($strategy->canProcess($amexPayment));
+    }
+
+    /** @test */
+    public function cross_provider_strategy_rejects_non_credit_card_payments(): void
+    {
+        $strategy = new CrossProviderStrategy;
+
+        $normalPayment = $this->createEvent([
+            'action' => 'card_payment_to',
+            'event_metadata' => [
+                'raw' => [
+                    'description' => 'Tesco Stores',
+                ],
+            ],
+        ]);
+
+        $this->assertFalse($strategy->canProcess($normalPayment));
+    }
+
+    /** @test */
+    public function cross_provider_strategy_extracts_card_identification(): void
+    {
+        $strategy = new CrossProviderStrategy;
+
+        $event = $this->createEvent([
+            'action' => 'direct_debit_to',
+            'event_metadata' => [
+                'raw' => [
+                    'description' => 'AMERICAN EXPRESS ************4006',
+                ],
+            ],
+        ]);
+
+        // Use reflection to test private method
+        $reflection = new ReflectionClass($strategy);
+        $method = $reflection->getMethod('extractCardIdentification');
+        $method->setAccessible(true);
+
+        $cardId = $method->invoke($strategy, $event);
+
+        $this->assertEquals('4006', $cardId);
+    }
+
+    // ==========================================
+    // TransactionLinkingService Tests
+    // ==========================================
+
+    /** @test */
+    public function service_creates_pending_link_for_low_confidence_match(): void
+    {
+        $service = app(TransactionLinkingService::class);
+
+        // Create events with explicit reference (100% confidence -> auto-approved)
+        $targetEvent = $this->createMonzoEvent([
+            'source_id' => 'tx_service_test',
+            'action' => 'card_payment_to',
+        ]);
+
+        $sourceEvent = $this->createMonzoEvent([
+            'action' => 'reward_from',
+            'event_metadata' => [
+                'raw' => [
+                    'metadata' => [
+                        'transaction_id' => 'tx_service_test',
+                    ],
+                ],
+            ],
+        ]);
+
+        $result = $service->processEvent($sourceEvent);
+
+        // High confidence matches should be auto-approved
+        $this->assertEquals(1, $result['auto_approved']);
+        $this->assertEquals(0, $result['pending']);
+
+        // Check relationship was created
+        $this->assertDatabaseHas('relationships', [
+            'user_id' => $this->user->id,
+            'from_type' => Event::class,
+            'from_id' => $sourceEvent->id,
+            'to_type' => Event::class,
+            'to_id' => $targetEvent->id,
+            'type' => 'triggered_by',
+        ]);
+    }
+
+    /** @test */
+    public function service_returns_stats(): void
+    {
+        $service = app(TransactionLinkingService::class);
+
+        // Create some pending links
+        PendingTransactionLink::create([
+            'user_id' => $this->user->id,
+            'source_event_id' => $this->createMonzoEvent()->id,
+            'target_event_id' => $this->createMonzoEvent()->id,
+            'relationship_type' => 'triggered_by',
+            'confidence' => 90,
+            'detection_strategy' => 'test',
+            'status' => 'pending',
+        ]);
+
+        PendingTransactionLink::create([
+            'user_id' => $this->user->id,
+            'source_event_id' => $this->createMonzoEvent()->id,
+            'target_event_id' => $this->createMonzoEvent()->id,
+            'relationship_type' => 'funded_by',
+            'confidence' => 60,
+            'detection_strategy' => 'test',
+            'status' => 'pending',
+        ]);
+
+        PendingTransactionLink::create([
+            'user_id' => $this->user->id,
+            'source_event_id' => $this->createMonzoEvent()->id,
+            'target_event_id' => $this->createMonzoEvent()->id,
+            'relationship_type' => 'payment_for',
+            'confidence' => 40,
+            'detection_strategy' => 'test',
+            'status' => 'pending',
+        ]);
+
+        $stats = $service->getPendingStats($this->user->id);
+
+        $this->assertEquals(3, $stats['total']);
+        $this->assertEquals(1, $stats['by_confidence']['high']);
+        $this->assertEquals(1, $stats['by_confidence']['medium']);
+        $this->assertEquals(1, $stats['by_confidence']['low']);
+    }
+
+    // ==========================================
+    // PendingTransactionLink Model Tests
+    // ==========================================
+
+    /** @test */
+    public function pending_link_can_be_approved(): void
+    {
+        $sourceEvent = $this->createMonzoEvent();
+        $targetEvent = $this->createMonzoEvent();
+
+        $pendingLink = PendingTransactionLink::create([
+            'user_id' => $this->user->id,
+            'source_event_id' => $sourceEvent->id,
+            'target_event_id' => $targetEvent->id,
+            'relationship_type' => 'triggered_by',
+            'confidence' => 75,
+            'detection_strategy' => 'test',
+            'status' => 'pending',
+        ]);
+
+        $this->assertTrue($pendingLink->isPending());
+
+        $pendingLink->approve();
+
+        $this->assertEquals('approved', $pendingLink->fresh()->status);
+        $this->assertNotNull($pendingLink->fresh()->approved_at);
+
+        // Check relationship was created
+        $this->assertDatabaseHas('relationships', [
+            'user_id' => $this->user->id,
+            'from_type' => Event::class,
+            'from_id' => $sourceEvent->id,
+            'to_type' => Event::class,
+            'to_id' => $targetEvent->id,
+            'type' => 'triggered_by',
+        ]);
+    }
+
+    /** @test */
+    public function pending_link_can_be_rejected(): void
+    {
+        $sourceEvent = $this->createMonzoEvent();
+        $targetEvent = $this->createMonzoEvent();
+
+        $pendingLink = PendingTransactionLink::create([
+            'user_id' => $this->user->id,
+            'source_event_id' => $sourceEvent->id,
+            'target_event_id' => $targetEvent->id,
+            'relationship_type' => 'triggered_by',
+            'confidence' => 75,
+            'detection_strategy' => 'test',
+            'status' => 'pending',
+        ]);
+
+        $pendingLink->reject();
+
+        $this->assertEquals('rejected', $pendingLink->fresh()->status);
+        $this->assertNotNull($pendingLink->fresh()->rejected_at);
+
+        // Verify no relationship was created
+        $this->assertDatabaseMissing('relationships', [
+            'from_id' => $sourceEvent->id,
+            'to_id' => $targetEvent->id,
+        ]);
+    }
+
+    /** @test */
+    public function pending_link_scopes_work_correctly(): void
+    {
+        $sourceEvent = $this->createMonzoEvent();
+        $targetEvent = $this->createMonzoEvent();
+
+        PendingTransactionLink::create([
+            'user_id' => $this->user->id,
+            'source_event_id' => $sourceEvent->id,
+            'target_event_id' => $targetEvent->id,
+            'relationship_type' => 'triggered_by',
+            'confidence' => 90,
+            'detection_strategy' => 'explicit_reference',
+            'status' => 'pending',
+        ]);
+
+        PendingTransactionLink::create([
+            'user_id' => $this->user->id,
+            'source_event_id' => $this->createMonzoEvent()->id,
+            'target_event_id' => $this->createMonzoEvent()->id,
+            'relationship_type' => 'funded_by',
+            'confidence' => 50,
+            'detection_strategy' => 'bacs_record',
+            'status' => 'approved',
+        ]);
+
+        $this->assertEquals(1, PendingTransactionLink::pending()->count());
+        $this->assertEquals(1, PendingTransactionLink::aboveConfidence(80)->count());
+        $this->assertEquals(1, PendingTransactionLink::forStrategy('explicit_reference')->count());
+    }
+
+    /** @test */
+    public function pending_link_stores_matching_criteria(): void
+    {
+        $sourceEvent = $this->createMonzoEvent();
+        $targetEvent = $this->createMonzoEvent();
+
+        $criteria = [
+            'type' => 'transaction_id',
+            'path' => 'raw.metadata.transaction_id',
+            'referenced_id' => 'tx_12345',
+        ];
+
+        $pendingLink = PendingTransactionLink::create([
+            'user_id' => $this->user->id,
+            'source_event_id' => $sourceEvent->id,
+            'target_event_id' => $targetEvent->id,
+            'relationship_type' => 'triggered_by',
+            'confidence' => 100,
+            'detection_strategy' => 'explicit_reference',
+            'matching_criteria' => $criteria,
+            'status' => 'pending',
+        ]);
+
+        $this->assertEquals($criteria, $pendingLink->matching_criteria);
+    }
+
+    // ==========================================
+    // Helper Methods
+    // ==========================================
+
+    private function createMonzoEvent(array $attributes = []): Event
+    {
+        return $this->createEvent(array_merge(['service' => 'monzo'], $attributes));
+    }
+
+    private function createEvent(array $attributes = []): Event
+    {
+        $actor = EventObject::factory()->create(['user_id' => $this->user->id]);
+        $target = EventObject::factory()->create(['user_id' => $this->user->id]);
+
+        return Event::create(array_merge([
+            'id' => fake()->uuid(),
+            'source_id' => fake()->uuid(),
+            'time' => now(),
+            'integration_id' => $this->integration->id,
+            'actor_id' => $actor->id,
+            'target_id' => $target->id,
+            'service' => 'test',
+            'domain' => 'money',
+            'action' => 'test_action',
+            'value' => 0,
+            'value_multiplier' => 100,
+            'value_unit' => 'GBP',
+            'event_metadata' => [],
+        ], $attributes));
+    }
+}

--- a/tests/Feature/TransactionLinkingTest.php
+++ b/tests/Feature/TransactionLinkingTest.php
@@ -364,7 +364,7 @@ class TransactionLinkingTest extends TestCase
     // ==========================================
 
     /** @test */
-    public function service_creates_pending_link_for_low_confidence_match(): void
+    public function service_auto_approves_high_confidence_links(): void
     {
         $service = app(TransactionLinkingService::class);
 
@@ -387,8 +387,8 @@ class TransactionLinkingTest extends TestCase
 
         $result = $service->processEvent($sourceEvent);
 
-        // High confidence matches should be auto-approved
-        $this->assertEquals(1, $result['auto_approved']);
+        // High confidence matches should be auto-approved (created)
+        $this->assertEquals(1, $result['created']);
         $this->assertEquals(0, $result['pending']);
 
         // Check relationship was created
@@ -415,6 +415,7 @@ class TransactionLinkingTest extends TestCase
             'relationship_type' => 'triggered_by',
             'confidence' => 90,
             'detection_strategy' => 'test',
+            'matching_criteria' => ['type' => 'test'],
             'status' => 'pending',
         ]);
 
@@ -425,6 +426,7 @@ class TransactionLinkingTest extends TestCase
             'relationship_type' => 'funded_by',
             'confidence' => 60,
             'detection_strategy' => 'test',
+            'matching_criteria' => ['type' => 'test'],
             'status' => 'pending',
         ]);
 
@@ -435,6 +437,7 @@ class TransactionLinkingTest extends TestCase
             'relationship_type' => 'payment_for',
             'confidence' => 40,
             'detection_strategy' => 'test',
+            'matching_criteria' => ['type' => 'test'],
             'status' => 'pending',
         ]);
 
@@ -463,6 +466,7 @@ class TransactionLinkingTest extends TestCase
             'relationship_type' => 'triggered_by',
             'confidence' => 75,
             'detection_strategy' => 'test',
+            'matching_criteria' => ['type' => 'test'],
             'status' => 'pending',
         ]);
 
@@ -471,7 +475,7 @@ class TransactionLinkingTest extends TestCase
         $pendingLink->approve();
 
         $this->assertEquals('approved', $pendingLink->fresh()->status);
-        $this->assertNotNull($pendingLink->fresh()->approved_at);
+        $this->assertNotNull($pendingLink->fresh()->reviewed_at);
 
         // Check relationship was created
         $this->assertDatabaseHas('relationships', [
@@ -497,13 +501,14 @@ class TransactionLinkingTest extends TestCase
             'relationship_type' => 'triggered_by',
             'confidence' => 75,
             'detection_strategy' => 'test',
+            'matching_criteria' => ['type' => 'test'],
             'status' => 'pending',
         ]);
 
         $pendingLink->reject();
 
         $this->assertEquals('rejected', $pendingLink->fresh()->status);
-        $this->assertNotNull($pendingLink->fresh()->rejected_at);
+        $this->assertNotNull($pendingLink->fresh()->reviewed_at);
 
         // Verify no relationship was created
         $this->assertDatabaseMissing('relationships', [
@@ -525,6 +530,7 @@ class TransactionLinkingTest extends TestCase
             'relationship_type' => 'triggered_by',
             'confidence' => 90,
             'detection_strategy' => 'explicit_reference',
+            'matching_criteria' => ['type' => 'test'],
             'status' => 'pending',
         ]);
 
@@ -535,6 +541,7 @@ class TransactionLinkingTest extends TestCase
             'relationship_type' => 'funded_by',
             'confidence' => 50,
             'detection_strategy' => 'bacs_record',
+            'matching_criteria' => ['type' => 'test'],
             'status' => 'approved',
         ]);
 


### PR DESCRIPTION
Implements a strategy-based system for detecting and linking related transactions:

- Add new relationship types (triggered_by, funded_by, payment_for, settles)
- Create PendingTransactionLink model and migration for review workflow
- Implement 3 detection strategies:
  - ExplicitReferenceStrategy: transaction_id, triggered_by, coin_jar refs
  - BacsRecordStrategy: BACS record ID matching for pot withdrawals
  - CrossProviderStrategy: Cross-provider payment matching
- Add TransactionLinkingService to orchestrate detection
- Add LinkTransactionsJob for async processing
- Add transactions:link command for batch processing
- Build admin UI at /admin/pending-links for manual review
- Add comprehensive tests for strategies and service