### PR TITLE
Fix Google Calendar OAuth redirect loop

### DIFF
--- a/app/Http/Controllers/IntegrationController.php
+++ b/app/Http/Controllers/IntegrationController.php
@@ -407,17 +407,11 @@ class IntegrationController extends Controller
         if ($group->service === 'google-calendar' && $pluginClass) {
             $plugin = new $pluginClass;
             if (method_exists($plugin, 'fetchAvailableCalendars')) {
-                try {
-                    $availableCalendars = $plugin->fetchAvailableCalendars($group);
-                } catch (Exception $e) {
-                    // Token refresh failed - user needs to re-authenticate
-                    Log::warning('Failed to fetch calendars, redirecting to OAuth', [
-                        'group_id' => $group->id,
-                        'error' => $e->getMessage(),
-                    ]);
+                $availableCalendars = $plugin->fetchAvailableCalendars($group);
 
-                    return redirect()->route('integrations.oauth', ['service' => 'google-calendar'])
-                        ->with('error', 'Your Google Calendar connection has expired. Please reconnect to add more calendars.');
+                // If we got no calendars and the token seems invalid, show a warning
+                if (empty($availableCalendars) && (! $group->access_token || ($group->expiry && $group->expiry->isPast() && ! $group->refresh_token))) {
+                    session()->flash('warning', 'Unable to fetch your calendars. Your connection may have expired. Try re-authenticating if the problem persists.');
                 }
             }
         }

--- a/resources/views/livewire/integrations/onboarding.blade.php
+++ b/resources/views/livewire/integrations/onboarding.blade.php
@@ -306,8 +306,9 @@ use Carbon\Carbon;
                                               @error('config.'.$typeKey.'.'.$field)
                                                   <div class="text-xs text-error mt-1">{{ $message }}</div>
                                               @enderror
-                                        @elseif ($group->service === 'google-calendar' && $field === 'calendar_id' && !empty($availableCalendars))
+                                        @elseif ($group->service === 'google-calendar' && $field === 'calendar_id')
                                               <!-- Special handling for Google Calendar dropdown -->
+                                              @if (!empty($availableCalendars))
                                               <select name="config[{{ $typeKey }}][{{ $field }}]" class="select select-bordered w-full" id="calendar-id-select" data-type-key="{{ $typeKey }}">
                                                   <option value="">{{ __('Select a calendar...') }}</option>
                                                   @foreach ($availableCalendars as $calendar)
@@ -316,6 +317,20 @@ use Carbon\Carbon;
                                                       </option>
                                                   @endforeach
                                               </select>
+                                              @else
+                                              <!-- No calendars available - show message and re-auth option -->
+                                              <div class="alert alert-warning">
+                                                  <x-icon name="fas.exclamation-triangle" class="w-5 h-5" />
+                                                  <div class="flex-1">
+                                                      <p class="font-medium">{{ __('Unable to load your calendars') }}</p>
+                                                      <p class="text-sm">{{ __('Your Google Calendar connection may have expired or there was an issue fetching your calendars.') }}</p>
+                                                  </div>
+                                              </div>
+                                              <a href="{{ route('integrations.oauth', ['service' => 'google-calendar']) }}" class="btn btn-primary btn-sm mt-2">
+                                                  <x-icon name="fas.rotate" class="w-4 h-4" />
+                                                  {{ __('Re-authenticate with Google') }}
+                                              </a>
+                                              @endif
                                               @error('config.'.$typeKey.'.'.$field)
                                                   <div class="text-xs text-error mt-1">{{ $message }}</div>
                                               @enderror


### PR DESCRIPTION
This commit fixes the infinite redirect loop where users were being sent to OAuth every time they tried to add another calendar, then redirected back to the integrations page instead of onboarding.

Root cause:
- Overly aggressive exception handling was catching ANY error during calendar fetching and redirecting to OAuth
- This created a loop: click "Add Another" → exception → OAuth → back to integrations page → repeat

Solution:
1. Removed the try/catch that was forcing OAuth redirects
2. Allow fetchAvailableCalendars() to return empty array on failure
3. Show helpful warning message on onboarding page when no calendars load
4. Provide explicit "Re-authenticate" button only when needed
5. No automatic redirects - user stays on onboarding page

New flow:
- User clicks "Add Another Calendar" → Goes to onboarding
- If calendars load: User selects calendar → Creates instance ✅
- If calendars don't load: Warning shown with re-auth button → User chooses to re-auth or cancel

This prevents the loop and gives users control over when to re-authenticate.