### PR TITLE
:bug: Handle expired Google Calendar tokens gracefully

### DIFF
--- a/app/Http/Controllers/IntegrationController.php
+++ b/app/Http/Controllers/IntegrationController.php
@@ -409,7 +409,7 @@ class IntegrationController extends Controller
             if (method_exists($plugin, 'fetchAvailableCalendars')) {
                 try {
                     $availableCalendars = $plugin->fetchAvailableCalendars($group);
-                } catch (\Exception $e) {
+                } catch (Exception $e) {
                     // Token refresh failed - user needs to re-authenticate
                     Log::warning('Failed to fetch calendars, redirecting to OAuth', [
                         'group_id' => $group->id,

--- a/app/Http/Controllers/IntegrationController.php
+++ b/app/Http/Controllers/IntegrationController.php
@@ -407,7 +407,18 @@ class IntegrationController extends Controller
         if ($group->service === 'google-calendar' && $pluginClass) {
             $plugin = new $pluginClass;
             if (method_exists($plugin, 'fetchAvailableCalendars')) {
-                $availableCalendars = $plugin->fetchAvailableCalendars($group);
+                try {
+                    $availableCalendars = $plugin->fetchAvailableCalendars($group);
+                } catch (\Exception $e) {
+                    // Token refresh failed - user needs to re-authenticate
+                    Log::warning('Failed to fetch calendars, redirecting to OAuth', [
+                        'group_id' => $group->id,
+                        'error' => $e->getMessage(),
+                    ]);
+
+                    return redirect()->route('integrations.oauth', ['service' => 'google-calendar'])
+                        ->with('error', 'Your Google Calendar connection has expired. Please reconnect to add more calendars.');
+                }
             }
         }
 


### PR DESCRIPTION
Add exception handling when fetching available calendars during onboarding. If token refresh fails (e.g., refresh token expired or invalid), the user is now redirected to re-authenticate with a clear error message instead of seeing a crash page.

This fixes the "Failed to refresh access token" exception that occurs when users try to add another calendar but their tokens have expired.

Flow when tokens are expired:
1. User clicks "Add Another Calendar"
2. System tries to fetch calendar list
3. Token refresh fails
4. User redirected to OAuth with helpful message
5. After re-auth, tokens updated via duplicate group merge
6. User redirected back to onboarding with fresh tokens