### PR TITLE
🐛 Support SNS action type with inline email content

### DIFF
--- a/app/Integrations/Receipt/ReceiptPlugin.php
+++ b/app/Integrations/Receipt/ReceiptPlugin.php
@@ -131,17 +131,39 @@ class ReceiptPlugin extends WebhookPlugin
             abort(400, 'Invalid SNS notification');
         }
 
-        // Extract S3 object key from SES notification
+        // Check if email content is included directly (SNS action type)
+        if (isset($snsMessage['content'])) {
+            $emailContent = $snsMessage['content'];
+
+            // Check encoding - SES can send base64 encoded content
+            $encoding = $snsMessage['receipt']['action']['encoding'] ?? null;
+            if ($encoding === 'BASE64') {
+                $emailContent = base64_decode($emailContent);
+            }
+
+            Log::info('Receipt: Processing email from SNS content', [
+                'integration_id' => $integration->id,
+                'content_length' => strlen($emailContent),
+                'encoding' => $encoding,
+            ]);
+
+            // Dispatch job with the raw email content
+            ProcessReceiptEmailJob::dispatch($integration, null, $emailContent);
+
+            return;
+        }
+
+        // Fall back to S3 object key extraction
         $s3ObjectKey = $this->extractS3ObjectKey($snsMessage);
 
         if (! $s3ObjectKey) {
-            Log::warning('Receipt: No S3 object key found in SNS notification', [
+            Log::warning('Receipt: No S3 object key or content found in SNS notification', [
                 'integration_id' => $integration->id,
             ]);
-            abort(400, 'No S3 object key in notification');
+            abort(400, 'No S3 object key or content in notification');
         }
 
-        // Dispatch job to process receipt email
+        // Dispatch job to process receipt email from S3
         ProcessReceiptEmailJob::dispatch($integration, $s3ObjectKey);
 
         Log::info('Receipt: Email processing job dispatched', [

--- a/app/Jobs/Data/Receipt/ProcessReceiptEmailJob.php
+++ b/app/Jobs/Data/Receipt/ProcessReceiptEmailJob.php
@@ -33,19 +33,27 @@ class ProcessReceiptEmailJob implements ShouldQueue
 
     public function __construct(
         public Integration $integration,
-        public string $s3ObjectKey
+        public ?string $s3ObjectKey = null,
+        public ?string $rawEmailContent = null
     ) {}
 
     public function handle(): void
     {
-        Log::info('Receipt: Processing receipt email from S3', [
+        Log::info('Receipt: Processing receipt email', [
             'integration_id' => $this->integration->id,
             's3_object_key' => $this->s3ObjectKey,
+            'has_raw_content' => ! empty($this->rawEmailContent),
         ]);
 
         try {
-            // Download email from S3
-            $emailContent = $this->downloadEmailFromS3($this->s3ObjectKey);
+            // Get email content - either from raw content or S3
+            if (! empty($this->rawEmailContent)) {
+                $emailContent = $this->rawEmailContent;
+            } elseif (! empty($this->s3ObjectKey)) {
+                $emailContent = $this->downloadEmailFromS3($this->s3ObjectKey);
+            } else {
+                throw new Exception('No email content or S3 key provided');
+            }
 
             // Parse email to extract text
             $parsedEmail = $this->parseEmail($emailContent);
@@ -82,7 +90,11 @@ class ProcessReceiptEmailJob implements ShouldQueue
 
     public function uniqueId(): string
     {
-        return 'process_receipt_email_' . $this->integration->id . '_' . md5($this->s3ObjectKey);
+        $contentHash = $this->s3ObjectKey
+            ? md5($this->s3ObjectKey)
+            : md5($this->rawEmailContent ?? '');
+
+        return 'process_receipt_email_' . $this->integration->id . '_' . $contentHash;
     }
 
     /**


### PR DESCRIPTION
SES can be configured to use SNS action (with inline content) instead of S3 action. This update handles both cases:
- If 'content' field exists in notification, process it directly
- Handles BASE64 encoding if specified
- Falls back to S3 object key extraction if no content
- Updated ProcessReceiptEmailJob to accept raw content as alternative to S3 key