### PR TITLE
🐛 Fix SNS notification parsing for Receipt webhook

### DIFF
--- a/app/Integrations/Receipt/ReceiptPlugin.php
+++ b/app/Integrations/Receipt/ReceiptPlugin.php
@@ -6,6 +6,7 @@ use App\Integrations\Base\WebhookPlugin;
 use App\Jobs\Data\Receipt\ProcessReceiptEmailJob;
 use App\Models\Integration;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 
 class ReceiptPlugin extends WebhookPlugin
@@ -160,7 +161,21 @@ class ReceiptPlugin extends WebhookPlugin
      */
     private function parseSnsNotification(Request $request): ?array
     {
-        $payload = $request->all();
+        // AWS SNS sends content as text/plain, so we need to parse the raw body
+        $rawBody = $request->getContent();
+        $payload = json_decode($rawBody, true);
+
+        // Fall back to request->all() if raw body isn't valid JSON
+        if (! $payload) {
+            $payload = $request->all();
+        }
+
+        Log::debug('Receipt: Parsing SNS notification', [
+            'content_type' => $request->header('Content-Type'),
+            'has_type' => isset($payload['Type']),
+            'type' => $payload['Type'] ?? null,
+            'has_message' => isset($payload['Message']),
+        ]);
 
         // Check if this is an SNS subscription confirmation
         if (isset($payload['Type']) && $payload['Type'] === 'SubscriptionConfirmation') {
@@ -168,18 +183,47 @@ class ReceiptPlugin extends WebhookPlugin
                 'subscribe_url' => $payload['SubscribeURL'] ?? null,
             ]);
 
-            // This should be handled by the route, not here
+            // Auto-confirm the subscription by hitting the SubscribeURL
+            if (isset($payload['SubscribeURL'])) {
+                try {
+                    Http::get($payload['SubscribeURL']);
+                    Log::info('Receipt: SNS subscription confirmed');
+                } catch (\Throwable $e) {
+                    Log::error('Receipt: Failed to confirm SNS subscription', [
+                        'error' => $e->getMessage(),
+                    ]);
+                }
+            }
+
             return null;
         }
 
-        // Extract the Message field (SES notification is JSON inside this)
-        if (! isset($payload['Message'])) {
-            return null;
+        // Handle SNS Notification type
+        if (isset($payload['Type']) && $payload['Type'] === 'Notification') {
+            // Extract the Message field (SES notification is JSON inside this)
+            if (! isset($payload['Message'])) {
+                Log::warning('Receipt: SNS Notification missing Message field', [
+                    'payload_keys' => array_keys($payload),
+                ]);
+
+                return null;
+            }
+
+            $message = json_decode($payload['Message'], true);
+
+            return $message ?: null;
         }
 
-        $message = json_decode($payload['Message'], true);
+        // If no Type field, maybe the payload IS the message (direct SES notification)
+        if (isset($payload['receipt']) || isset($payload['mail'])) {
+            return $payload;
+        }
 
-        return $message ?: null;
+        Log::warning('Receipt: Unrecognized SNS payload format', [
+            'payload_keys' => array_keys($payload),
+        ]);
+
+        return null;
     }
 
     /**

--- a/app/Integrations/Receipt/ReceiptPlugin.php
+++ b/app/Integrations/Receipt/ReceiptPlugin.php
@@ -8,6 +8,7 @@ use App\Models\Integration;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use Throwable;
 
 class ReceiptPlugin extends WebhookPlugin
 {
@@ -188,7 +189,7 @@ class ReceiptPlugin extends WebhookPlugin
                 try {
                     Http::get($payload['SubscribeURL']);
                     Log::info('Receipt: SNS subscription confirmed');
-                } catch (\Throwable $e) {
+                } catch (Throwable $e) {
                     Log::error('Receipt: Failed to confirm SNS subscription', [
                         'error' => $e->getMessage(),
                     ]);


### PR DESCRIPTION
- Parse raw request body since AWS SNS sends text/plain content
- Add debug logging for SNS payload inspection
- Auto-confirm SNS subscription confirmations
- Handle both SNS Notification type and direct SES notifications
- Add better error messages for unrecognized payload formats