### PR TITLE
Improve Google Calendar multi-calendar support UX

### DIFF
--- a/resources/views/livewire/integrations/index.blade.php
+++ b/resources/views/livewire/integrations/index.blade.php
@@ -464,6 +464,19 @@ new class extends Component {
                                 {{ __('Add Another') }}
                             </button>
                         </form>
+                        @elseif ($plugin['identifier'] === 'google-calendar')
+                        <!-- Google Calendar: Direct to onboarding to add another calendar -->
+                        <a href="{{ route('integrations.onboarding', ['group' => $group['id']]) }}"
+                            class="btn btn-outline btn-sm w-full">
+                            <x-icon name="fas.plus" class="w-4 h-4" />
+                            {{ __('Add Another Calendar') }}
+                        </a>
+                        <!-- Re-authenticate option for Google Calendar -->
+                        <a href="{{ route('integrations.oauth', $plugin['identifier']) }}"
+                            class="btn btn-ghost btn-sm w-full text-xs">
+                            <x-icon name="fas.rotate" class="w-3 h-3" />
+                            {{ __('Re-authenticate') }}
+                        </a>
                         @else
                         <a href="{{ route('integrations.oauth', $plugin['identifier']) }}"
                             class="btn btn-outline btn-sm w-full">

--- a/resources/views/livewire/integrations/onboarding.blade.php
+++ b/resources/views/livewire/integrations/onboarding.blade.php
@@ -16,6 +16,16 @@ use Carbon\Carbon;
                     </div>
                 </div>
 
+                <!-- Show info when adding additional instances to existing group -->
+                @if ($group->integrations->count() > 0 && $group->service === 'google-calendar')
+                <div class="alert alert-info mb-6">
+                    <x-icon name="fas.info-circle" class="w-5 h-5" />
+                    <span>
+                        {{ __('You already have :count calendar(s) connected. Select another calendar below to add to your account.', ['count' => $group->integrations->count()]) }}
+                    </span>
+                </div>
+                @endif
+
                 <form method="POST" action="{{ route('integrations.storeInstances', ['group' => $group->id]) }}" class="space-y-6">
                     @csrf
 


### PR DESCRIPTION
This update streamlines the process of adding multiple calendars from the same Google account by eliminating unnecessary re-authentication.

Changes:
- Add direct onboarding link for Google Calendar "Add Another Calendar" button
- Bypass OAuth flow when adding additional calendars to existing account
- Add "Re-authenticate" option as secondary button for token refresh
- Display helpful context message when adding additional calendars

Previously, users had to go through the full OAuth flow again to add a second calendar, which would detect the duplicate account and merge groups. Now, users can directly access the onboarding page to select additional calendars without re-authenticating.

This maintains the existing two-tier architecture (IntegrationGroup for account credentials + Integration for calendar instances) while providing a more intuitive user experience.