### PR TITLE
✨ Reference Cards! Bug fixes! Book blocks!

### DIFF
--- a/app/Models/Integration.php
+++ b/app/Models/Integration.php
@@ -206,7 +206,9 @@ class Integration extends Model
     }
 
     /**
-     * Check if this integration is stale (for webhook/manual integrations)
+     * Check if this integration is stale or overdue
+     * - For webhook/manual integrations: checks if no events received within configured time
+     * - For OAuth integrations: checks if overdue for scheduled update
      */
     public function isStale(): bool
     {
@@ -216,18 +218,26 @@ class Integration extends Model
         }
 
         $timeUntilStaleMinutes = $pluginClass::getTimeUntilStaleMinutes();
-        if ($timeUntilStaleMinutes === null) {
-            return false; // Staleness checking disabled for this plugin
+
+        // For webhook/manual integrations, check event staleness
+        if ($timeUntilStaleMinutes !== null) {
+            $lastEventTime = $this->getLastEventTime();
+            if (! $lastEventTime) {
+                return true; // No events yet, consider stale
+            }
+
+            $staleThreshold = Carbon::now()->subMinutes($timeUntilStaleMinutes);
+
+            return $lastEventTime->lessThan($staleThreshold);
         }
 
-        $lastEventTime = $this->getLastEventTime();
-        if (! $lastEventTime) {
-            return true; // No events yet, consider stale
+        // For OAuth integrations, check if overdue for update
+        // An integration is overdue if it's due for an update but not currently processing
+        if ($this->isPaused() || $this->isProcessing()) {
+            return false;
         }
 
-        $staleThreshold = Carbon::now()->subMinutes($timeUntilStaleMinutes);
-
-        return $lastEventTime->lessThan($staleThreshold);
+        return $this->isDue();
     }
 
     /**

--- a/resources/views/blocks/types/book.blade.php
+++ b/resources/views/blocks/types/book.blade.php
@@ -107,7 +107,7 @@ $shelfDisplay = $currentShelf ? ucfirst(str_replace('-', ' ', $currentShelf)) : 
                 @if ($seriesName)
                 <div class="text-xs text-base-content/60 flex items-center gap-1">
                     <x-icon name="fas.layer-group" class="w-3 h-3" />
-                    {{ $seriesName }}@if($seriesNumber) #{{ $seriesNumber }}@endif
+                    {{ $seriesName }}@if ($seriesNumber) #{{ $seriesNumber }}@endif
                 </div>
                 @endif
 
@@ -153,7 +153,7 @@ $shelfDisplay = $currentShelf ? ucfirst(str_replace('-', ' ', $currentShelf)) : 
                         <progress class="progress progress-{{ $accentColor }} w-full h-2" value="{{ $currentProgress }}" max="100"></progress>
                     </div>
                 @elseif ($currentShelf === 'to-read')
-                    
+
                 @elseif ($currentShelf === 'read' && $dateRead)
                     {{-- Read Badge with Date --}}
                     <div class="badge badge-sm badge-outline badge-{{ $accentColor }} gap-1">

--- a/resources/views/blocks/types/book.blade.php
+++ b/resources/views/blocks/types/book.blade.php
@@ -1,0 +1,215 @@
+@props(['block'])
+
+@php
+use App\Integrations\PluginRegistry;
+
+$pluginClass = PluginRegistry::getPlugin($block->event->service);
+$icon = $pluginClass ? $pluginClass::getIcon() : 'fas.book';
+$displayName = $pluginClass ? $pluginClass::getDisplayName() : 'Goodreads';
+$accentColor = $pluginClass ? $pluginClass::getAccentColor() : 'warning';
+
+// Get book information from the target EventObject
+$book = $block->event->target;
+$bookTitle = $book->title ?? $block->title ?? 'Unknown Book';
+$bookUrl = $book->url ?? null;
+
+// Get metadata from both block and target object
+$metadata = array_merge($block->metadata ?? [], $book->metadata ?? []);
+$authorName = $metadata['author'] ?? null;
+$authorUrl = $metadata['author_url'] ?? null;
+$numPages = $metadata['num_pages'] ?? null;
+$publishedYear = $metadata['published_year'] ?? null;
+$isbn = $metadata['isbn'] ?? null;
+$averageRating = $metadata['average_rating'] ?? null;
+$userRating = $metadata['user_rating'] ?? null;
+$seriesName = $metadata['series_name'] ?? null;
+$seriesNumber = $metadata['series_number'] ?? null;
+$dateRead = $metadata['date_read'] ?? null;
+$currentShelf = $metadata['current_shelf'] ?? null;
+$currentProgress = $metadata['current_progress'] ?? null;
+
+// If book has been read (date_read is set), treat as 100% progress
+if ($dateRead && ($currentProgress === null || $currentProgress < 100)) {
+    $currentProgress = 100;
+}
+
+// Get action display name
+$actionTypes = $pluginClass ? $pluginClass::getActionTypes() : [];
+$actionType = $actionTypes[$block->event->action] ?? null;
+$actionDisplayName = $actionType['display_name'] ?? ucfirst(str_replace('_', ' ', $block->event->action));
+$actionIcon = $actionType['icon'] ?? 'fas.book';
+
+// Use Media Library for cover image
+$imageUrl = get_media_url($block, 'downloaded_images');
+$hasImage = $block->getFirstMedia('downloaded_images') !== null;
+
+// Format shelf name
+$shelfDisplay = $currentShelf ? ucfirst(str_replace('-', ' ', $currentShelf)) : null;
+@endphp
+
+<div class="card bg-base-200 shadow hover:shadow-lg transition-all">
+    <div class="card-body p-4 gap-3">
+        {{-- Header: Action and Date --}}
+        <div class="flex items-center justify-between gap-2">
+            <div class="badge badge-{{ $accentColor }} badge-outline badge-sm gap-1">
+                <x-icon name="{{ $actionIcon }}" class="w-3 h-3" />
+                {{ $actionDisplayName }}
+            </div>
+            <x-uk-date :date="$block->time" :show-time="true" class="text-xs flex-shrink-0" />
+        </div>
+
+        {{-- Book Cover and Info Layout --}}
+        <div class="flex gap-4">
+            {{-- Book Cover --}}
+            <div class="flex-shrink-0 w-24">
+                @if ($hasImage)
+                <div class="w-full aspect-[2/3] rounded-lg overflow-hidden bg-base-300 shadow-md">
+                    {!! render_media_responsive($block, 'downloaded_images', [
+                        'alt' => $bookTitle,
+                        'class' => 'w-full h-full object-cover',
+                        'loading' => 'lazy',
+                    ]) !!}
+                </div>
+                @else
+                <div class="w-full aspect-[2/3] rounded-lg overflow-hidden bg-base-300 flex items-center justify-center">
+                    <x-icon name="fas.book" class="w-8 h-8 text-base-content/30" />
+                </div>
+                @endif
+            </div>
+
+            {{-- Book Details --}}
+            <div class="flex-1 min-w-0 space-y-2">
+                {{-- Title --}}
+                <h3 class="font-semibold text-base leading-tight line-clamp-2">
+                    @if ($bookUrl)
+                        <a href="{{ $bookUrl }}" target="_blank" rel="noopener noreferrer" class="hover:underline">
+                            {{ $bookTitle }}
+                        </a>
+                    @else
+                        {{ $bookTitle }}
+                    @endif
+                </h3>
+
+                {{-- Author --}}
+                @if ($authorName)
+                <div class="text-sm text-base-content/70">
+                    @if ($authorUrl)
+                        <a href="{{ $authorUrl }}" target="_blank" rel="noopener noreferrer" class="hover:underline">
+                            {{ $authorName }}
+                        </a>
+                    @else
+                        {{ $authorName }}
+                    @endif
+                </div>
+                @endif
+
+                {{-- Series Info --}}
+                @if ($seriesName)
+                <div class="text-xs text-base-content/60 flex items-center gap-1">
+                    <x-icon name="fas.layer-group" class="w-3 h-3" />
+                    {{ $seriesName }}@if($seriesNumber) #{{ $seriesNumber }}@endif
+                </div>
+                @endif
+
+                {{-- Metadata Grid --}}
+                <div class="grid grid-cols-2 gap-2 text-xs">
+                    @if ($publishedYear)
+                    <div class="flex items-center gap-1 text-base-content/70">
+                        <x-icon name="fas.calendar" class="w-3 h-3" />
+                        {{ $publishedYear }}
+                    </div>
+                    @endif
+
+                    @if ($numPages)
+                    <div class="flex items-center gap-1 text-base-content/70">
+                        <x-icon name="fas.file-lines" class="w-3 h-3" />
+                        {{ number_format($numPages) }} pages
+                    </div>
+                    @endif
+
+                    @if ($userRating)
+                    <div class="flex items-center gap-1 text-base-content/70">
+                        <x-icon name="fas.star" class="w-3 h-3" />
+                        You: {{ number_format($userRating, 1) }}
+                    </div>
+                    @endif
+
+                    @if ($averageRating)
+                    <div class="flex items-center gap-1 text-base-content/70">
+                        <x-icon name="fas.star-half-stroke" class="w-3 h-3" />
+                        Avg: {{ number_format($averageRating, 2) }}
+                    </div>
+                    @endif
+                </div>
+
+                {{-- Reading Status / Progress --}}
+                @if ($currentProgress !== null && $currentProgress < 100)
+                    {{-- Progress Bar (for currently reading) --}}
+                    <div class="space-y-1">
+                        <div class="flex items-center justify-between text-xs text-base-content/60">
+                            <span>Reading Progress</span>
+                            <span>{{ $currentProgress }}%</span>
+                        </div>
+                        <progress class="progress progress-{{ $accentColor }} w-full h-2" value="{{ $currentProgress }}" max="100"></progress>
+                    </div>
+                @elseif ($currentShelf === 'to-read')
+                    
+                @elseif ($currentShelf === 'read' && $dateRead)
+                    {{-- Read Badge with Date --}}
+                    <div class="badge badge-sm badge-outline badge-{{ $accentColor }} gap-1">
+                        <x-icon name="fas.book-bookmark" class="w-3 h-3" />
+                        Read <x-uk-date :date="\Carbon\Carbon::parse($dateRead)" :show-time="false" class="ml-1" />
+                    </div>
+                @endif
+            </div>
+        </div>
+
+        {{-- Footer --}}
+        <div class="flex items-center gap-2 pt-2 border-t border-base-300">
+            <div class="badge badge-ghost badge-sm gap-1">
+                <x-icon name="{{ $icon }}" class="w-3 h-3" />
+                {{ $displayName }}
+            </div>
+
+            <div class="flex-1"></div>
+
+            <div class="dropdown dropdown-end">
+                <div tabindex="0" role="button" class="btn btn-ghost btn-xs btn-square">
+                    <x-icon name="fas.ellipsis-vertical" class="w-4 h-4" />
+                </div>
+                <ul tabindex="0" class="dropdown-content menu bg-base-100 rounded-box z-[1] w-52 p-2 shadow-lg border border-base-300">
+                    <li>
+                        <a href="{{ route('blocks.show', $block) }}" wire:navigate>
+                            <x-icon name="fas.eye" class="w-4 h-4" />
+                            View Block
+                        </a>
+                    </li>
+                    @if ($bookUrl)
+                    <li>
+                        <a href="{{ $bookUrl }}" target="_blank" rel="noopener noreferrer">
+                            <x-icon name="o-arrow-top-right-on-square" class="w-4 h-4" />
+                            Open in Goodreads
+                        </a>
+                    </li>
+                    @endif
+                    @if ($authorUrl)
+                    <li>
+                        <a href="{{ $authorUrl }}" target="_blank" rel="noopener noreferrer">
+                            <x-icon name="fas.pen-nib" class="w-4 h-4" />
+                            View Author
+                        </a>
+                    </li>
+                    @endif
+                    @if ($imageUrl)
+                    <li>
+                        <a href="{{ $imageUrl }}" target="_blank" rel="noopener noreferrer">
+                            <x-icon name="fas.image" class="w-4 h-4" />
+                            View Cover Image
+                        </a>
+                    </li>
+                    @endif
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>

--- a/resources/views/components/action-ref.blade.php
+++ b/resources/views/components/action-ref.blade.php
@@ -44,11 +44,15 @@ $popoverId = 'action-ref-' . md5($service . '-' . $action);
         open: false,
         showTimeout: null,
         hideTimeout: null,
+        popoverId: '{{ $popoverId }}',
         isMobile: window.innerWidth < 768,
         show() {
             if (this.isMobile) return;
             clearTimeout(this.hideTimeout);
-            this.showTimeout = setTimeout(() => { this.open = true; }, 200);
+            this.showTimeout = setTimeout(() => {
+                window.dispatchEvent(new CustomEvent('popover-opening', { detail: this.popoverId }));
+                this.open = true;
+            }, 200);
         },
         hide() {
             clearTimeout(this.showTimeout);
@@ -59,7 +63,14 @@ $popoverId = 'action-ref-' . md5($service . '-' . $action);
         },
         toggle() {
             if (this.isMobile) {
+                window.dispatchEvent(new CustomEvent('popover-opening', { detail: this.popoverId }));
                 this.open = !this.open;
+            }
+        },
+        closeIfNotMe(event) {
+            if (event.detail !== this.popoverId) {
+                clearTimeout(this.showTimeout);
+                this.open = false;
             }
         }
     }"
@@ -67,6 +78,7 @@ $popoverId = 'action-ref-' . md5($service . '-' . $action);
     @mouseleave="hide()"
     @click="toggle()"
     @keydown.escape="open = false"
+    @popover-opening.window="closeIfNotMe($event)"
     class="relative inline-block"
 >
     {{-- Trigger: Badge variant (default) --}}

--- a/resources/views/components/action-ref.blade.php
+++ b/resources/views/components/action-ref.blade.php
@@ -1,0 +1,216 @@
+@props(['action', 'service', 'variant' => 'badge', 'href' => null, 'showService' => false])
+
+@php
+use App\Integrations\PluginRegistry;
+
+// Handle null/empty action gracefully
+if (!$action || !$service) {
+    return;
+}
+
+// Get plugin info
+$pluginClass = PluginRegistry::getPlugin($service);
+$serviceIcon = $pluginClass ? $pluginClass::getIcon() : 'fas.bolt';
+$serviceName = $pluginClass ? $pluginClass::getDisplayName() : ucfirst($service);
+$accentColor = $pluginClass ? $pluginClass::getAccentColor() : 'primary';
+$domain = $pluginClass ? $pluginClass::getDomain() : 'knowledge';
+
+// Get action type info from plugin
+$actionTypes = $pluginClass ? $pluginClass::getActionTypes() : [];
+$actionInfo = $actionTypes[$action] ?? null;
+$actionIcon = $actionInfo['icon'] ?? $serviceIcon;
+$actionDisplay = $actionInfo['display_name'] ?? Str::headline($action);
+$actionDescription = $actionInfo['description'] ?? null;
+$valueUnit = $actionInfo['value_unit'] ?? null;
+$displayWithObject = $actionInfo['display_with_object'] ?? false;
+$isHidden = $actionInfo['hidden'] ?? false;
+
+// Domain-based colors
+$domainColors = [
+    'health' => 'success',
+    'money' => 'warning',
+    'media' => 'info',
+    'knowledge' => 'primary',
+    'online' => 'accent',
+];
+$domainColor = $domainColors[$domain] ?? 'primary';
+
+// Generate unique ID for this popover
+$popoverId = 'action-ref-' . md5($service . '-' . $action);
+@endphp
+
+<span
+    x-data="{
+        open: false,
+        showTimeout: null,
+        hideTimeout: null,
+        isMobile: window.innerWidth < 768,
+        show() {
+            if (this.isMobile) return;
+            clearTimeout(this.hideTimeout);
+            this.showTimeout = setTimeout(() => { this.open = true; }, 200);
+        },
+        hide() {
+            clearTimeout(this.showTimeout);
+            this.hideTimeout = setTimeout(() => { this.open = false; }, 150);
+        },
+        keepOpen() {
+            clearTimeout(this.hideTimeout);
+        },
+        toggle() {
+            if (this.isMobile) {
+                this.open = !this.open;
+            }
+        }
+    }"
+    @mouseenter="show()"
+    @mouseleave="hide()"
+    @click="toggle()"
+    @keydown.escape="open = false"
+    class="relative inline-block"
+>
+    {{-- Trigger: Badge variant (default) --}}
+    @if ($variant === 'badge')
+    @if ($href)
+    <a
+        href="{{ $href }}"
+        wire:navigate
+        @click.stop="if (isMobile) { $event.preventDefault(); toggle(); }"
+        class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md text-sm font-medium
+               bg-{{ $domainColor }}/10 text-{{ $domainColor }} hover:bg-{{ $domainColor }}/20
+               border border-{{ $domainColor }}/20 transition-all duration-150 cursor-pointer"
+    >
+        <x-icon :name="$actionIcon" class="w-3 h-3 opacity-70" />
+        <span class="max-w-[200px] truncate">{{ $actionDisplay }}</span>
+        @if ($showService)
+            <span class="badge badge-xs badge-ghost opacity-70">{{ $serviceName }}</span>
+        @endif
+    </a>
+    @else
+    <span
+        @click.stop="toggle()"
+        class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md text-sm font-medium
+               bg-{{ $domainColor }}/10 text-{{ $domainColor }}
+               border border-{{ $domainColor }}/20 cursor-default"
+    >
+        <x-icon :name="$actionIcon" class="w-3 h-3 opacity-70" />
+        <span class="max-w-[200px] truncate">{{ $actionDisplay }}</span>
+        @if ($showService)
+            <span class="badge badge-xs badge-ghost opacity-70">{{ $serviceName }}</span>
+        @endif
+    </span>
+    @endif
+    @else
+    {{-- Trigger: Text variant (plain text with hover) --}}
+    @if ($href)
+    <a
+        href="{{ $href }}"
+        wire:navigate
+        @click.stop="if (isMobile) { $event.preventDefault(); toggle(); }"
+        class="font-medium hover:text-{{ $domainColor }} transition-colors cursor-pointer"
+    >{{ $actionDisplay }}</a>
+    @else
+    <span
+        @click.stop="toggle()"
+        class="font-medium cursor-default"
+    >{{ $actionDisplay }}</span>
+    @endif
+    @endif
+
+    {{-- Popover Card --}}
+    <div
+        x-show="open"
+        x-transition:enter="transition ease-out duration-150"
+        x-transition:enter-start="opacity-0 scale-95 translate-y-1"
+        x-transition:enter-end="opacity-100 scale-100 translate-y-0"
+        x-transition:leave="transition ease-in duration-100"
+        x-transition:leave-start="opacity-100 scale-100"
+        x-transition:leave-end="opacity-0 scale-95"
+        x-cloak
+        @mouseenter="keepOpen()"
+        @click.outside="open = false"
+        class="absolute z-50 mt-2 left-0"
+        style="min-width: 280px; max-width: 340px;"
+    >
+        <div class="card bg-base-100 shadow-xl border border-{{ $domainColor }}/30 overflow-hidden">
+            {{-- Accent bar at top --}}
+            <div class="h-1 bg-gradient-to-r from-{{ $domainColor }} to-{{ $domainColor }}/50"></div>
+
+            <div class="card-body p-4 gap-3">
+                {{-- Header with icon and action name --}}
+                <div class="flex items-center gap-3">
+                    <div class="w-12 h-12 rounded-xl bg-{{ $domainColor }}/10 flex items-center justify-center flex-shrink-0 ring-2 ring-{{ $domainColor }}/20">
+                        <x-icon :name="$actionIcon" class="w-6 h-6 text-{{ $domainColor }}" />
+                    </div>
+                    <div class="flex-1 min-w-0">
+                        <h4 class="font-bold text-base leading-tight">
+                            {{ $actionDisplay }}
+                        </h4>
+                        <div class="flex flex-wrap gap-1 mt-1">
+                            <span class="badge badge-{{ $accentColor }} badge-outline badge-xs gap-1">
+                                <x-icon :name="$serviceIcon" class="w-2.5 h-2.5" />
+                                {{ $serviceName }}
+                            </span>
+                            <span class="badge badge-ghost badge-xs">{{ Str::headline($domain) }}</span>
+                        </div>
+                    </div>
+                </div>
+
+                {{-- Description --}}
+                @if ($actionDescription)
+                    <p class="text-sm text-base-content/70 leading-relaxed">
+                        {{ $actionDescription }}
+                    </p>
+                @endif
+
+                {{-- Action details --}}
+                <div class="space-y-2 text-sm">
+                    {{-- Raw action key --}}
+                    <div class="flex items-center justify-between gap-2">
+                        <span class="text-base-content/60">Action key</span>
+                        <code class="text-xs bg-base-200 px-2 py-0.5 rounded font-mono">{{ $action }}</code>
+                    </div>
+
+                    {{-- Value unit if present --}}
+                    @if ($valueUnit)
+                        <div class="flex items-center justify-between gap-2">
+                            <span class="text-base-content/60">Value unit</span>
+                            <span class="font-medium">{{ $valueUnit }}</span>
+                        </div>
+                    @endif
+
+                    {{-- Display with object --}}
+                    <div class="flex items-center justify-between gap-2">
+                        <span class="text-base-content/60">Shows with object</span>
+                        <span class="badge badge-xs {{ $displayWithObject ? 'badge-success' : 'badge-ghost' }}">
+                            {{ $displayWithObject ? 'Yes' : 'No' }}
+                        </span>
+                    </div>
+
+                    {{-- Hidden status --}}
+                    @if ($isHidden)
+                        <div class="flex items-center justify-between gap-2">
+                            <span class="text-base-content/60">Visibility</span>
+                            <span class="badge badge-xs badge-warning">Hidden from timeline</span>
+                        </div>
+                    @endif
+                </div>
+
+                {{-- Footer with link to filter events --}}
+                @if ($href)
+                <div class="pt-3 border-t border-base-300">
+                    <a
+                        href="{{ $href }}"
+                        wire:navigate
+                        @click.stop
+                        class="btn btn-{{ $domainColor }} btn-sm w-full gap-1"
+                    >
+                        <x-icon name="fas.arrow-right" class="w-3 h-3" />
+                        View Event
+                    </a>
+                </div>
+                @endif
+            </div>
+        </div>
+    </div>
+</span>

--- a/resources/views/components/action-ref.blade.php
+++ b/resources/views/components/action-ref.blade.php
@@ -35,8 +35,8 @@ $domainColors = [
 ];
 $domainColor = $domainColors[$domain] ?? 'primary';
 
-// Generate unique ID for this popover instance (not just per action, but per render)
-$popoverId = 'action-ref-' . md5($service . '-' . $action) . '-' . Str::random(8);
+// Base ID for this popover (unique suffix added via JavaScript)
+$popoverBaseId = 'action-ref-' . md5($service . '-' . $action);
 @endphp
 
 <span
@@ -44,7 +44,7 @@ $popoverId = 'action-ref-' . md5($service . '-' . $action) . '-' . Str::random(8
         open: false,
         showTimeout: null,
         hideTimeout: null,
-        popoverId: '{{ $popoverId }}',
+        popoverId: '{{ $popoverBaseId }}-' + Math.random().toString(36).substring(2, 10),
         isMobile: window.innerWidth < 768,
         show() {
             if (this.isMobile) return;

--- a/resources/views/components/action-ref.blade.php
+++ b/resources/views/components/action-ref.blade.php
@@ -1,4 +1,4 @@
-@props(['action', 'service', 'variant' => 'badge', 'href' => null, 'showService' => false])
+@props(['action', 'service', 'variant' => 'badge', 'href' => null, 'showService' => false, 'text' => null])
 
 @php
 use App\Integrations\PluginRegistry;
@@ -93,7 +93,7 @@ $popoverBaseId = 'action-ref-' . md5($service . '-' . $action);
                border border-{{ $domainColor }}/20 transition-all duration-150 cursor-pointer"
     >
         <x-icon :name="$actionIcon" class="w-3 h-3 opacity-70" />
-        <span class="max-w-[200px] truncate">{{ $actionDisplay }}</span>
+        <span class="max-w-[200px] truncate">{!! $text ?? $actionDisplay !!}</span>
         @if ($showService)
             <span class="badge badge-xs badge-ghost opacity-70">{{ $serviceName }}</span>
         @endif
@@ -106,7 +106,7 @@ $popoverBaseId = 'action-ref-' . md5($service . '-' . $action);
                border border-{{ $domainColor }}/20 cursor-default"
     >
         <x-icon :name="$actionIcon" class="w-3 h-3 opacity-70" />
-        <span class="max-w-[200px] truncate">{{ $actionDisplay }}</span>
+        <span class="max-w-[200px] truncate">{!! $text ?? $actionDisplay !!}</span>
         @if ($showService)
             <span class="badge badge-xs badge-ghost opacity-70">{{ $serviceName }}</span>
         @endif
@@ -120,12 +120,12 @@ $popoverBaseId = 'action-ref-' . md5($service . '-' . $action);
         wire:navigate
         @click.stop="if (isMobile) { $event.preventDefault(); toggle(); }"
         class="font-medium hover:text-{{ $domainColor }} transition-colors cursor-pointer"
-    >{{ $actionDisplay }}</a>
+    >{!! $text ?? $actionDisplay !!}</a>
     @else
     <span
         @click.stop="toggle()"
         class="font-medium cursor-default"
-    >{{ $actionDisplay }}</span>
+    >{!! $text ?? $actionDisplay !!}</span>
     @endif
     @endif
 

--- a/resources/views/components/action-ref.blade.php
+++ b/resources/views/components/action-ref.blade.php
@@ -35,8 +35,8 @@ $domainColors = [
 ];
 $domainColor = $domainColors[$domain] ?? 'primary';
 
-// Generate unique ID for this popover
-$popoverId = 'action-ref-' . md5($service . '-' . $action);
+// Generate unique ID for this popover instance (not just per action, but per render)
+$popoverId = 'action-ref-' . md5($service . '-' . $action) . '-' . Str::random(8);
 @endphp
 
 <span

--- a/resources/views/components/block-ref.blade.php
+++ b/resources/views/components/block-ref.blade.php
@@ -37,8 +37,8 @@ $accentColor = $domainColors[$domain] ?? 'accent';
 $hasCustomLayout = $block->hasCustomCardLayout();
 $customLayoutPath = $block->getCustomCardLayoutPath();
 
-// Generate unique ID
-$popoverId = 'block-ref-' . $block->id;
+// Generate unique ID for this popover instance (not just per block, but per render)
+$popoverId = 'block-ref-' . $block->id . '-' . Str::random(8);
 @endphp
 
 <span

--- a/resources/views/components/block-ref.blade.php
+++ b/resources/views/components/block-ref.blade.php
@@ -1,4 +1,4 @@
-@props(['block', 'showType' => true])
+@props(['block', 'showType' => true, 'text' => null])
 
 @php
 use App\Integrations\PluginRegistry;
@@ -93,7 +93,7 @@ $popoverBaseId = 'block-ref-' . $block->id;
                border border-{{ $accentColor }}/20 transition-all duration-150 cursor-pointer"
     >
         <x-icon :name="$blockIcon" class="w-3 h-3 opacity-70" />
-        <span class="max-w-[180px] truncate">{{ $block->title ?? $blockDisplayName }}</span>
+        <span class="max-w-[180px] truncate">{!! $text ?? ($block->title ?? $blockDisplayName) !!}</span>
         @if ($showType && $block->block_type)
             <span class="badge badge-xs badge-ghost opacity-70">{{ $blockDisplayName }}</span>
         @endif
@@ -192,14 +192,6 @@ $popoverBaseId = 'block-ref-' . $block->id;
                                     @endforeach
                                 </div>
                             @endif
-                        @endif
-
-                        {{-- Parent event info --}}
-                        @if ($block->event)
-                            <div class="flex items-center gap-2 text-xs text-base-content/50">
-                                <x-icon :name="$icon" class="w-3 h-3" />
-                                <span>From {{ $serviceName }} event</span>
-                            </div>
                         @endif
                     </div>
                 @endif

--- a/resources/views/components/block-ref.blade.php
+++ b/resources/views/components/block-ref.blade.php
@@ -46,11 +46,15 @@ $popoverId = 'block-ref-' . $block->id;
         open: false,
         showTimeout: null,
         hideTimeout: null,
+        popoverId: '{{ $popoverId }}',
         isMobile: window.innerWidth < 768,
         show() {
             if (this.isMobile) return;
             clearTimeout(this.hideTimeout);
-            this.showTimeout = setTimeout(() => { this.open = true; }, 200);
+            this.showTimeout = setTimeout(() => {
+                window.dispatchEvent(new CustomEvent('popover-opening', { detail: this.popoverId }));
+                this.open = true;
+            }, 200);
         },
         hide() {
             clearTimeout(this.showTimeout);
@@ -61,13 +65,21 @@ $popoverId = 'block-ref-' . $block->id;
         },
         toggle() {
             if (this.isMobile) {
+                window.dispatchEvent(new CustomEvent('popover-opening', { detail: this.popoverId }));
                 this.open = !this.open;
+            }
+        },
+        closeIfNotMe(event) {
+            if (event.detail !== this.popoverId) {
+                clearTimeout(this.showTimeout);
+                this.open = false;
             }
         }
     }"
     @mouseenter="show()"
     @mouseleave="hide()"
     @click="toggle()"
+    @popover-opening.window="closeIfNotMe($event)"
     @keydown.escape="open = false"
     class="relative inline-block"
 >

--- a/resources/views/components/block-ref.blade.php
+++ b/resources/views/components/block-ref.blade.php
@@ -37,8 +37,8 @@ $accentColor = $domainColors[$domain] ?? 'accent';
 $hasCustomLayout = $block->hasCustomCardLayout();
 $customLayoutPath = $block->getCustomCardLayoutPath();
 
-// Generate unique ID for this popover instance (not just per block, but per render)
-$popoverId = 'block-ref-' . $block->id . '-' . Str::random(8);
+// Base ID for this popover (unique suffix added via JavaScript)
+$popoverBaseId = 'block-ref-' . $block->id;
 @endphp
 
 <span
@@ -46,7 +46,7 @@ $popoverId = 'block-ref-' . $block->id . '-' . Str::random(8);
         open: false,
         showTimeout: null,
         hideTimeout: null,
-        popoverId: '{{ $popoverId }}',
+        popoverId: '{{ $popoverBaseId }}-' + Math.random().toString(36).substring(2, 10),
         isMobile: window.innerWidth < 768,
         show() {
             if (this.isMobile) return;

--- a/resources/views/components/block-ref.blade.php
+++ b/resources/views/components/block-ref.blade.php
@@ -1,0 +1,227 @@
+@props(['block', 'showType' => true])
+
+@php
+use App\Integrations\PluginRegistry;
+
+// Handle null blocks gracefully
+if (!$block) {
+    return;
+}
+
+// Load event relationship if needed
+$block->loadMissing('event');
+
+// Get plugin info (through the event)
+$pluginClass = $block->event ? PluginRegistry::getPlugin($block->event->service) : null;
+$icon = $pluginClass ? $pluginClass::getIcon() : 'fas.grip';
+$serviceName = $pluginClass ? $pluginClass::getDisplayName() : 'Unknown';
+$domain = $pluginClass ? $pluginClass::getDomain() : 'knowledge';
+
+// Get block type info
+$blockTypes = $pluginClass ? $pluginClass::getBlockTypes() : [];
+$blockTypeInfo = $blockTypes[$block->block_type] ?? null;
+$blockIcon = $blockTypeInfo['icon'] ?? 'fas.grip';
+$blockDisplayName = $blockTypeInfo['display_name'] ?? Str::headline($block->block_type ?? 'Block');
+
+// Domain-based colors
+$domainColors = [
+    'health' => 'success',
+    'money' => 'warning',
+    'media' => 'info',
+    'knowledge' => 'primary',
+    'online' => 'accent',
+];
+$accentColor = $domainColors[$domain] ?? 'accent';
+
+// Check for custom layout
+$hasCustomLayout = $block->hasCustomCardLayout();
+$customLayoutPath = $block->getCustomCardLayoutPath();
+
+// Generate unique ID
+$popoverId = 'block-ref-' . $block->id;
+@endphp
+
+<span
+    x-data="{
+        open: false,
+        timeout: null,
+        isMobile: window.innerWidth < 768,
+        show() {
+            if (this.isMobile) return;
+            this.timeout = setTimeout(() => { this.open = true; }, 200);
+        },
+        hide() {
+            clearTimeout(this.timeout);
+            this.open = false;
+        },
+        toggle() {
+            if (this.isMobile) {
+                this.open = !this.open;
+            }
+        }
+    }"
+    @mouseenter="show()"
+    @mouseleave="hide()"
+    @click="toggle()"
+    @keydown.escape="open = false"
+    class="relative inline-block"
+>
+    {{-- Trigger: The reference link/badge --}}
+    <a
+        href="{{ route('blocks.show', $block) }}"
+        wire:navigate
+        @click.stop="if (isMobile) { $event.preventDefault(); toggle(); }"
+        class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md text-sm font-medium
+               bg-{{ $accentColor }}/10 text-{{ $accentColor }} hover:bg-{{ $accentColor }}/20
+               border border-{{ $accentColor }}/20 transition-all duration-150 cursor-pointer"
+    >
+        <x-icon :name="$blockIcon" class="w-3 h-3 opacity-70" />
+        <span class="max-w-[180px] truncate">{{ $block->title ?? $blockDisplayName }}</span>
+        @if ($showType && $block->block_type)
+            <span class="badge badge-xs badge-ghost opacity-70">{{ $blockDisplayName }}</span>
+        @endif
+    </a>
+
+    {{-- Popover Card --}}
+    <div
+        x-show="open"
+        x-transition:enter="transition ease-out duration-150"
+        x-transition:enter-start="opacity-0 scale-95 translate-y-1"
+        x-transition:enter-end="opacity-100 scale-100 translate-y-0"
+        x-transition:leave="transition ease-in duration-100"
+        x-transition:leave-start="opacity-100 scale-100"
+        x-transition:leave-end="opacity-0 scale-95"
+        x-cloak
+        @click.outside="open = false"
+        class="absolute z-50 mt-2 left-0"
+        style="min-width: 320px; max-width: 400px;"
+    >
+        <div class="card bg-base-100 shadow-xl border border-{{ $accentColor }}/30 overflow-hidden">
+            {{-- Accent bar --}}
+            <div class="h-1 bg-gradient-to-r from-{{ $accentColor }} to-{{ $accentColor }}/50"></div>
+
+            <div class="card-body p-0">
+                @if ($hasCustomLayout && $customLayoutPath)
+                    {{-- Use custom block type view (scaled down for popover) --}}
+                    <div class="transform scale-95 origin-top-left p-2">
+                        @include($customLayoutPath, ['block' => $block])
+                    </div>
+                @else
+                    {{-- Default block preview --}}
+                    <div class="p-4 gap-3 flex flex-col">
+                        {{-- Header --}}
+                        <div class="flex items-center justify-between gap-2">
+                            <div class="flex items-center gap-2">
+                                <div class="badge badge-{{ $accentColor }} badge-outline gap-1">
+                                    <x-icon :name="$blockIcon" class="w-3 h-3" />
+                                    {{ $blockDisplayName }}
+                                </div>
+                            </div>
+                            @if ($block->time)
+                                <div class="text-xs text-base-content/60">
+                                    {{ $block->time->diffForHumans() }}
+                                </div>
+                            @endif
+                        </div>
+
+                        {{-- Title --}}
+                        @if ($block->title)
+                            <h4 class="font-bold text-base leading-tight">
+                                {{ $block->title }}
+                            </h4>
+                        @endif
+
+                        {{-- Value display --}}
+                        @if ($block->value !== null)
+                            <div class="flex items-baseline gap-2">
+                                <span class="text-3xl font-bold text-{{ $accentColor }}">
+                                    {{ number_format($block->formatted_value, ($block->value_multiplier && $block->value_multiplier > 1) ? 2 : 0) }}
+                                </span>
+                                @if ($block->value_unit)
+                                    <span class="text-sm text-base-content/60">{{ $block->value_unit }}</span>
+                                @endif
+                            </div>
+                        @endif
+
+                        {{-- Content preview --}}
+                        @php
+                            $contentPreview = $block->getContent();
+                            if ($contentPreview) {
+                                $contentPreview = Str::limit(strip_tags($contentPreview), 150);
+                            }
+                        @endphp
+                        @if ($contentPreview)
+                            <p class="text-sm text-base-content/70 line-clamp-3 leading-relaxed">
+                                {{ $contentPreview }}
+                            </p>
+                        @endif
+
+                        {{-- Metadata preview (select important fields) --}}
+                        @if ($block->metadata && count($block->metadata) > 0)
+                            @php
+                                $displayMeta = collect($block->metadata)
+                                    ->except(['content', 'summary', 'text', 'description', 'image', 'image_url', 'article_text'])
+                                    ->filter(fn($v) => !is_array($v) && !is_null($v) && $v !== '')
+                                    ->take(3);
+                            @endphp
+                            @if ($displayMeta->count() > 0)
+                                <div class="text-xs text-base-content/60 space-y-1">
+                                    @foreach ($displayMeta as $key => $value)
+                                        <div class="flex justify-between gap-2">
+                                            <span class="font-medium capitalize">{{ str_replace('_', ' ', $key) }}:</span>
+                                            <span class="text-right truncate max-w-[150px]">{{ Str::limit($value, 30) }}</span>
+                                        </div>
+                                    @endforeach
+                                </div>
+                            @endif
+                        @endif
+
+                        {{-- Parent event info --}}
+                        @if ($block->event)
+                            <div class="flex items-center gap-2 text-xs text-base-content/50">
+                                <x-icon :name="$icon" class="w-3 h-3" />
+                                <span>From {{ $serviceName }} event</span>
+                            </div>
+                        @endif
+                    </div>
+                @endif
+
+                {{-- Action footer (always shown) --}}
+                <div class="flex items-center gap-2 p-4 pt-0 border-t border-base-300 mt-auto">
+                    <a
+                        href="{{ route('blocks.show', $block) }}"
+                        wire:navigate
+                        @click.stop
+                        class="btn btn-{{ $accentColor }} btn-sm flex-1 gap-1"
+                    >
+                        <x-icon name="fas.arrow-right" class="w-3 h-3" />
+                        View Block
+                    </a>
+                    @if ($block->event)
+                        <a
+                            href="{{ route('events.show', $block->event) }}"
+                            wire:navigate
+                            @click.stop
+                            class="btn btn-ghost btn-sm btn-square"
+                            title="View Parent Event"
+                        >
+                            <x-icon name="fas.bolt" class="w-4 h-4" />
+                        </a>
+                    @endif
+                    @if ($block->url)
+                        <a
+                            href="{{ $block->url }}"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            @click.stop
+                            class="btn btn-ghost btn-sm btn-square"
+                            title="Open URL"
+                        >
+                            <x-icon name="o-arrow-top-right-on-square" class="w-4 h-4" />
+                        </a>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+</span>

--- a/resources/views/components/block-ref.blade.php
+++ b/resources/views/components/block-ref.blade.php
@@ -44,15 +44,20 @@ $popoverId = 'block-ref-' . $block->id;
 <span
     x-data="{
         open: false,
-        timeout: null,
+        showTimeout: null,
+        hideTimeout: null,
         isMobile: window.innerWidth < 768,
         show() {
             if (this.isMobile) return;
-            this.timeout = setTimeout(() => { this.open = true; }, 200);
+            clearTimeout(this.hideTimeout);
+            this.showTimeout = setTimeout(() => { this.open = true; }, 200);
         },
         hide() {
-            clearTimeout(this.timeout);
-            this.open = false;
+            clearTimeout(this.showTimeout);
+            this.hideTimeout = setTimeout(() => { this.open = false; }, 150);
+        },
+        keepOpen() {
+            clearTimeout(this.hideTimeout);
         },
         toggle() {
             if (this.isMobile) {
@@ -92,6 +97,7 @@ $popoverId = 'block-ref-' . $block->id;
         x-transition:leave-start="opacity-100 scale-100"
         x-transition:leave-end="opacity-0 scale-95"
         x-cloak
+        @mouseenter="keepOpen()"
         @click.outside="open = false"
         class="absolute z-50 mt-2 left-0"
         style="min-width: 320px; max-width: 400px;"

--- a/resources/views/components/event-ref.blade.php
+++ b/resources/views/components/event-ref.blade.php
@@ -34,8 +34,8 @@ $domainColor = $domainColors[$domain] ?? 'primary';
 $event->loadMissing(['actor', 'target', 'integration']);
 $blocksCount = $event->blocks()->count();
 
-// Generate unique ID for this popover instance (not just per event, but per render)
-$popoverId = 'event-ref-' . $event->id . '-' . Str::random(8);
+// Base ID for this popover (unique suffix added via JavaScript)
+$popoverBaseId = 'event-ref-' . $event->id;
 @endphp
 
 <span
@@ -43,7 +43,7 @@ $popoverId = 'event-ref-' . $event->id . '-' . Str::random(8);
         open: false,
         showTimeout: null,
         hideTimeout: null,
-        popoverId: '{{ $popoverId }}',
+        popoverId: '{{ $popoverBaseId }}-' + Math.random().toString(36).substring(2, 10),
         isMobile: window.innerWidth < 768,
         show() {
             if (this.isMobile) return;

--- a/resources/views/components/event-ref.blade.php
+++ b/resources/views/components/event-ref.blade.php
@@ -43,11 +43,15 @@ $popoverId = 'event-ref-' . $event->id;
         open: false,
         showTimeout: null,
         hideTimeout: null,
+        popoverId: '{{ $popoverId }}',
         isMobile: window.innerWidth < 768,
         show() {
             if (this.isMobile) return;
             clearTimeout(this.hideTimeout);
-            this.showTimeout = setTimeout(() => { this.open = true; }, 200);
+            this.showTimeout = setTimeout(() => {
+                window.dispatchEvent(new CustomEvent('popover-opening', { detail: this.popoverId }));
+                this.open = true;
+            }, 200);
         },
         hide() {
             clearTimeout(this.showTimeout);
@@ -58,7 +62,14 @@ $popoverId = 'event-ref-' . $event->id;
         },
         toggle() {
             if (this.isMobile) {
+                window.dispatchEvent(new CustomEvent('popover-opening', { detail: this.popoverId }));
                 this.open = !this.open;
+            }
+        },
+        closeIfNotMe(event) {
+            if (event.detail !== this.popoverId) {
+                clearTimeout(this.showTimeout);
+                this.open = false;
             }
         }
     }"
@@ -66,6 +77,7 @@ $popoverId = 'event-ref-' . $event->id;
     @mouseleave="hide()"
     @click="toggle()"
     @keydown.escape="open = false"
+    @popover-opening.window="closeIfNotMe($event)"
     class="relative inline-block"
 >
     {{-- Trigger: The reference link/badge --}}

--- a/resources/views/components/event-ref.blade.php
+++ b/resources/views/components/event-ref.blade.php
@@ -1,0 +1,224 @@
+@props(['event', 'showService' => true])
+
+@php
+use App\Integrations\PluginRegistry;
+
+// Handle null events gracefully
+if (!$event) {
+    return;
+}
+
+// Get plugin info
+$pluginClass = PluginRegistry::getPlugin($event->service);
+$icon = $pluginClass ? $pluginClass::getIcon() : 'fas.bolt';
+$serviceName = $pluginClass ? $pluginClass::getDisplayName() : ucfirst($event->service);
+$accentColor = $pluginClass ? $pluginClass::getAccentColor() : 'primary';
+$domain = $pluginClass ? $pluginClass::getDomain() : 'knowledge';
+
+// Get action display
+$actionTypes = $pluginClass ? $pluginClass::getActionTypes() : [];
+$actionInfo = $actionTypes[$event->action] ?? null;
+$actionDisplay = $actionInfo['display_name'] ?? Str::headline($event->action ?? 'Event');
+
+// Domain-based colors
+$domainColors = [
+    'health' => 'success',
+    'money' => 'warning',
+    'media' => 'info',
+    'knowledge' => 'primary',
+    'online' => 'accent',
+];
+$domainColor = $domainColors[$domain] ?? 'primary';
+
+// Load relationships if needed
+$event->loadMissing(['actor', 'target', 'integration']);
+$blocksCount = $event->blocks()->count();
+
+// Generate unique ID
+$popoverId = 'event-ref-' . $event->id;
+@endphp
+
+<span
+    x-data="{
+        open: false,
+        timeout: null,
+        isMobile: window.innerWidth < 768,
+        show() {
+            if (this.isMobile) return;
+            this.timeout = setTimeout(() => { this.open = true; }, 200);
+        },
+        hide() {
+            clearTimeout(this.timeout);
+            this.open = false;
+        },
+        toggle() {
+            if (this.isMobile) {
+                this.open = !this.open;
+            }
+        }
+    }"
+    @mouseenter="show()"
+    @mouseleave="hide()"
+    @click="toggle()"
+    @keydown.escape="open = false"
+    class="relative inline-block"
+>
+    {{-- Trigger: The reference link/badge --}}
+    <a
+        href="{{ route('events.show', $event) }}"
+        wire:navigate
+        @click.stop="if (isMobile) { $event.preventDefault(); toggle(); }"
+        class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md text-sm font-medium
+               bg-{{ $domainColor }}/10 text-{{ $domainColor }} hover:bg-{{ $domainColor }}/20
+               border border-{{ $domainColor }}/20 transition-all duration-150 cursor-pointer"
+    >
+        <x-icon :name="$icon" class="w-3 h-3 opacity-70" />
+        <span class="max-w-[200px] truncate">{{ $actionDisplay }}</span>
+        @if ($showService)
+            <span class="badge badge-xs badge-ghost opacity-70">{{ $serviceName }}</span>
+        @endif
+    </a>
+
+    {{-- Popover Card --}}
+    <div
+        x-show="open"
+        x-transition:enter="transition ease-out duration-150"
+        x-transition:enter-start="opacity-0 scale-95 translate-y-1"
+        x-transition:enter-end="opacity-100 scale-100 translate-y-0"
+        x-transition:leave="transition ease-in duration-100"
+        x-transition:leave-start="opacity-100 scale-100"
+        x-transition:leave-end="opacity-0 scale-95"
+        x-cloak
+        @click.outside="open = false"
+        class="absolute z-50 mt-2 left-0"
+        style="min-width: 340px; max-width: 400px;"
+    >
+        <div class="card bg-base-100 shadow-xl border border-{{ $domainColor }}/30 overflow-hidden">
+            {{-- Accent bar with gradient --}}
+            <div class="h-1 bg-gradient-to-r from-{{ $domainColor }} to-{{ $domainColor }}/50"></div>
+
+            <div class="card-body p-4 gap-3">
+                {{-- Header: Service badge and timestamp --}}
+                <div class="flex items-center justify-between gap-2">
+                    <div class="flex items-center gap-2">
+                        <div class="badge badge-{{ $domainColor }} gap-1">
+                            <x-icon :name="$icon" class="w-3 h-3" />
+                            {{ $serviceName }}
+                        </div>
+                        <div class="badge badge-ghost badge-sm">{{ Str::headline($domain) }}</div>
+                    </div>
+                    <div class="text-xs text-base-content/60">
+                        {{ $event->time?->diffForHumans() ?? 'No time' }}
+                    </div>
+                </div>
+
+                {{-- Action headline --}}
+                <div class="text-lg font-bold leading-tight">
+                    {{ $actionDisplay }}
+                </div>
+
+                {{-- Actor → Target flow --}}
+                @if ($event->actor || $event->target)
+                    <div class="flex items-center gap-2 flex-wrap">
+                        @if ($event->actor)
+                            <div class="flex items-center gap-1 px-2 py-1 rounded bg-base-200 text-sm">
+                                <x-icon name="fas.user" class="w-3 h-3 text-base-content/50" />
+                                <span class="font-medium truncate max-w-[120px]">{{ $event->actor->title }}</span>
+                            </div>
+                        @endif
+
+                        @if ($event->actor && $event->target)
+                            <x-icon name="fas.arrow-right" class="w-4 h-4 text-base-content/30" />
+                        @endif
+
+                        @if ($event->target)
+                            <div class="flex items-center gap-1 px-2 py-1 rounded bg-base-200 text-sm">
+                                <x-icon name="fas.bullseye" class="w-3 h-3 text-base-content/50" />
+                                <span class="font-medium truncate max-w-[120px]">{{ $event->target->title }}</span>
+                            </div>
+                        @endif
+                    </div>
+                @endif
+
+                {{-- Value display (if present) --}}
+                @if ($event->value !== null)
+                    <div class="flex items-baseline gap-2">
+                        <span class="text-2xl font-bold text-{{ $domainColor }}">
+                            {{ number_format($event->formatted_value, ($event->value_multiplier && $event->value_multiplier > 1) ? 2 : 0) }}
+                        </span>
+                        @if ($event->value_unit)
+                            <span class="text-sm text-base-content/60">{{ $event->value_unit }}</span>
+                        @endif
+                    </div>
+                @endif
+
+                {{-- Stats row --}}
+                <div class="flex items-center gap-4 text-xs text-base-content/60">
+                    @if ($blocksCount > 0)
+                        <div class="flex items-center gap-1">
+                            <x-icon name="fas.grip" class="w-3 h-3" />
+                            <span>{{ $blocksCount }} block{{ $blocksCount !== 1 ? 's' : '' }}</span>
+                        </div>
+                    @endif
+                    @if ($event->tags->count() > 0)
+                        <div class="flex items-center gap-1">
+                            <x-icon name="fas.tags" class="w-3 h-3" />
+                            <span>{{ $event->tags->count() }} tag{{ $event->tags->count() !== 1 ? 's' : '' }}</span>
+                        </div>
+                    @endif
+                    <div class="flex items-center gap-1 ml-auto">
+                        <x-icon name="fas.calendar" class="w-3 h-3" />
+                        <span>{{ $event->time?->format('j M Y, H:i') ?? 'No date' }}</span>
+                    </div>
+                </div>
+
+                {{-- Tags preview --}}
+                @if ($event->tags->count() > 0)
+                    <div class="flex flex-wrap gap-1">
+                        @foreach ($event->tags->take(5) as $tag)
+                            <span class="badge badge-ghost badge-xs">{{ $tag->name }}</span>
+                        @endforeach
+                        @if ($event->tags->count() > 5)
+                            <span class="badge badge-ghost badge-xs">+{{ $event->tags->count() - 5 }}</span>
+                        @endif
+                    </div>
+                @endif
+
+                {{-- Action footer --}}
+                <div class="flex items-center gap-2 pt-3 border-t border-base-300">
+                    <a
+                        href="{{ route('events.show', $event) }}"
+                        wire:navigate
+                        @click.stop
+                        class="btn btn-{{ $domainColor }} btn-sm flex-1 gap-1"
+                    >
+                        <x-icon name="fas.arrow-right" class="w-3 h-3" />
+                        View Event
+                    </a>
+                    @if ($event->actor)
+                        <a
+                            href="{{ route('objects.show', $event->actor) }}"
+                            wire:navigate
+                            @click.stop
+                            class="btn btn-ghost btn-sm btn-square"
+                            title="View Actor"
+                        >
+                            <x-icon name="fas.user" class="w-4 h-4" />
+                        </a>
+                    @endif
+                    @if ($event->target)
+                        <a
+                            href="{{ route('objects.show', $event->target) }}"
+                            wire:navigate
+                            @click.stop
+                            class="btn btn-ghost btn-sm btn-square"
+                            title="View Target"
+                        >
+                            <x-icon name="fas.bullseye" class="w-4 h-4" />
+                        </a>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+</span>

--- a/resources/views/components/event-ref.blade.php
+++ b/resources/views/components/event-ref.blade.php
@@ -41,15 +41,20 @@ $popoverId = 'event-ref-' . $event->id;
 <span
     x-data="{
         open: false,
-        timeout: null,
+        showTimeout: null,
+        hideTimeout: null,
         isMobile: window.innerWidth < 768,
         show() {
             if (this.isMobile) return;
-            this.timeout = setTimeout(() => { this.open = true; }, 200);
+            clearTimeout(this.hideTimeout);
+            this.showTimeout = setTimeout(() => { this.open = true; }, 200);
         },
         hide() {
-            clearTimeout(this.timeout);
-            this.open = false;
+            clearTimeout(this.showTimeout);
+            this.hideTimeout = setTimeout(() => { this.open = false; }, 150);
+        },
+        keepOpen() {
+            clearTimeout(this.hideTimeout);
         },
         toggle() {
             if (this.isMobile) {
@@ -89,6 +94,7 @@ $popoverId = 'event-ref-' . $event->id;
         x-transition:leave-start="opacity-100 scale-100"
         x-transition:leave-end="opacity-0 scale-95"
         x-cloak
+        @mouseenter="keepOpen()"
         @click.outside="open = false"
         class="absolute z-50 mt-2 left-0"
         style="min-width: 340px; max-width: 400px;"

--- a/resources/views/components/event-ref.blade.php
+++ b/resources/views/components/event-ref.blade.php
@@ -34,8 +34,8 @@ $domainColor = $domainColors[$domain] ?? 'primary';
 $event->loadMissing(['actor', 'target', 'integration']);
 $blocksCount = $event->blocks()->count();
 
-// Generate unique ID
-$popoverId = 'event-ref-' . $event->id;
+// Generate unique ID for this popover instance (not just per event, but per render)
+$popoverId = 'event-ref-' . $event->id . '-' . Str::random(8);
 @endphp
 
 <span

--- a/resources/views/components/event-ref.blade.php
+++ b/resources/views/components/event-ref.blade.php
@@ -1,4 +1,4 @@
-@props(['event', 'showService' => true])
+@props(['event', 'showService' => true, 'text' => null])
 
 @php
 use App\Integrations\PluginRegistry;
@@ -90,7 +90,7 @@ $popoverBaseId = 'event-ref-' . $event->id;
                border border-{{ $domainColor }}/20 transition-all duration-150 cursor-pointer"
     >
         <x-icon :name="$icon" class="w-3 h-3 opacity-70" />
-        <span class="max-w-[200px] truncate">{{ $actionDisplay }}</span>
+        <span class="max-w-[200px] truncate">{!! $text ?? $actionDisplay !!}</span>
         @if ($showService)
             <span class="badge badge-xs badge-ghost opacity-70">{{ $serviceName }}</span>
         @endif

--- a/resources/views/components/integration-ref.blade.php
+++ b/resources/views/components/integration-ref.blade.php
@@ -1,0 +1,212 @@
+@props(['integration', 'showStatus' => true])
+
+@php
+use App\Integrations\PluginRegistry;
+
+// Handle null integrations gracefully
+if (!$integration) {
+    return;
+}
+
+// Get plugin info
+$pluginClass = PluginRegistry::getPlugin($integration->service);
+$icon = $pluginClass ? $pluginClass::getIcon() : 'fas.plug';
+$serviceName = $pluginClass ? $pluginClass::getDisplayName() : ucfirst($integration->service);
+$accentColor = $pluginClass ? $pluginClass::getAccentColor() : 'primary';
+$domain = $pluginClass ? $pluginClass::getDomain() : 'knowledge';
+$serviceType = $pluginClass ? $pluginClass::getServiceType() : 'manual';
+
+// Get instance type info
+$instanceTypes = $pluginClass ? $pluginClass::getInstanceTypes() : [];
+$instanceTypeInfo = $instanceTypes[$integration->instance_type] ?? null;
+$instanceDisplayName = $instanceTypeInfo['display_name'] ?? Str::headline($integration->instance_type ?? 'Instance');
+
+// Determine status
+$isPaused = $integration->isPaused();
+$isStale = $integration->isStale();
+$isProcessing = $integration->isProcessing();
+
+$statusColor = 'success';
+$statusText = 'Active';
+$statusIcon = 'fas.check-circle';
+
+if ($isPaused) {
+    $statusColor = 'warning';
+    $statusText = 'Paused';
+    $statusIcon = 'fas.pause-circle';
+} elseif ($isStale) {
+    $statusColor = 'error';
+    $statusText = 'Stale';
+    $statusIcon = 'fas.exclamation-circle';
+} elseif ($isProcessing) {
+    $statusColor = 'info';
+    $statusText = 'Processing';
+    $statusIcon = 'fas.spinner';
+}
+
+// Get timing info
+$lastUpdate = $integration->last_successful_update_at;
+$nextUpdate = $integration->getNextUpdateTime();
+
+// Generate unique ID
+$popoverId = 'integration-ref-' . $integration->id;
+@endphp
+
+<span
+    x-data="{
+        open: false,
+        timeout: null,
+        isMobile: window.innerWidth < 768,
+        show() {
+            if (this.isMobile) return;
+            this.timeout = setTimeout(() => { this.open = true; }, 200);
+        },
+        hide() {
+            clearTimeout(this.timeout);
+            this.open = false;
+        },
+        toggle() {
+            if (this.isMobile) {
+                this.open = !this.open;
+            }
+        }
+    }"
+    @mouseenter="show()"
+    @mouseleave="hide()"
+    @click="toggle()"
+    @keydown.escape="open = false"
+    class="relative inline-block"
+>
+    {{-- Trigger: The reference link/badge --}}
+    <a
+        href="{{ route('integrations.configure', $integration) }}"
+        wire:navigate
+        @click.stop="if (isMobile) { $event.preventDefault(); toggle(); }"
+        class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md text-sm font-medium
+               bg-{{ $accentColor }}/10 text-{{ $accentColor }} hover:bg-{{ $accentColor }}/20
+               border border-{{ $accentColor }}/20 transition-all duration-150 cursor-pointer"
+    >
+        <x-icon :name="$icon" class="w-3 h-3 opacity-70" />
+        <span class="max-w-[180px] truncate">{{ $integration->name ?? $serviceName }}</span>
+        @if ($showStatus)
+            <span class="w-2 h-2 rounded-full bg-{{ $statusColor }} {{ $isProcessing ? 'animate-pulse' : '' }}"></span>
+        @endif
+    </a>
+
+    {{-- Popover Card --}}
+    <div
+        x-show="open"
+        x-transition:enter="transition ease-out duration-150"
+        x-transition:enter-start="opacity-0 scale-95 translate-y-1"
+        x-transition:enter-end="opacity-100 scale-100 translate-y-0"
+        x-transition:leave="transition ease-in duration-100"
+        x-transition:leave-start="opacity-100 scale-100"
+        x-transition:leave-end="opacity-0 scale-95"
+        x-cloak
+        @click.outside="open = false"
+        class="absolute z-50 mt-2 left-0"
+        style="min-width: 300px; max-width: 360px;"
+    >
+        <div class="card bg-base-100 shadow-xl border border-{{ $accentColor }}/30 overflow-hidden">
+            {{-- Accent bar --}}
+            <div class="h-1 bg-gradient-to-r from-{{ $accentColor }} to-{{ $accentColor }}/50"></div>
+
+            <div class="card-body p-4 gap-3">
+                {{-- Header with icon and service name --}}
+                <div class="flex items-center gap-3">
+                    <div class="w-12 h-12 rounded-xl bg-{{ $accentColor }}/10 flex items-center justify-center flex-shrink-0 ring-2 ring-{{ $accentColor }}/20">
+                        <x-icon :name="$icon" class="w-6 h-6 text-{{ $accentColor }}" />
+                    </div>
+                    <div class="flex-1 min-w-0">
+                        <h4 class="font-bold text-base leading-tight">
+                            {{ $integration->name ?? $serviceName }}
+                        </h4>
+                        <div class="flex items-center gap-2 mt-1">
+                            <span class="badge badge-{{ $accentColor }} badge-outline badge-xs">{{ $serviceName }}</span>
+                            <span class="badge badge-ghost badge-xs">{{ $instanceDisplayName }}</span>
+                        </div>
+                    </div>
+                </div>
+
+                {{-- Status indicator --}}
+                <div class="flex items-center gap-2 p-2 rounded-lg bg-{{ $statusColor }}/10 border border-{{ $statusColor }}/20">
+                    <x-icon :name="$statusIcon" class="w-4 h-4 text-{{ $statusColor }} {{ $isProcessing ? 'animate-spin' : '' }}" />
+                    <span class="text-sm font-medium text-{{ $statusColor }}">{{ $statusText }}</span>
+                    @if ($isPaused)
+                        <span class="text-xs text-base-content/50 ml-auto">Updates suspended</span>
+                    @elseif ($isStale)
+                        <span class="text-xs text-base-content/50 ml-auto">No recent data</span>
+                    @elseif ($isProcessing)
+                        <span class="text-xs text-base-content/50 ml-auto">Syncing...</span>
+                    @endif
+                </div>
+
+                {{-- Timing info --}}
+                <div class="space-y-2 text-sm">
+                    @if ($lastUpdate)
+                        <div class="flex items-center justify-between gap-2">
+                            <span class="text-base-content/60 flex items-center gap-1">
+                                <x-icon name="fas.clock-rotate-left" class="w-3 h-3" />
+                                Last updated
+                            </span>
+                            <span class="font-medium">{{ $lastUpdate->diffForHumans() }}</span>
+                        </div>
+                    @endif
+
+                    @if ($nextUpdate && !$isPaused)
+                        <div class="flex items-center justify-between gap-2">
+                            <span class="text-base-content/60 flex items-center gap-1">
+                                <x-icon name="fas.clock" class="w-3 h-3" />
+                                Next update
+                            </span>
+                            <span class="font-medium">{{ $nextUpdate->diffForHumans() }}</span>
+                        </div>
+                    @endif
+
+                    @if ($integration->useSchedule())
+                        @php $scheduleSummary = $integration->getScheduleSummary(); @endphp
+                        @if ($scheduleSummary)
+                            <div class="flex items-center gap-2 text-xs text-base-content/50">
+                                <x-icon name="fas.calendar-days" class="w-3 h-3" />
+                                <span>{{ $scheduleSummary }}</span>
+                            </div>
+                        @endif
+                    @else
+                        <div class="flex items-center gap-2 text-xs text-base-content/50">
+                            <x-icon name="fas.repeat" class="w-3 h-3" />
+                            <span>Every {{ $integration->getUpdateFrequencyMinutes() }} minutes</span>
+                        </div>
+                    @endif
+                </div>
+
+                {{-- Service type badge --}}
+                <div class="flex items-center gap-2 text-xs text-base-content/50">
+                    <span class="badge badge-ghost badge-xs capitalize">{{ $serviceType }}</span>
+                    <span class="badge badge-ghost badge-xs capitalize">{{ $domain }}</span>
+                </div>
+
+                {{-- Action footer --}}
+                <div class="flex items-center gap-2 pt-3 border-t border-base-300">
+                    <a
+                        href="{{ route('integrations.configure', $integration) }}"
+                        wire:navigate
+                        @click.stop
+                        class="btn btn-{{ $accentColor }} btn-sm flex-1 gap-1"
+                    >
+                        <x-icon name="fas.cog" class="w-3 h-3" />
+                        Configure
+                    </a>
+                    <a
+                        href="{{ route('integrations.index') }}"
+                        wire:navigate
+                        @click.stop
+                        class="btn btn-ghost btn-sm btn-square"
+                        title="All Integrations"
+                    >
+                        <x-icon name="fas.list" class="w-4 h-4" />
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+</span>

--- a/resources/views/components/integration-ref.blade.php
+++ b/resources/views/components/integration-ref.blade.php
@@ -1,4 +1,4 @@
-@props(['integration', 'showStatus' => true])
+@props(['integration', 'showStatus' => true, 'text' => null])
 
 @php
 use App\Integrations\PluginRegistry;
@@ -28,20 +28,16 @@ $isProcessing = $integration->isProcessing();
 
 $statusColor = 'success';
 $statusText = 'Active';
-$statusIcon = 'fas.check-circle';
 
 if ($isPaused) {
     $statusColor = 'warning';
     $statusText = 'Paused';
-    $statusIcon = 'fas.pause-circle';
 } elseif ($isStale) {
     $statusColor = 'error';
-    $statusText = 'Stale';
-    $statusIcon = 'fas.exclamation-circle';
+    $statusText = 'Overdue';
 } elseif ($isProcessing) {
     $statusColor = 'info';
     $statusText = 'Processing';
-    $statusIcon = 'fas.spinner';
 }
 
 // Get timing info
@@ -104,9 +100,9 @@ $popoverBaseId = 'integration-ref-' . $integration->id;
                border border-{{ $accentColor }}/20 transition-all duration-150 cursor-pointer"
     >
         <x-icon :name="$icon" class="w-3 h-3 opacity-70" />
-        <span class="max-w-[180px] truncate">{{ $integration->name ?? $serviceName }}</span>
+        <span class="max-w-[180px] truncate">{!! $text ?? ($integration->name ?? $serviceName) !!}</span>
         @if ($showStatus)
-            <span class="w-2 h-2 rounded-full bg-{{ $statusColor }} {{ $isProcessing ? 'animate-pulse' : '' }}"></span>
+            <span class="status status-{{ $statusColor }} status-xs {{ $isProcessing ? 'animate-pulse' : '' }}"></span>
         @endif
     </a>
 
@@ -146,61 +142,37 @@ $popoverBaseId = 'integration-ref-' . $integration->id;
                     </div>
                 </div>
 
-                {{-- Status indicator --}}
-                <div class="flex items-center gap-2 p-2 rounded-lg bg-{{ $statusColor }}/10 border border-{{ $statusColor }}/20">
-                    <x-icon :name="$statusIcon" class="w-4 h-4 text-{{ $statusColor }} {{ $isProcessing ? 'animate-spin' : '' }}" />
-                    <span class="text-sm font-medium text-{{ $statusColor }}">{{ $statusText }}</span>
-                    @if ($isPaused)
-                        <span class="text-xs text-base-content/50 ml-auto">Updates suspended</span>
-                    @elseif ($isStale)
-                        <span class="text-xs text-base-content/50 ml-auto">No recent data</span>
-                    @elseif ($isProcessing)
-                        <span class="text-xs text-base-content/50 ml-auto">Syncing...</span>
-                    @endif
-                </div>
-
                 {{-- Timing info --}}
-                <div class="space-y-2 text-sm">
+                <div class="text-xs space-y-1.5">
                     @if ($lastUpdate)
                         <div class="flex items-center justify-between gap-2">
-                            <span class="text-base-content/60 flex items-center gap-1">
-                                <x-icon name="fas.clock-rotate-left" class="w-3 h-3" />
-                                Last updated
-                            </span>
-                            <span class="font-medium">{{ $lastUpdate->diffForHumans() }}</span>
+                            <span class="text-base-content/50">Last updated</span>
+                            <x-uk-date :date="$lastUpdate" :show-time="true" class="font-medium" />
                         </div>
                     @endif
 
                     @if ($nextUpdate && !$isPaused)
                         <div class="flex items-center justify-between gap-2">
-                            <span class="text-base-content/60 flex items-center gap-1">
-                                <x-icon name="fas.clock" class="w-3 h-3" />
-                                Next update
-                            </span>
-                            <span class="font-medium">{{ $nextUpdate->diffForHumans() }}</span>
+                            <span class="text-base-content/50">Next update</span>
+                            <x-uk-date :date="$nextUpdate" :show-time="true" class="font-medium" />
                         </div>
                     @endif
 
-                    @if ($integration->useSchedule())
-                        @php $scheduleSummary = $integration->getScheduleSummary(); @endphp
-                        @if ($scheduleSummary)
-                            <div class="flex items-center gap-2 text-xs text-base-content/50">
-                                <x-icon name="fas.calendar-days" class="w-3 h-3" />
-                                <span>{{ $scheduleSummary }}</span>
-                            </div>
+                    <div class="flex items-center justify-between gap-2 pt-1.5 border-t border-base-300">
+                        @if ($integration->useSchedule())
+                            @php $scheduleSummary = $integration->getScheduleSummary(); @endphp
+                            @if ($scheduleSummary)
+                                <span class="text-base-content/50">{{ $scheduleSummary }}</span>
+                            @endif
+                        @else
+                            <span class="text-base-content/50">Every {{ $integration->getUpdateFrequencyMinutes() }}min</span>
                         @endif
-                    @else
-                        <div class="flex items-center gap-2 text-xs text-base-content/50">
-                            <x-icon name="fas.repeat" class="w-3 h-3" />
-                            <span>Every {{ $integration->getUpdateFrequencyMinutes() }} minutes</span>
-                        </div>
-                    @endif
-                </div>
 
-                {{-- Service type badge --}}
-                <div class="flex items-center gap-2 text-xs text-base-content/50">
-                    <span class="badge badge-ghost badge-xs capitalize">{{ $serviceType }}</span>
-                    <span class="badge badge-ghost badge-xs capitalize">{{ $domain }}</span>
+                        <div class="flex items-center gap-1.5">
+                            <span class="status status-{{ $statusColor }} {{ $isProcessing ? 'animate-pulse' : '' }}"></span>
+                            <span class="font-medium">{{ $statusText }}</span>
+                        </div>
+                    </div>
                 </div>
 
                 {{-- Action footer --}}

--- a/resources/views/components/integration-ref.blade.php
+++ b/resources/views/components/integration-ref.blade.php
@@ -48,8 +48,8 @@ if ($isPaused) {
 $lastUpdate = $integration->last_successful_update_at;
 $nextUpdate = $integration->getNextUpdateTime();
 
-// Generate unique ID for this popover instance (not just per integration, but per render)
-$popoverId = 'integration-ref-' . $integration->id . '-' . Str::random(8);
+// Base ID for this popover (unique suffix added via JavaScript)
+$popoverBaseId = 'integration-ref-' . $integration->id;
 @endphp
 
 <span
@@ -57,7 +57,7 @@ $popoverId = 'integration-ref-' . $integration->id . '-' . Str::random(8);
         open: false,
         showTimeout: null,
         hideTimeout: null,
-        popoverId: '{{ $popoverId }}',
+        popoverId: '{{ $popoverBaseId }}-' + Math.random().toString(36).substring(2, 10),
         isMobile: window.innerWidth < 768,
         show() {
             if (this.isMobile) return;

--- a/resources/views/components/integration-ref.blade.php
+++ b/resources/views/components/integration-ref.blade.php
@@ -55,15 +55,20 @@ $popoverId = 'integration-ref-' . $integration->id;
 <span
     x-data="{
         open: false,
-        timeout: null,
+        showTimeout: null,
+        hideTimeout: null,
         isMobile: window.innerWidth < 768,
         show() {
             if (this.isMobile) return;
-            this.timeout = setTimeout(() => { this.open = true; }, 200);
+            clearTimeout(this.hideTimeout);
+            this.showTimeout = setTimeout(() => { this.open = true; }, 200);
         },
         hide() {
-            clearTimeout(this.timeout);
-            this.open = false;
+            clearTimeout(this.showTimeout);
+            this.hideTimeout = setTimeout(() => { this.open = false; }, 150);
+        },
+        keepOpen() {
+            clearTimeout(this.hideTimeout);
         },
         toggle() {
             if (this.isMobile) {
@@ -103,6 +108,7 @@ $popoverId = 'integration-ref-' . $integration->id;
         x-transition:leave-start="opacity-100 scale-100"
         x-transition:leave-end="opacity-0 scale-95"
         x-cloak
+        @mouseenter="keepOpen()"
         @click.outside="open = false"
         class="absolute z-50 mt-2 left-0"
         style="min-width: 300px; max-width: 360px;"

--- a/resources/views/components/integration-ref.blade.php
+++ b/resources/views/components/integration-ref.blade.php
@@ -48,8 +48,8 @@ if ($isPaused) {
 $lastUpdate = $integration->last_successful_update_at;
 $nextUpdate = $integration->getNextUpdateTime();
 
-// Generate unique ID
-$popoverId = 'integration-ref-' . $integration->id;
+// Generate unique ID for this popover instance (not just per integration, but per render)
+$popoverId = 'integration-ref-' . $integration->id . '-' . Str::random(8);
 @endphp
 
 <span

--- a/resources/views/components/integration-ref.blade.php
+++ b/resources/views/components/integration-ref.blade.php
@@ -57,11 +57,15 @@ $popoverId = 'integration-ref-' . $integration->id;
         open: false,
         showTimeout: null,
         hideTimeout: null,
+        popoverId: '{{ $popoverId }}',
         isMobile: window.innerWidth < 768,
         show() {
             if (this.isMobile) return;
             clearTimeout(this.hideTimeout);
-            this.showTimeout = setTimeout(() => { this.open = true; }, 200);
+            this.showTimeout = setTimeout(() => {
+                window.dispatchEvent(new CustomEvent('popover-opening', { detail: this.popoverId }));
+                this.open = true;
+            }, 200);
         },
         hide() {
             clearTimeout(this.showTimeout);
@@ -72,12 +76,20 @@ $popoverId = 'integration-ref-' . $integration->id;
         },
         toggle() {
             if (this.isMobile) {
+                window.dispatchEvent(new CustomEvent('popover-opening', { detail: this.popoverId }));
                 this.open = !this.open;
+            }
+        },
+        closeIfNotMe(event) {
+            if (event.detail !== this.popoverId) {
+                clearTimeout(this.showTimeout);
+                this.open = false;
             }
         }
     }"
     @mouseenter="show()"
     @mouseleave="hide()"
+    @popover-opening.window="closeIfNotMe($event)"
     @click="toggle()"
     @keydown.escape="open = false"
     class="relative inline-block"

--- a/resources/views/components/object-ref.blade.php
+++ b/resources/views/components/object-ref.blade.php
@@ -51,15 +51,20 @@ $relationshipCount = $object->allRelationships()->count();
 <span
     x-data="{
         open: false,
-        timeout: null,
+        showTimeout: null,
+        hideTimeout: null,
         isMobile: window.innerWidth < 768,
         show() {
             if (this.isMobile) return;
-            this.timeout = setTimeout(() => { this.open = true; }, 200);
+            clearTimeout(this.hideTimeout);
+            this.showTimeout = setTimeout(() => { this.open = true; }, 200);
         },
         hide() {
-            clearTimeout(this.timeout);
-            this.open = false;
+            clearTimeout(this.showTimeout);
+            this.hideTimeout = setTimeout(() => { this.open = false; }, 150);
+        },
+        keepOpen() {
+            clearTimeout(this.hideTimeout);
         },
         toggle() {
             if (this.isMobile) {
@@ -99,6 +104,7 @@ $relationshipCount = $object->allRelationships()->count();
         x-transition:leave-start="opacity-100 scale-100"
         x-transition:leave-end="opacity-0 scale-95"
         x-cloak
+        @mouseenter="keepOpen()"
         @click.outside="open = false"
         class="absolute z-50 mt-2 left-0"
         style="min-width: 320px; max-width: 380px;"

--- a/resources/views/components/object-ref.blade.php
+++ b/resources/views/components/object-ref.blade.php
@@ -1,4 +1,4 @@
-@props(['object', 'showType' => false])
+@props(['object', 'showType' => false, 'variant' => 'badge', 'href' => null])
 
 @php
 use App\Integrations\PluginRegistry;
@@ -24,6 +24,20 @@ $conceptDisplay = Str::headline($object->concept ?? '');
 // Generate unique ID for this popover
 $popoverId = 'object-ref-' . $object->id;
 
+// Try to get icon from plugin object types config
+$objectIcon = 'fas.cube'; // default
+$objectTypes = [];
+
+// Find the plugin that defines this object type
+foreach (PluginRegistry::all() as $pluginClass) {
+    $types = $pluginClass::getObjectTypes();
+    if (isset($types[$object->type])) {
+        $objectTypes = $types[$object->type];
+        $objectIcon = $objectTypes['icon'] ?? 'fas.cube';
+        break;
+    }
+}
+
 // Determine accent color based on concept
 $accentColors = [
     'user' => 'secondary',
@@ -46,6 +60,9 @@ foreach ($accentColors as $key => $color) {
 // Event counts
 $eventCount = $object->actorEvents()->count() + $object->targetEvents()->count();
 $relationshipCount = $object->allRelationships()->count();
+
+// Default href to object show page
+$linkHref = $href ?? route('objects.show', $object);
 @endphp
 
 <span
@@ -78,21 +95,31 @@ $relationshipCount = $object->allRelationships()->count();
     @keydown.escape="open = false"
     class="relative inline-block"
 >
-    {{-- Trigger: The reference link/badge --}}
+    {{-- Trigger: Badge variant (default) --}}
+    @if ($variant === 'badge')
     <a
-        href="{{ route('objects.show', $object) }}"
+        href="{{ $linkHref }}"
         wire:navigate
         @click.stop="if (isMobile) { $event.preventDefault(); toggle(); }"
         class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md text-sm font-medium
                bg-{{ $accentColor }}/10 text-{{ $accentColor }} hover:bg-{{ $accentColor }}/20
                border border-{{ $accentColor }}/20 transition-all duration-150 cursor-pointer"
     >
-        <x-icon name="fas.cube" class="w-3 h-3 opacity-70" />
+        <x-icon :name="$objectIcon" class="w-3 h-3 opacity-70" />
         <span class="max-w-[200px] truncate">{{ $object->title }}</span>
         @if ($showType && $object->type)
             <span class="badge badge-xs badge-ghost opacity-70">{{ $typeDisplay }}</span>
         @endif
     </a>
+    @else
+    {{-- Trigger: Text variant (plain text with hover) --}}
+    <a
+        href="{{ $linkHref }}"
+        wire:navigate
+        @click.stop="if (isMobile) { $event.preventDefault(); toggle(); }"
+        class="font-medium hover:text-{{ $accentColor }} transition-colors cursor-pointer"
+    >{{ $object->title }}</a>
+    @endif
 
     {{-- Popover Card --}}
     <div
@@ -114,16 +141,16 @@ $relationshipCount = $object->allRelationships()->count();
             <div class="h-1 bg-gradient-to-r from-{{ $accentColor }} to-{{ $accentColor }}/50"></div>
 
             <div class="card-body p-4 gap-3">
-                {{-- Header with thumbnail and title --}}
+                {{-- Header with thumbnail/icon and title --}}
                 <div class="flex gap-3">
-                    {{-- Thumbnail --}}
+                    {{-- Thumbnail or Icon --}}
                     @if ($thumbnailUrl)
                         <div class="w-16 h-16 rounded-lg overflow-hidden bg-base-300 flex-shrink-0 ring-2 ring-{{ $accentColor }}/20">
                             <img src="{{ $thumbnailUrl }}" alt="{{ $object->title }}" class="w-full h-full object-cover">
                         </div>
                     @else
-                        <div class="w-16 h-16 rounded-lg bg-{{ $accentColor }}/10 flex items-center justify-center flex-shrink-0">
-                            <x-icon name="fas.cube" class="w-8 h-8 text-{{ $accentColor }}/50" />
+                        <div class="w-16 h-16 rounded-lg bg-{{ $accentColor }}/10 flex items-center justify-center flex-shrink-0 ring-2 ring-{{ $accentColor }}/20">
+                            <x-icon :name="$objectIcon" class="w-8 h-8 text-{{ $accentColor }}" />
                         </div>
                     @endif
 
@@ -134,7 +161,10 @@ $relationshipCount = $object->allRelationships()->count();
                         </h4>
                         <div class="flex flex-wrap gap-1">
                             @if ($object->type)
-                                <span class="badge badge-{{ $accentColor }} badge-outline badge-xs">{{ $typeDisplay }}</span>
+                                <span class="badge badge-{{ $accentColor }} badge-outline badge-xs gap-1">
+                                    <x-icon :name="$objectIcon" class="w-2.5 h-2.5" />
+                                    {{ $typeDisplay }}
+                                </span>
                             @endif
                             @if ($conceptDisplay)
                                 <span class="badge badge-ghost badge-xs">{{ $conceptDisplay }}</span>

--- a/resources/views/components/object-ref.blade.php
+++ b/resources/views/components/object-ref.blade.php
@@ -29,7 +29,7 @@ $objectIcon = 'fas.cube'; // default
 $objectTypes = [];
 
 // Find the plugin that defines this object type
-foreach (PluginRegistry::all() as $pluginClass) {
+foreach (PluginRegistry::getAllPlugins() as $pluginClass) {
     $types = $pluginClass::getObjectTypes();
     if (isset($types[$object->type])) {
         $objectTypes = $types[$object->type];

--- a/resources/views/components/object-ref.blade.php
+++ b/resources/views/components/object-ref.blade.php
@@ -70,11 +70,15 @@ $linkHref = $href ?? route('objects.show', $object);
         open: false,
         showTimeout: null,
         hideTimeout: null,
+        popoverId: '{{ $popoverId }}',
         isMobile: window.innerWidth < 768,
         show() {
             if (this.isMobile) return;
             clearTimeout(this.hideTimeout);
-            this.showTimeout = setTimeout(() => { this.open = true; }, 200);
+            this.showTimeout = setTimeout(() => {
+                window.dispatchEvent(new CustomEvent('popover-opening', { detail: this.popoverId }));
+                this.open = true;
+            }, 200);
         },
         hide() {
             clearTimeout(this.showTimeout);
@@ -85,7 +89,14 @@ $linkHref = $href ?? route('objects.show', $object);
         },
         toggle() {
             if (this.isMobile) {
+                window.dispatchEvent(new CustomEvent('popover-opening', { detail: this.popoverId }));
                 this.open = !this.open;
+            }
+        },
+        closeIfNotMe(event) {
+            if (event.detail !== this.popoverId) {
+                clearTimeout(this.showTimeout);
+                this.open = false;
             }
         }
     }"
@@ -93,6 +104,7 @@ $linkHref = $href ?? route('objects.show', $object);
     @mouseleave="hide()"
     @click="toggle()"
     @keydown.escape="open = false"
+    @popover-opening.window="closeIfNotMe($event)"
     class="relative inline-block"
 >
     {{-- Trigger: Badge variant (default) --}}

--- a/resources/views/components/object-ref.blade.php
+++ b/resources/views/components/object-ref.blade.php
@@ -1,4 +1,4 @@
-@props(['object', 'showType' => false, 'variant' => 'badge', 'href' => null])
+@props(['object', 'showType' => false, 'variant' => 'badge', 'href' => null, 'text' => null])
 
 @php
 use App\Integrations\PluginRegistry;
@@ -118,7 +118,7 @@ $linkHref = $href ?? route('objects.show', $object);
                border border-{{ $accentColor }}/20 transition-all duration-150 cursor-pointer"
     >
         <x-icon :name="$objectIcon" class="w-3 h-3 opacity-70" />
-        <span class="max-w-[200px] truncate">{{ $object->title }}</span>
+        <span class="max-w-[200px] truncate">{!! $text ?? $object->title !!}</span>
         @if ($showType && $object->type)
             <span class="badge badge-xs badge-ghost opacity-70">{{ $typeDisplay }}</span>
         @endif
@@ -130,7 +130,7 @@ $linkHref = $href ?? route('objects.show', $object);
         wire:navigate
         @click.stop="if (isMobile) { $event.preventDefault(); toggle(); }"
         class="font-medium hover:text-{{ $accentColor }} transition-colors cursor-pointer"
-    >{{ $object->title }}</a>
+    >{!! $text ?? $object->title !!}</a>
     @endif
 
     {{-- Popover Card --}}

--- a/resources/views/components/object-ref.blade.php
+++ b/resources/views/components/object-ref.blade.php
@@ -1,0 +1,216 @@
+@props(['object', 'showType' => false])
+
+@php
+use App\Integrations\PluginRegistry;
+
+// Handle null objects gracefully
+if (!$object) {
+    return;
+}
+
+// Get media thumbnail URL
+$thumbnailUrl = get_media_temporary_url($object, 'article_images', 'thumbnail', 60)
+    ?? get_media_temporary_url($object, 'downloaded_images', 'thumbnail', 60)
+    ?? get_media_temporary_url($object, 'screenshots', 'thumbnail', 60)
+    ?? $object->media_url;
+
+// Content preview
+$contentPreview = $object->content ? Str::limit(strip_tags($object->content), 100) : null;
+
+// Get type info from metadata if available
+$typeDisplay = Str::headline($object->type ?? 'Object');
+$conceptDisplay = Str::headline($object->concept ?? '');
+
+// Generate unique ID for this popover
+$popoverId = 'object-ref-' . $object->id;
+
+// Determine accent color based on concept
+$accentColors = [
+    'user' => 'secondary',
+    'person' => 'secondary',
+    'account' => 'warning',
+    'money' => 'warning',
+    'media' => 'info',
+    'bookmark' => 'primary',
+    'document' => 'primary',
+    'day' => 'accent',
+];
+$accentColor = 'secondary';
+foreach ($accentColors as $key => $color) {
+    if (str_contains(strtolower($object->concept ?? ''), $key)) {
+        $accentColor = $color;
+        break;
+    }
+}
+
+// Event counts
+$eventCount = $object->actorEvents()->count() + $object->targetEvents()->count();
+$relationshipCount = $object->allRelationships()->count();
+@endphp
+
+<span
+    x-data="{
+        open: false,
+        timeout: null,
+        isMobile: window.innerWidth < 768,
+        show() {
+            if (this.isMobile) return;
+            this.timeout = setTimeout(() => { this.open = true; }, 200);
+        },
+        hide() {
+            clearTimeout(this.timeout);
+            this.open = false;
+        },
+        toggle() {
+            if (this.isMobile) {
+                this.open = !this.open;
+            }
+        }
+    }"
+    @mouseenter="show()"
+    @mouseleave="hide()"
+    @click="toggle()"
+    @keydown.escape="open = false"
+    class="relative inline-block"
+>
+    {{-- Trigger: The reference link/badge --}}
+    <a
+        href="{{ route('objects.show', $object) }}"
+        wire:navigate
+        @click.stop="if (isMobile) { $event.preventDefault(); toggle(); }"
+        class="inline-flex items-center gap-1.5 px-2 py-0.5 rounded-md text-sm font-medium
+               bg-{{ $accentColor }}/10 text-{{ $accentColor }} hover:bg-{{ $accentColor }}/20
+               border border-{{ $accentColor }}/20 transition-all duration-150 cursor-pointer"
+    >
+        <x-icon name="fas.cube" class="w-3 h-3 opacity-70" />
+        <span class="max-w-[200px] truncate">{{ $object->title }}</span>
+        @if ($showType && $object->type)
+            <span class="badge badge-xs badge-ghost opacity-70">{{ $typeDisplay }}</span>
+        @endif
+    </a>
+
+    {{-- Popover Card --}}
+    <div
+        x-show="open"
+        x-transition:enter="transition ease-out duration-150"
+        x-transition:enter-start="opacity-0 scale-95 translate-y-1"
+        x-transition:enter-end="opacity-100 scale-100 translate-y-0"
+        x-transition:leave="transition ease-in duration-100"
+        x-transition:leave-start="opacity-100 scale-100"
+        x-transition:leave-end="opacity-0 scale-95"
+        x-cloak
+        @click.outside="open = false"
+        class="absolute z-50 mt-2 left-0"
+        style="min-width: 320px; max-width: 380px;"
+    >
+        <div class="card bg-base-100 shadow-xl border border-{{ $accentColor }}/30 overflow-hidden">
+            {{-- Accent bar at top --}}
+            <div class="h-1 bg-gradient-to-r from-{{ $accentColor }} to-{{ $accentColor }}/50"></div>
+
+            <div class="card-body p-4 gap-3">
+                {{-- Header with thumbnail and title --}}
+                <div class="flex gap-3">
+                    {{-- Thumbnail --}}
+                    @if ($thumbnailUrl)
+                        <div class="w-16 h-16 rounded-lg overflow-hidden bg-base-300 flex-shrink-0 ring-2 ring-{{ $accentColor }}/20">
+                            <img src="{{ $thumbnailUrl }}" alt="{{ $object->title }}" class="w-full h-full object-cover">
+                        </div>
+                    @else
+                        <div class="w-16 h-16 rounded-lg bg-{{ $accentColor }}/10 flex items-center justify-center flex-shrink-0">
+                            <x-icon name="fas.cube" class="w-8 h-8 text-{{ $accentColor }}/50" />
+                        </div>
+                    @endif
+
+                    {{-- Title and type info --}}
+                    <div class="flex-1 min-w-0">
+                        <h4 class="font-bold text-base leading-tight line-clamp-2 mb-1">
+                            {{ $object->title }}
+                        </h4>
+                        <div class="flex flex-wrap gap-1">
+                            @if ($object->type)
+                                <span class="badge badge-{{ $accentColor }} badge-outline badge-xs">{{ $typeDisplay }}</span>
+                            @endif
+                            @if ($conceptDisplay)
+                                <span class="badge badge-ghost badge-xs">{{ $conceptDisplay }}</span>
+                            @endif
+                        </div>
+                    </div>
+                </div>
+
+                {{-- Content preview --}}
+                @if ($contentPreview)
+                    <p class="text-sm text-base-content/70 line-clamp-2 leading-relaxed">
+                        {{ $contentPreview }}
+                    </p>
+                @endif
+
+                {{-- Stats row --}}
+                <div class="flex items-center gap-4 text-xs text-base-content/60">
+                    @if ($eventCount > 0)
+                        <div class="flex items-center gap-1">
+                            <x-icon name="fas.bolt" class="w-3 h-3" />
+                            <span>{{ $eventCount }} event{{ $eventCount !== 1 ? 's' : '' }}</span>
+                        </div>
+                    @endif
+                    @if ($relationshipCount > 0)
+                        <div class="flex items-center gap-1">
+                            <x-icon name="fas.link" class="w-3 h-3" />
+                            <span>{{ $relationshipCount }} link{{ $relationshipCount !== 1 ? 's' : '' }}</span>
+                        </div>
+                    @endif
+                    @if ($object->time)
+                        <div class="flex items-center gap-1 ml-auto">
+                            <x-icon name="fas.clock" class="w-3 h-3" />
+                            <span>{{ $object->time->diffForHumans() }}</span>
+                        </div>
+                    @endif
+                </div>
+
+                {{-- Tags preview (if any) --}}
+                @if ($object->tags->count() > 0)
+                    <div class="flex flex-wrap gap-1">
+                        @foreach ($object->tags->take(4) as $tag)
+                            <span class="badge badge-ghost badge-xs">{{ $tag->name }}</span>
+                        @endforeach
+                        @if ($object->tags->count() > 4)
+                            <span class="badge badge-ghost badge-xs">+{{ $object->tags->count() - 4 }} more</span>
+                        @endif
+                    </div>
+                @endif
+
+                {{-- URL indicator --}}
+                @if ($object->url)
+                    <div class="flex items-center gap-1 text-xs text-base-content/50 truncate">
+                        <x-icon name="fas.link" class="w-3 h-3 flex-shrink-0" />
+                        <span class="truncate">{{ parse_url($object->url, PHP_URL_HOST) }}</span>
+                    </div>
+                @endif
+
+                {{-- Action footer --}}
+                <div class="flex items-center gap-2 pt-3 border-t border-base-300">
+                    <a
+                        href="{{ route('objects.show', $object) }}"
+                        wire:navigate
+                        @click.stop
+                        class="btn btn-{{ $accentColor }} btn-sm flex-1 gap-1"
+                    >
+                        <x-icon name="fas.arrow-right" class="w-3 h-3" />
+                        View Object
+                    </a>
+                    @if ($object->url)
+                        <a
+                            href="{{ $object->url }}"
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            @click.stop
+                            class="btn btn-ghost btn-sm btn-square"
+                            title="Open URL"
+                        >
+                            <x-icon name="o-arrow-top-right-on-square" class="w-4 h-4" />
+                        </a>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+</span>

--- a/resources/views/components/object-ref.blade.php
+++ b/resources/views/components/object-ref.blade.php
@@ -21,8 +21,8 @@ $contentPreview = $object->content ? Str::limit(strip_tags($object->content), 10
 $typeDisplay = Str::headline($object->type ?? 'Object');
 $conceptDisplay = Str::headline($object->concept ?? '');
 
-// Generate unique ID for this popover instance (not just per object, but per render)
-$popoverId = 'object-ref-' . $object->id . '-' . Str::random(8);
+// Base ID for this popover (unique suffix added via JavaScript)
+$popoverBaseId = 'object-ref-' . $object->id;
 
 // Try to get icon from plugin object types config
 $objectIcon = 'fas.cube'; // default
@@ -70,7 +70,7 @@ $linkHref = $href ?? route('objects.show', $object);
         open: false,
         showTimeout: null,
         hideTimeout: null,
-        popoverId: '{{ $popoverId }}',
+        popoverId: '{{ $popoverBaseId }}-' + Math.random().toString(36).substring(2, 10),
         isMobile: window.innerWidth < 768,
         show() {
             if (this.isMobile) return;

--- a/resources/views/components/object-ref.blade.php
+++ b/resources/views/components/object-ref.blade.php
@@ -21,8 +21,8 @@ $contentPreview = $object->content ? Str::limit(strip_tags($object->content), 10
 $typeDisplay = Str::headline($object->type ?? 'Object');
 $conceptDisplay = Str::headline($object->concept ?? '');
 
-// Generate unique ID for this popover
-$popoverId = 'object-ref-' . $object->id;
+// Generate unique ID for this popover instance (not just per object, but per render)
+$popoverId = 'object-ref-' . $object->id . '-' . Str::random(8);
 
 // Try to get icon from plugin object types config
 $objectIcon = 'fas.cube'; // default

--- a/resources/views/components/spark-tag.blade.php
+++ b/resources/views/components/spark-tag.blade.php
@@ -1,4 +1,4 @@
-@props(['tag', 'full' => false, 'fill' => false, 'size' => 'sm'])
+@props(['tag', 'full' => false, 'fill' => false, 'size' => 'sm', 'showCounts' => false])
 
 @php
 // Handle both objects and arrays
@@ -6,70 +6,228 @@ $isObject = is_object($tag);
 $isArray = is_array($tag);
 
 if ($isObject) {
-$tagName = is_array($tag->name ?? null) ? ($tag->name['en'] ?? $tag->name[0] ?? '') : (string)($tag->name ?? '');
-$tagType = $tag->type ?? null;
-$tagId = $tag->id ?? null;
-$tagSlug = is_array($tag->slug ?? null) ? ($tag->slug['en'] ?? $tag->slug[0] ?? null) : ($tag->slug ?? null);
+    $tagName = is_array($tag->name ?? null) ? ($tag->name['en'] ?? $tag->name[0] ?? '') : (string)($tag->name ?? '');
+    $tagType = $tag->type ?? null;
+    $tagId = $tag->id ?? null;
+    $tagSlug = is_array($tag->slug ?? null) ? ($tag->slug['en'] ?? $tag->slug[0] ?? null) : ($tag->slug ?? null);
+    // Get counts if available (from withCount on the tag model)
+    $eventsCount = $tag->events_count ?? null;
+    $objectsCount = $tag->objects_count ?? null;
 } elseif ($isArray) {
-$tagName = is_array($tag['name'] ?? null) ? ($tag['name']['en'] ?? $tag['name'][0] ?? '') : (string)($tag['name'] ?? '');
-$tagType = $tag['type'] ?? null;
-$tagId = $tag['id'] ?? null;
-$tagSlug = is_array($tag['slug'] ?? null) ? ($tag['slug']['en'] ?? $tag['slug'][0] ?? null) : ($tag['slug'] ?? null);
+    $tagName = is_array($tag['name'] ?? null) ? ($tag['name']['en'] ?? $tag['name'][0] ?? '') : (string)($tag['name'] ?? '');
+    $tagType = $tag['type'] ?? null;
+    $tagId = $tag['id'] ?? null;
+    $tagSlug = is_array($tag['slug'] ?? null) ? ($tag['slug']['en'] ?? $tag['slug'][0] ?? null) : ($tag['slug'] ?? null);
+    $eventsCount = $tag['events_count'] ?? null;
+    $objectsCount = $tag['objects_count'] ?? null;
 } else {
-$tagName = (string)$tag;
-$tagType = null;
-$tagId = null;
-$tagSlug = null;
+    $tagName = (string)$tag;
+    $tagType = null;
+    $tagId = null;
+    $tagSlug = null;
+    $eventsCount = null;
+    $objectsCount = null;
 }
-
-$uuid = 'tag-' . md5($tagName . ($tagId ?? ''));
 
 // Truncate long tag names
 $displayName = $tagName;
-if (!$full && strlen($tagName) > 20) {
-$spacePos = strpos($tagName, ' ');
-$cut = $spacePos === false || $spacePos > 20;
-$wrapped = wordwrap($tagName, 20, ';;', $cut);
-$parts = explode(';;', $wrapped);
-$displayName = $parts[0] . '...';
+if (!$full && mb_strlen($tagName) > 20) {
+    $spacePos = mb_strpos($tagName, ' ');
+    $cut = $spacePos === false || $spacePos > 20;
+    $wrapped = wordwrap($tagName, 20, ';;', $cut);
+    $parts = explode(';;', $wrapped);
+    $displayName = $parts[0] . '...';
 }
 
-// Determine popover color based on badge color
-$color = match($tagType) {
-'transaction_category', 'transaction_type', 'transaction_status', 'transaction_scheme',
-'transaction_currency', 'balance_type', 'card_pan', 'decline_reason', 'merchant_country', 'merchant_category', 'music_album', 'spotify_context', 'karakeep' => 'info',
-'music_artist', 'person' => 'secondary',
-'emoji', 'merchant_emoji' => 'warning',
-'spark' => 'primary',
-default => 'info',
-};
+// Determine color based on tag type with more variety
+$colorMap = [
+    // Money-related tags
+    'transaction_category' => 'warning',
+    'transaction_type' => 'warning',
+    'transaction_status' => 'warning',
+    'transaction_scheme' => 'warning',
+    'transaction_currency' => 'warning',
+    'balance_type' => 'warning',
+    'card_pan' => 'warning',
+    'decline_reason' => 'error',
+    'merchant_country' => 'info',
+    'merchant_category' => 'info',
 
-// Determine badge color based on tag type
+    // Music/Media tags
+    'music_artist' => 'secondary',
+    'music_album' => 'accent',
+    'spotify_context' => 'success',
+
+    // People
+    'person' => 'secondary',
+
+    // Emoji/Visual
+    'emoji' => 'warning',
+    'merchant_emoji' => 'warning',
+
+    // System
+    'spark' => 'primary',
+    'karakeep' => 'info',
+];
+
+$color = $colorMap[$tagType] ?? 'info';
+
+// Determine icon based on tag type
+$iconMap = [
+    'transaction_category' => 'fas.folder',
+    'transaction_type' => 'fas.exchange-alt',
+    'transaction_status' => 'fas.check-circle',
+    'transaction_scheme' => 'fas.credit-card',
+    'transaction_currency' => 'fas.coins',
+    'merchant_category' => 'fas.store',
+    'merchant_country' => 'fas.globe',
+    'music_artist' => 'fas.microphone',
+    'music_album' => 'fas.compact-disc',
+    'spotify_context' => 'fab.spotify',
+    'person' => 'fas.user',
+    'emoji' => 'fas.face-smile',
+    'merchant_emoji' => 'fas.face-smile',
+    'spark' => 'fas.star',
+    'karakeep' => 'fas.bookmark',
+];
+$tagIcon = $iconMap[$tagType] ?? 'fas.tag';
+
+// Badge styling
 $badgeClass = "badge-{$color}";
-
 if (!$fill) {
-$badgeClass .= ' badge-outline';
+    $badgeClass .= ' badge-outline';
 }
 
-// Add size class
 $sizeClass = match($size) {
-'xs' => 'badge-xs',
-'sm' => 'badge-sm',
-'md' => 'badge-md',
-'lg' => 'badge-lg',
-default => 'badge-sm',
+    'xs' => 'badge-xs',
+    'sm' => 'badge-sm',
+    'md' => 'badge-md',
+    'lg' => 'badge-lg',
+    default => 'badge-sm',
 };
-
 $badgeClass .= ' ' . $sizeClass;
+
+// Check if tag is linkable
+$isLinkable = $tagType && $tagSlug && $tagId;
 @endphp
 
-<x-popover class="inline-block bg-{{ $color }}">
-    <x-slot:trigger>
-        <x-badge class="{{ $badgeClass }}">
-            <x-slot:value>
-                {{ $displayName }}
-            </x-slot:value>
-        </x-badge>
-    </x-slot:trigger>
-    <x-slot:content class="bg-{{ $color }} text-{{ $color }}-content text-center border-{{ $color }}/40">@if ($tagType && $tagSlug && $tagId)<a href="{{ route('tags.show', [$tagType, $tagSlug, $tagId]) }}"><x-fas-tags class="w-4 h-4 inline" /> {{ Str::headline($tagType ?? 'Tag') }}<br /><span class="font-bold text-base text-center">{{ $tagName }}</span></a>@else<div><x-fas-tags class="w-4 h-4 inline" /> {{ Str::headline($tagType ?? 'Tag') }}<br /><span class="font-bold text-base text-center">{{ $tagName }}</span></div>@endif</x-slot:content>
-</x-popover>
+<span
+    x-data="{
+        open: false,
+        timeout: null,
+        isMobile: window.innerWidth < 768,
+        show() {
+            if (this.isMobile) return;
+            this.timeout = setTimeout(() => { this.open = true; }, 200);
+        },
+        hide() {
+            clearTimeout(this.timeout);
+            this.open = false;
+        },
+        toggle() {
+            if (this.isMobile) {
+                this.open = !this.open;
+            }
+        }
+    }"
+    @mouseenter="show()"
+    @mouseleave="hide()"
+    @click="toggle()"
+    @keydown.escape="open = false"
+    class="relative inline-block"
+>
+    {{-- Trigger: The tag badge --}}
+    @if ($isLinkable)
+        <a
+            href="{{ route('tags.show', [$tagType, $tagSlug, $tagId]) }}"
+            wire:navigate
+            @click.stop="if (isMobile) { $event.preventDefault(); toggle(); }"
+            class="badge {{ $badgeClass }} gap-1 cursor-pointer hover:brightness-110 transition-all"
+        >
+            <x-icon :name="$tagIcon" class="w-3 h-3 opacity-70" />
+            <span>{{ $displayName }}</span>
+        </a>
+    @else
+        <span
+            @click.stop="toggle()"
+            class="badge {{ $badgeClass }} gap-1 cursor-default"
+        >
+            <x-icon :name="$tagIcon" class="w-3 h-3 opacity-70" />
+            <span>{{ $displayName }}</span>
+        </span>
+    @endif
+
+    {{-- Popover Card --}}
+    <div
+        x-show="open"
+        x-transition:enter="transition ease-out duration-150"
+        x-transition:enter-start="opacity-0 scale-95 translate-y-1"
+        x-transition:enter-end="opacity-100 scale-100 translate-y-0"
+        x-transition:leave="transition ease-in duration-100"
+        x-transition:leave-start="opacity-100 scale-100"
+        x-transition:leave-end="opacity-0 scale-95"
+        x-cloak
+        @click.outside="open = false"
+        class="absolute z-50 mt-2 left-0"
+        style="min-width: 200px; max-width: 280px;"
+    >
+        <div class="card bg-base-100 shadow-xl border border-{{ $color }}/30 overflow-hidden">
+            {{-- Accent bar --}}
+            <div class="h-1 bg-gradient-to-r from-{{ $color }} to-{{ $color }}/50"></div>
+
+            <div class="card-body p-4 gap-3">
+                {{-- Header with icon --}}
+                <div class="flex items-center gap-3">
+                    <div class="w-10 h-10 rounded-lg bg-{{ $color }}/10 flex items-center justify-center flex-shrink-0 ring-2 ring-{{ $color }}/20">
+                        <x-icon :name="$tagIcon" class="w-5 h-5 text-{{ $color }}" />
+                    </div>
+                    <div class="flex-1 min-w-0">
+                        <div class="text-xs text-base-content/60 uppercase tracking-wide font-medium">
+                            {{ Str::headline($tagType ?? 'Tag') }}
+                        </div>
+                        <div class="font-bold text-base leading-tight truncate" title="{{ $tagName }}">
+                            {{ $tagName }}
+                        </div>
+                    </div>
+                </div>
+
+                {{-- Counts (if available and requested) --}}
+                @if ($showCounts && ($eventsCount !== null || $objectsCount !== null))
+                    <div class="flex items-center gap-4 text-sm text-base-content/60">
+                        @if ($eventsCount !== null)
+                            <div class="flex items-center gap-1">
+                                <x-icon name="fas.bolt" class="w-3 h-3" />
+                                <span>{{ number_format($eventsCount) }} event{{ $eventsCount !== 1 ? 's' : '' }}</span>
+                            </div>
+                        @endif
+                        @if ($objectsCount !== null)
+                            <div class="flex items-center gap-1">
+                                <x-icon name="fas.cube" class="w-3 h-3" />
+                                <span>{{ number_format($objectsCount) }} object{{ $objectsCount !== 1 ? 's' : '' }}</span>
+                            </div>
+                        @endif
+                    </div>
+                @endif
+
+                {{-- Action footer --}}
+                @if ($isLinkable)
+                    <div class="pt-3 border-t border-base-300">
+                        <a
+                            href="{{ route('tags.show', [$tagType, $tagSlug, $tagId]) }}"
+                            wire:navigate
+                            @click.stop
+                            class="btn btn-{{ $color }} btn-sm w-full gap-1"
+                        >
+                            <x-icon name="fas.arrow-right" class="w-3 h-3" />
+                            View Tagged Items
+                        </a>
+                    </div>
+                @else
+                    <div class="text-xs text-base-content/50 text-center pt-2 border-t border-base-300">
+                        This tag is not linkable
+                    </div>
+                @endif
+            </div>
+        </div>
+    </div>
+</span>

--- a/resources/views/components/spark-tag.blade.php
+++ b/resources/views/components/spark-tag.blade.php
@@ -109,6 +109,9 @@ $badgeClass .= ' ' . $sizeClass;
 
 // Check if tag is linkable
 $isLinkable = $tagType && $tagSlug && $tagId;
+
+// Generate unique ID for this popover
+$popoverId = 'spark-tag-' . ($tagId ?? md5($tagName . ($tagType ?? '')));
 @endphp
 
 <span
@@ -116,11 +119,15 @@ $isLinkable = $tagType && $tagSlug && $tagId;
         open: false,
         showTimeout: null,
         hideTimeout: null,
+        popoverId: '{{ $popoverId }}',
         isMobile: window.innerWidth < 768,
         show() {
             if (this.isMobile) return;
             clearTimeout(this.hideTimeout);
-            this.showTimeout = setTimeout(() => { this.open = true; }, 200);
+            this.showTimeout = setTimeout(() => {
+                window.dispatchEvent(new CustomEvent('popover-opening', { detail: this.popoverId }));
+                this.open = true;
+            }, 200);
         },
         hide() {
             clearTimeout(this.showTimeout);
@@ -131,7 +138,14 @@ $isLinkable = $tagType && $tagSlug && $tagId;
         },
         toggle() {
             if (this.isMobile) {
+                window.dispatchEvent(new CustomEvent('popover-opening', { detail: this.popoverId }));
                 this.open = !this.open;
+            }
+        },
+        closeIfNotMe(event) {
+            if (event.detail !== this.popoverId) {
+                clearTimeout(this.showTimeout);
+                this.open = false;
             }
         }
     }"
@@ -139,6 +153,7 @@ $isLinkable = $tagType && $tagSlug && $tagId;
     @mouseleave="hide()"
     @click="toggle()"
     @keydown.escape="open = false"
+    @popover-opening.window="closeIfNotMe($event)"
     class="relative inline-block"
 >
     {{-- Trigger: The tag badge --}}

--- a/resources/views/components/spark-tag.blade.php
+++ b/resources/views/components/spark-tag.blade.php
@@ -114,15 +114,20 @@ $isLinkable = $tagType && $tagSlug && $tagId;
 <span
     x-data="{
         open: false,
-        timeout: null,
+        showTimeout: null,
+        hideTimeout: null,
         isMobile: window.innerWidth < 768,
         show() {
             if (this.isMobile) return;
-            this.timeout = setTimeout(() => { this.open = true; }, 200);
+            clearTimeout(this.hideTimeout);
+            this.showTimeout = setTimeout(() => { this.open = true; }, 200);
         },
         hide() {
-            clearTimeout(this.timeout);
-            this.open = false;
+            clearTimeout(this.showTimeout);
+            this.hideTimeout = setTimeout(() => { this.open = false; }, 150);
+        },
+        keepOpen() {
+            clearTimeout(this.hideTimeout);
         },
         toggle() {
             if (this.isMobile) {
@@ -167,6 +172,7 @@ $isLinkable = $tagType && $tagSlug && $tagId;
         x-transition:leave-start="opacity-100 scale-100"
         x-transition:leave-end="opacity-0 scale-95"
         x-cloak
+        @mouseenter="keepOpen()"
         @click.outside="open = false"
         class="absolute z-50 mt-2 left-0"
         style="min-width: 200px; max-width: 280px;"

--- a/resources/views/components/tag-ref.blade.php
+++ b/resources/views/components/tag-ref.blade.php
@@ -1,4 +1,4 @@
-@props(['tag', 'full' => false, 'fill' => false, 'size' => 'sm', 'showCounts' => false])
+@props(['tag', 'full' => false, 'fill' => false, 'size' => 'sm', 'showCounts' => false, 'text' => null])
 
 @php
 // Handle both objects and arrays
@@ -165,7 +165,7 @@ $popoverId = 'spark-tag-' . ($tagId ?? md5($tagName . ($tagType ?? '')));
             class="badge {{ $badgeClass }} gap-1 cursor-pointer hover:brightness-110 transition-all"
         >
             <x-icon :name="$tagIcon" class="w-3 h-3 opacity-70" />
-            <span>{{ $displayName }}</span>
+            <span>{!! $text ?? $displayName !!}</span>
         </a>
     @else
         <span
@@ -173,7 +173,7 @@ $popoverId = 'spark-tag-' . ($tagId ?? md5($tagName . ($tagType ?? '')));
             class="badge {{ $badgeClass }} gap-1 cursor-default"
         >
             <x-icon :name="$tagIcon" class="w-3 h-3 opacity-70" />
-            <span>{{ $displayName }}</span>
+            <span>{!! $text ?? $displayName !!}</span>
         </span>
     @endif
 

--- a/resources/views/livewire/admin/activity.blade.php
+++ b/resources/views/livewire/admin/activity.blade.php
@@ -486,14 +486,21 @@ new class extends Component
                     @endscope
 
                     @scope('cell_subject_type', $activity)
-                    @if ($this->getSubjectUrl($activity))
-                    <a href="{{ $this->getSubjectUrl($activity) }}" class="link font-medium">
-                        {{ Str::limit($this->getSubjectTitle($activity), 30) }}
-                    </a>
+                    @if ($activity->subject)
+                        @if ($activity->subject instanceof \App\Models\Event)
+                            <x-event-ref :event="$activity->subject" :showService="false" />
+                        @elseif ($activity->subject instanceof \App\Models\EventObject)
+                            <x-object-ref :object="$activity->subject" />
+                        @elseif ($activity->subject instanceof \App\Models\Block)
+                            <x-block-ref :block="$activity->subject" :showType="false" />
+                        @else
+                            <span class="text-base-content/70">{{ Str::limit($this->getSubjectTitle($activity), 30) }}</span>
+                            <div class="text-xs text-base-content/70">{{ $this->prettifySubjectType($activity->subject_type) }}</div>
+                        @endif
                     @else
-                    <span class="text-base-content/70">{{ Str::limit($this->getSubjectTitle($activity), 30) }}</span>
+                        <span class="text-base-content/70 italic">Deleted</span>
+                        <div class="text-xs text-base-content/70">{{ $this->prettifySubjectType($activity->subject_type) }}</div>
                     @endif
-                    <div class="text-xs text-base-content/70">{{ $this->prettifySubjectType($activity->subject_type) }}</div>
                     @endscope
 
                     @scope('cell_changes', $activity)
@@ -561,14 +568,20 @@ new class extends Component
                                 <div>
                                     <span class="text-sm font-medium">Subject:</span>
                                     <div class="mt-1">
-                                        @if ($this->getSubjectUrl($selectedActivity))
-                                        <a href="{{ $this->getSubjectUrl($selectedActivity) }}" class="link font-medium" target="_blank">
-                                            {{ $this->getSubjectTitle($selectedActivity) }}
-                                        </a>
+                                        @if ($selectedActivity->subject)
+                                            @if ($selectedActivity->subject instanceof \App\Models\Event)
+                                                <x-event-ref :event="$selectedActivity->subject" />
+                                            @elseif ($selectedActivity->subject instanceof \App\Models\EventObject)
+                                                <x-object-ref :object="$selectedActivity->subject" :showType="true" />
+                                            @elseif ($selectedActivity->subject instanceof \App\Models\Block)
+                                                <x-block-ref :block="$selectedActivity->subject" />
+                                            @else
+                                                <span class="text-base-content/70">{{ $this->getSubjectTitle($selectedActivity) }}</span>
+                                            @endif
                                         @else
-                                        <span class="text-base-content/70">{{ $this->getSubjectTitle($selectedActivity) }}</span>
+                                            <span class="text-base-content/70 italic">Deleted</span>
                                         @endif
-                                        <div class="text-xs text-base-content/70">{{ $this->prettifySubjectType($selectedActivity->subject_type) }}</div>
+                                        <div class="text-xs text-base-content/70 mt-1">{{ $this->prettifySubjectType($selectedActivity->subject_type) }}</div>
                                         @if ($selectedActivity->subject_id)
                                         <div class="text-xs text-base-content/70 font-mono">ID: {{ $selectedActivity->subject_id }}</div>
                                         @endif

--- a/resources/views/livewire/admin/blocks.blade.php
+++ b/resources/views/livewire/admin/blocks.blade.php
@@ -375,9 +375,7 @@ new class extends Component
 
                 @scope('cell_event_id', $block)
                 @if ($block->event)
-                <a href="{{ route('events.show', $block->event) }}" class="link">
-                    <code class="text-xs">{{ $this->truncateId($block->event->id) }}</code>
-                </a>
+                <x-event-ref :event="$block->event" :showService="false" />
                 @else
                 <span class="text-error">Missing Event</span>
                 @endif

--- a/resources/views/livewire/admin/blocks.blade.php
+++ b/resources/views/livewire/admin/blocks.blade.php
@@ -341,7 +341,7 @@ new class extends Component
                 class="[&_table]:!static [&_td]:!static">
 
                 @scope('cell_id', $block)
-                <code class="text-xs hidden md:inline">{{ $this->truncateId($block->id) }}</code>
+                <x-block-ref :block="$block" :showType="false" :text="'<span class=\'font-mono text-xs\'>' . $this->truncateId($block->id) . '</span>'" />
                 @endscope
 
                 @scope('cell_title', $block)

--- a/resources/views/livewire/admin/blocks.blade.php
+++ b/resources/views/livewire/admin/blocks.blade.php
@@ -332,7 +332,6 @@ new class extends Component
                 :headers="$this->headers()"
                 :rows="$this->getBlocks()"
                 :sort-by="$sortBy"
-                :link="route('blocks.show', ['block' => '[id]'])"
                 with-pagination
                 per-page=" perPage"
                 :per-page-values="[10, 25, 50, 100]"
@@ -346,8 +345,6 @@ new class extends Component
                 @endscope
 
                 @scope('cell_title', $block)
-                <x-uk-date :date="$block->time" class="sm:hidden" />
-                <br />
                 <div class="font-medium">{{ $block->title ?: 'N/A' }}</div>
                 @endscope
 

--- a/resources/views/livewire/admin/events.blade.php
+++ b/resources/views/livewire/admin/events.blade.php
@@ -375,9 +375,11 @@ new class extends Component {
                     @endscope
 
                     @scope('cell_target', $event)
-                    <x-uk-date :date="$event->time" />
+                    <x-uk-date :date="$event->time" class="sm:hidden" />
                     @if ($event->target)
-                    {{ Str::limit($event->target->title, 30) }}
+                    <x-object-ref :object="$event->target" />
+                    @elseif ($event->actor)
+                    <x-object-ref :object="$event->actor" />
                     @endif
                     @endscope
 

--- a/resources/views/livewire/admin/events.blade.php
+++ b/resources/views/livewire/admin/events.blade.php
@@ -352,7 +352,7 @@ new class extends Component {
                     </x-slot:empty>
 
                     @scope('cell_id', $event)
-                    <span class="text-sm font-mono">{{ $this->truncateId($event->id) }}</span>
+                    <x-event-ref :event="$event" :showService="false" :text="'<span class=\'font-mono text-xs\'>' . $this->truncateId($event->id) . '</span>'" />
                     @endscope
 
                     @scope('cell_service', $event)

--- a/resources/views/livewire/admin/events.blade.php
+++ b/resources/views/livewire/admin/events.blade.php
@@ -335,7 +335,6 @@ new class extends Component {
                     selectable
                     selectable-key="id"
                     wire:model.live="selectedEvents"
-                    link="/events/{id}"
                     striped
                     class="[&_table]:!static [&_td]:!static">
                     <x-slot:empty>

--- a/resources/views/livewire/admin/events.blade.php
+++ b/resources/views/livewire/admin/events.blade.php
@@ -367,7 +367,7 @@ new class extends Component {
                     @scope('cell_action', $event)
                     <div class="flex flex-col gap-1">
                         <span class="sm:hidden text-xs">{{ $event->service }}</span>
-                        <span class="text-sm">{{ $this->prettifyAction($event->action) }}</span>
+                        <x-action-ref :action="$event->action" :service="$event->service" :href="route('events.show', $event)" />
                         @if (!empty($event->value))
                         <span class="sm:hidden text-sm">{{ $this->formatValue($event->value, $event->value_multiplier, $event->value_unit) }}</span>
                         @endif

--- a/resources/views/livewire/admin/objects.blade.php
+++ b/resources/views/livewire/admin/objects.blade.php
@@ -318,9 +318,7 @@ new class extends Component
                 class="[&_table]:!static [&_td]:!static">
 
                 @scope('cell_id', $object)
-                <a href="{{ route('objects.show', $object->id) }}" class="link font-mono text-xs hidden md:inline" title="{{ $object->id }}">
-                    {{ $this->truncateId($object->id) }}
-                </a>
+                <x-object-ref :object="$object" :showType="false" :text="'<span class=\'font-mono text-xs\'>' . $this->truncateId($object->id) . '</span>'" />
                 @endscope
 
                 @scope('cell_title', $object)

--- a/resources/views/livewire/admin/relationships.blade.php
+++ b/resources/views/livewire/admin/relationships.blade.php
@@ -428,10 +428,16 @@ new class extends Component
 
                     @scope('cell_from', $relationship)
                     <div class="flex items-center gap-2">
-                        <div class="flex flex-col">
+                        @if ($relationship->from instanceof App\Models\Event)
+                            <x-event-ref :event="$relationship->from" :showService="false" />
+                        @elseif ($relationship->from instanceof App\Models\EventObject)
+                            <x-object-ref :object="$relationship->from" :showType="false" />
+                        @elseif ($relationship->from instanceof App\Models\Block)
+                            <x-block-ref :block="$relationship->from" :showType="false" />
+                        @else
                             <span class="text-sm">{{ $this->formatEntityTitle($relationship, 'from') }}</span>
-                            <span class="text-xs text-base-content/70 sm:hidden">{{ $this->formatModelType($relationship->from_type) }}</span>
-                        </div>
+                        @endif
+                        <span class="text-xs text-base-content/70 sm:hidden">{{ $this->formatModelType($relationship->from_type) }}</span>
                     </div>
                     @endscope
 
@@ -451,10 +457,16 @@ new class extends Component
 
                     @scope('cell_to', $relationship)
                     <div class="flex items-center gap-2">
-                        <div class="flex flex-col">
+                        @if ($relationship->to instanceof App\Models\Event)
+                            <x-event-ref :event="$relationship->to" :showService="false" />
+                        @elseif ($relationship->to instanceof App\Models\EventObject)
+                            <x-object-ref :object="$relationship->to" :showType="false" />
+                        @elseif ($relationship->to instanceof App\Models\Block)
+                            <x-block-ref :block="$relationship->to" :showType="false" />
+                        @else
                             <span class="text-sm">{{ $this->formatEntityTitle($relationship, 'to') }}</span>
-                            <span class="text-xs text-base-content/70 sm:hidden">{{ $this->formatModelType($relationship->to_type) }}</span>
-                        </div>
+                        @endif
+                        <span class="text-xs text-base-content/70 sm:hidden">{{ $this->formatModelType($relationship->to_type) }}</span>
                     </div>
                     @endscope
 

--- a/resources/views/livewire/blocks/show.blade.php
+++ b/resources/views/livewire/blocks/show.blade.php
@@ -737,9 +737,7 @@ new class extends Component
                         @endif
                         @if ($this->block->event)
                             <x-metadata-row label="Related Event" :copy-value="format_action_title($this->block->event->action)">
-                                <a href="{{ route('events.show', $this->block->event->id) }}" class="hover:underline">
-                                    {{ format_action_title($this->block->event->action) }}
-                                </a>
+                                <x-action-ref :action="$this->block->event->action" :service="$this->block->event->service" :href="route('events.show', $this->block->event)" />
                             </x-metadata-row>
                         @endif
                     </dl>

--- a/resources/views/livewire/blocks/show.blade.php
+++ b/resources/views/livewire/blocks/show.blade.php
@@ -487,47 +487,43 @@ new class extends Component
                 Related Event
             </h3>
             <div class="border border-base-300 rounded-lg p-3 hover:bg-base-50 transition-colors">
-                <a href="{{ route('events.show', $this->block->event->id) }}"
-                    class="block hover:text-primary transition-colors">
-                    <div class="flex items-start gap-3">
-                        <div class="w-8 h-8 rounded-full bg-base-200 flex items-center justify-center flex-shrink-0 mt-1">
-                            <x-icon name="o-bolt" class="w-4 h-4" />
-                        </div>
-                        <div class="flex-1 min-w-0">
-                            <div class="flex items-start justify-between gap-2 mb-1">
-                                <span class="font-medium">
-                                    {{ format_action_title($this->block->event->action) }}
-                                    @if (should_display_action_with_object($this->block->event->action, $this->block->event->service))
-                                    @if ($this->block->event->target)
-                                    <span class="text-base-content/80">{{ ' ' . $this->block->event->target->title }}</span>
-                                    @elseif ($this->block->event->actor)
-                                    <span class="text-base-content/80">{{ ' ' . $this->block->event->actor->title }}</span>
-                                    @endif
-                                    @endif
-                                </span>
-                                @if ($this->block->event->value)
-                                <span class="text-sm font-semibold flex-shrink-0">
-                                    {!! format_event_value_display($this->block->event->formatted_value, $this->block->event->value_unit, $this->block->event->service, $this->block->event->action, 'action') !!}
-                                </span>
-                                @endif
-                            </div>
-                            <div class="text-sm text-base-content/70 flex flex-wrap items-center gap-1">
-                                <span>{{ to_user_timezone($this->block->event->time, auth()->user())->format('d/m/Y H:i') }}</span>
-                                @if ($this->block->event->domain)
-                                <span>·</span>
-                                <x-badge :value="$this->block->event->domain" class="badge-xs badge-outline" />
-                                @endif
-                                <span>·</span>
-                                <x-badge :value="$this->block->event->service" class="badge-xs badge-outline" />
-                                @if ($this->block->event->integration)
-                                <span>·</span>
-                                <x-badge :value="$this->block->event->integration->name" class="badge-xs badge-outline" />
-                                @endif
-                            </div>
-                        </div>
-                        <x-icon name="o-chevron-right" class="w-4 h-4 text-base-content/40 flex-shrink-0 mt-1" />
+                <div class="flex items-start gap-3">
+                    <div class="w-8 h-8 rounded-full bg-base-200 flex items-center justify-center flex-shrink-0 mt-1">
+                        <x-icon name="o-bolt" class="w-4 h-4" />
                     </div>
-                </a>
+                    <div class="flex-1 min-w-0">
+                        <div class="flex items-start justify-between gap-2 mb-1">
+                            <div class="flex items-center flex-wrap gap-1">
+                                <x-event-ref :event="$this->block->event" :showService="false" />
+                                @if (should_display_action_with_object($this->block->event->action, $this->block->event->service))
+                                @if ($this->block->event->target)
+                                <x-object-ref :object="$this->block->event->target" />
+                                @elseif ($this->block->event->actor)
+                                <x-object-ref :object="$this->block->event->actor" />
+                                @endif
+                                @endif
+                            </div>
+                            @if ($this->block->event->value)
+                            <span class="text-sm font-semibold flex-shrink-0">
+                                {!! format_event_value_display($this->block->event->formatted_value, $this->block->event->value_unit, $this->block->event->service, $this->block->event->action, 'action') !!}
+                            </span>
+                            @endif
+                        </div>
+                        <div class="text-sm text-base-content/70 flex flex-wrap items-center gap-1">
+                            <span>{{ to_user_timezone($this->block->event->time, auth()->user())->format('d/m/Y H:i') }}</span>
+                            @if ($this->block->event->domain)
+                            <span>·</span>
+                            <x-badge :value="$this->block->event->domain" class="badge-xs badge-outline" />
+                            @endif
+                            <span>·</span>
+                            @if ($this->block->event->integration)
+                            <x-integration-ref :integration="$this->block->event->integration" :showStatus="false" />
+                            @else
+                            <x-badge :value="$this->block->event->service" class="badge-xs badge-outline" />
+                            @endif
+                        </div>
+                    </div>
+                </div>
             </div>
         </x-card>
         @endif
@@ -647,16 +643,20 @@ new class extends Component
                     @else
                     <span class="text-base-content/40 text-sm">↔</span>
                     @endif
-                    <a href="{{ $route }}" class="flex items-center gap-2 flex-1 min-w-0 hover:text-accent transition-colors">
-                        <x-icon name="{{ $icon }}" class="w-4 h-4 flex-shrink-0" />
-                        <div class="min-w-0 flex-1">
-                            <div class="font-medium truncate text-sm">{{ $title }}</div>
-                            @if ($subtitle)
-                            <div class="text-xs text-base-content/60 truncate">{{ $subtitle }}</div>
-                            @endif
-                        </div>
-                    </a>
-                    <span class="badge {{ $badgeClass }} badge-xs">{{ $badgeText }}</span>
+                    <div class="flex-1 min-w-0">
+                        @if ($relatedModel instanceof \App\Models\Event)
+                            <x-event-ref :event="$relatedModel" :showService="true" />
+                        @elseif ($relatedModel instanceof \App\Models\EventObject)
+                            <x-object-ref :object="$relatedModel" :showType="true" />
+                        @elseif ($relatedModel instanceof \App\Models\Block)
+                            <x-block-ref :block="$relatedModel" :showType="true" />
+                        @else
+                            <a href="{{ $route }}" class="flex items-center gap-2 hover:text-accent transition-colors">
+                                <x-icon name="{{ $icon }}" class="w-4 h-4 flex-shrink-0" />
+                                <span class="font-medium truncate text-sm">{{ $title }}</span>
+                            </a>
+                        @endif
+                    </div>
                     @if ($relationship->value !== null)
                     <div class="text-xs font-mono text-info">
                         @if ($relationship->value_unit)

--- a/resources/views/livewire/blocks/show.blade.php
+++ b/resources/views/livewire/blocks/show.blade.php
@@ -962,6 +962,8 @@ new class extends Component
                 @endif
             </div>
         </x-drawer>
+        </div>
+        <!-- End two-column layout -->
     </div>
     @else
     <div class="text-center py-12">

--- a/resources/views/livewire/day.blade.php
+++ b/resources/views/livewire/day.blade.php
@@ -1072,7 +1072,7 @@ $availableStreams = computed(function () {
                                     <span class="hidden sm:inline">·</span>
                                     <span class="sm:hidden w-full"></span>
                                     @endif
-                                    @foreach ($firstEvent->tags ?? [] as $tag)<x-spark-tag :tag="$tag" size="md" fill />@endforeach
+                                    @foreach ($firstEvent->tags ?? [] as $tag)<x-tag-ref :tag="$tag" size="md" fill />@endforeach
                                 </div>
                             </div>
                             @else
@@ -1100,7 +1100,7 @@ $availableStreams = computed(function () {
                                     <span class="hidden sm:inline">·</span>
                                     <span class="sm:hidden w-full"></span>
                                     @endif
-                                    @foreach ($firstEvent->tags ?? [] as $tag)<x-spark-tag :tag="$tag" size="md" fill />@endforeach
+                                    @foreach ($firstEvent->tags ?? [] as $tag)<x-tag-ref :tag="$tag" size="md" fill />@endforeach
                                     @if ($firstEvent->blocks && count($firstEvent->blocks) > 0)
                                     <span class="hidden sm:inline">·</span>
                                     <span class="sm:hidden w-full"></span>
@@ -1151,7 +1151,7 @@ $availableStreams = computed(function () {
                             <span class="hidden sm:inline">·</span>
                             <span class="sm:hidden w-full"></span>
                             @endif
-                            @foreach ($event->tags ?? [] as $tag)<x-spark-tag :tag="$tag" size="sm" />@endforeach
+                            @foreach ($event->tags ?? [] as $tag)<x-tag-ref :tag="$tag" size="sm" />@endforeach
                             @if ($event->blocks && count($event->blocks) > 0)
                             <span class="hidden sm:inline">·</span>
                             <span class="sm:hidden w-full"></span>

--- a/resources/views/livewire/day.blade.php
+++ b/resources/views/livewire/day.blade.php
@@ -1051,9 +1051,9 @@ $availableStreams = computed(function () {
                                     <span class="font-semibold">{{ $this->formatAction($firstEvent->action) }}</span>
                                     @if (should_display_action_with_object($firstEvent->action, $firstEvent->service))
                                         @if ($firstEvent->target)
-                                            <x-object-ref :object="$firstEvent->target" />
+                                            <x-object-ref :object="$firstEvent->target" variant="text" :href="route('events.show', $firstEvent)" />
                                         @elseif ($firstEvent->actor)
-                                            <x-object-ref :object="$firstEvent->actor" />
+                                            <x-object-ref :object="$firstEvent->actor" variant="text" :href="route('events.show', $firstEvent)" />
                                         @endif
                                     @endif
                                     @if ($eventGroup['count'] > 1)
@@ -1082,9 +1082,9 @@ $availableStreams = computed(function () {
                                     <a href="{{ route('events.show', $firstEvent->id) }}" wire:navigate class="hover:text-primary transition-colors font-semibold">{{ $this->formatAction($firstEvent->action) }}</a>
                                     @if (should_display_action_with_object($firstEvent->action, $firstEvent->service))
                                     @if ($firstEvent->target)
-                                    <x-object-ref :object="$firstEvent->target" />
+                                    <x-object-ref :object="$firstEvent->target" variant="text" :href="route('events.show', $firstEvent)" />
                                     @elseif ($firstEvent->actor)
-                                    <x-object-ref :object="$firstEvent->actor" />
+                                    <x-object-ref :object="$firstEvent->actor" variant="text" :href="route('events.show', $firstEvent)" />
                                     @endif
                                     @endif
                                 </div>
@@ -1134,9 +1134,9 @@ $availableStreams = computed(function () {
                             <a href="{{ route('events.show', $event->id) }}" wire:navigate class="text-base-content hover:text-primary transition-colors font-medium">{{ $this->formatAction($event->action) }}</a>
                             @if (should_display_action_with_object($event->action, $event->service))
                             @if ($event->target)
-                            <x-object-ref :object="$event->target" />
+                            <x-object-ref :object="$event->target" variant="text" :href="route('events.show', $event)" />
                             @elseif ($event->actor)
-                            <x-object-ref :object="$event->actor" />
+                            <x-object-ref :object="$event->actor" variant="text" :href="route('events.show', $event)" />
                             @endif
                             @endif
                         </div>

--- a/resources/views/livewire/day.blade.php
+++ b/resources/views/livewire/day.blade.php
@@ -138,7 +138,7 @@ $events = computed(function () {
         $selectedDate = Carbon::today();
     }
 
-    $query = Event::with(['actor', 'target', 'integration', 'tags'])
+    $query = Event::with(['actor', 'target', 'integration', 'tags', 'blocks'])
         ->whereHas('integration', function ($q) {
             $userId = optional(auth()->guard('web')->user())->id;
             if ($userId) {
@@ -1051,9 +1051,9 @@ $availableStreams = computed(function () {
                                     <span class="font-semibold">{{ $this->formatAction($firstEvent->action) }}</span>
                                     @if (should_display_action_with_object($firstEvent->action, $firstEvent->service))
                                         @if ($firstEvent->target)
-                                            <span class="sm:inline block break-words font-bold min-w-0">{{ ' ' . $firstEvent->target->title }}</span>
+                                            <x-object-ref :object="$firstEvent->target" />
                                         @elseif ($firstEvent->actor)
-                                            <span class="sm:inline block break-words font-bold min-w-0">{{ ' ' . $firstEvent->actor->title }}</span>
+                                            <x-object-ref :object="$firstEvent->actor" />
                                         @endif
                                     @endif
                                     @if ($eventGroup['count'] > 1)
@@ -1066,11 +1066,7 @@ $availableStreams = computed(function () {
                                     <span class="hidden sm:inline">·</span>
                                     <span class="sm:hidden w-full"></span>
                                     @if ($firstEvent->integration)
-                                    <x-badge class="badge-sm sm:badge-md badge-base">
-                                        <x-slot:value>
-                                            {{ str::Lower($firstEvent->integration->name) }}
-                                        </x-slot:value>
-                                    </x-badge>
+                                    <x-integration-ref :integration="$firstEvent->integration" :showStatus="false" />
                                     @endif
                                     @if ($firstEvent->tags && count($firstEvent->tags) > 0)
                                     <span class="hidden sm:inline">·</span>
@@ -1082,33 +1078,37 @@ $availableStreams = computed(function () {
                             @else
                             @php $firstEvent = $eventGroup['events'][0]; @endphp
                             <div class="py-2 px-2">
-                                <a href="{{ route('events.show', $firstEvent->id) }}" wire:navigate class="block hover:text-primary transition-colors min-w-0 text-xl">
-                                    <span class="font-semibold">{{ $this->formatAction($firstEvent->action) }}</span>
+                                <div class="text-xl">
+                                    <a href="{{ route('events.show', $firstEvent->id) }}" wire:navigate class="hover:text-primary transition-colors font-semibold">{{ $this->formatAction($firstEvent->action) }}</a>
                                     @if (should_display_action_with_object($firstEvent->action, $firstEvent->service))
                                     @if ($firstEvent->target)
-                                    <span class="sm:inline block break-words font-bold min-w-0">{{ ' ' . $firstEvent->target->title }}</span>
+                                    <x-object-ref :object="$firstEvent->target" />
                                     @elseif ($firstEvent->actor)
-                                    <span class="sm:inline block break-words font-bold min-w-0">{{ ' ' . $firstEvent->actor->title }}</span>
+                                    <x-object-ref :object="$firstEvent->actor" />
                                     @endif
                                     @endif
-                                </a>
+                                </div>
                                 <div class="mt-1 text-sm text-base-content/70 flex items-center flex-wrap gap-1">
                                     {{ to_user_timezone($firstEvent->time, auth()->user())->format(' H:i') }} ·
                                     <span title="{{ to_user_timezone($firstEvent->time, auth()->user())->toDayDateTimeString() }}">{{ to_user_timezone($firstEvent->time, auth()->user())->diffForHumans() }}</span>
                                     <span class="hidden sm:inline">·</span>
                                     <span class="sm:hidden w-full"></span>
                                     @if ($firstEvent->integration)
-                                    <x-badge class="badge-sm sm:badge-md badge-base">
-                                        <x-slot:value>
-                                            {{ str::Lower($firstEvent->integration->name) }}
-                                        </x-slot:value>
-                                    </x-badge>
+                                    <x-integration-ref :integration="$firstEvent->integration" :showStatus="false" />
                                     @endif
                                     @if ($firstEvent->tags && count($firstEvent->tags) > 0)
                                     <span class="hidden sm:inline">·</span>
                                     <span class="sm:hidden w-full"></span>
                                     @endif
                                     @foreach ($firstEvent->tags ?? [] as $tag)<x-spark-tag :tag="$tag" size="md" fill />@endforeach
+                                    @if ($firstEvent->blocks && count($firstEvent->blocks) > 0)
+                                    <span class="hidden sm:inline">·</span>
+                                    <span class="sm:hidden w-full"></span>
+                                    @foreach ($firstEvent->blocks->take(3) as $block)<x-block-ref :block="$block" :showType="false" />@endforeach
+                                    @if (count($firstEvent->blocks) > 3)
+                                    <span class="badge badge-ghost badge-sm">+{{ count($firstEvent->blocks) - 3 }}</span>
+                                    @endif
+                                    @endif
                                 </div>
                             </div>
                             @endif
@@ -1130,32 +1130,36 @@ $availableStreams = computed(function () {
                         <div class="absolute left-2 top-0 bottom-0 w-px bg-base-300"></div>
                     </div>
                     <div class="py-2 px-2">
-                        <a href="{{ route('events.show', $event->id) }}" wire:navigate class="text-base-content block hover:text-primary transition-colors min-w-0 text-lg">
-                            <span class="font-medium">{{ $this->formatAction($event->action) }}</span>
+                        <div class="text-lg">
+                            <a href="{{ route('events.show', $event->id) }}" wire:navigate class="text-base-content hover:text-primary transition-colors font-medium">{{ $this->formatAction($event->action) }}</a>
                             @if (should_display_action_with_object($event->action, $event->service))
                             @if ($event->target)
-                            <span class="sm:inline block break-words font-bold min-w-0">{{ ' ' . $event->target->title }}</span>
+                            <x-object-ref :object="$event->target" />
                             @elseif ($event->actor)
-                            <span class="sm:inline block break-words font-bold min-w-0">{{ ' ' . $event->actor->title }}</span>
+                            <x-object-ref :object="$event->actor" />
                             @endif
                             @endif
-                        </a>
+                        </div>
                         <div class="mt-1 text-sm text-base-content/70 flex items-center flex-wrap gap-1">
                             <span title="{{ to_user_timezone($event->time, auth()->user())->toDayDateTimeString() }}">{{ to_user_timezone($event->time, auth()->user())->diffForHumans() }}</span>
                             <span class="hidden sm:inline">·</span>
                             <span class="sm:hidden w-full"></span>
                             @if ($event->integration)
-                            <x-badge class="badge-sm badge-outline">
-                                <x-slot:value>
-                                    {{ str::Lower($event->integration->name) }}
-                                </x-slot:value>
-                            </x-badge>
+                            <x-integration-ref :integration="$event->integration" :showStatus="false" />
                             @endif
                             @if ($event->tags && count($event->tags) > 0)
                             <span class="hidden sm:inline">·</span>
                             <span class="sm:hidden w-full"></span>
                             @endif
                             @foreach ($event->tags ?? [] as $tag)<x-spark-tag :tag="$tag" size="sm" />@endforeach
+                            @if ($event->blocks && count($event->blocks) > 0)
+                            <span class="hidden sm:inline">·</span>
+                            <span class="sm:hidden w-full"></span>
+                            @foreach ($event->blocks->take(2) as $block)<x-block-ref :block="$block" :showType="false" />@endforeach
+                            @if (count($event->blocks) > 2)
+                            <span class="badge badge-ghost badge-xs">+{{ count($event->blocks) - 2 }}</span>
+                            @endif
+                            @endif
                         </div>
                     </div>
                     <div class="py-2 pr-2 text-right">

--- a/resources/views/livewire/events/show.blade.php
+++ b/resources/views/livewire/events/show.blade.php
@@ -860,12 +860,12 @@ new class extends Component
                         <div class="mb-4 text-center sm:text-left">
                             <div class="flex flex-col sm:flex-row items-center sm:items-start justify-between gap-2 mb-2">
                                 <h2 class="text-xl sm:text-2xl lg:text-3xl font-bold text-base-content leading-tight">
-                                    {{ $this->formatAction($this->event->action) }}
+                                    <x-action-ref :action="$this->event->action" :service="$this->event->service" variant="text" />
                                     @if (should_display_action_with_object($this->event->action, $this->event->service))
                                     @if ($this->event->target)
-                                    {{ $this->event->target->title }}
+                                    <x-object-ref :object="$this->event->target" variant="text" />
                                     @elseif ($this->event->actor)
-                                    {{ $this->event->actor->title }}
+                                    <x-object-ref :object="$this->event->actor" variant="text" />
                                     @endif
                                     @endif
                                 </h2>
@@ -912,12 +912,7 @@ new class extends Component
                             @endif
                             @if ($this->event->integration)
                             <x-icon name="fas.arrow-right" class="w-3 h-3 text-base-content/40" />
-                            <x-badge class="badge-xs badge-outline">
-                                <x-slot:value>
-                                    <x-icon name="fas.thumbtack" class="w-3 h-3 text-base-content/40" />
-                                    {{ str::Headline($this->event->integration->name) }}
-                                </x-slot:value>
-                            </x-badge>
+                            <x-integration-ref :integration="$this->event->integration" :showStatus="false" />
                             @endif
                         </div>
 
@@ -939,7 +934,7 @@ new class extends Component
                                 <div class="flex items-center gap-2">
                                     <x-icon name="fas.arrow-down" class="w-4 h-4 text-base-content/40 sm:hidden" />
                                     <x-icon name="fas.arrow-right" class="w-4 h-4 text-base-content/40 hidden sm:block" />
-                                    <span class="text-sm text-base-content/70 font-medium">{{ $this->formatAction($this->event->action) }}</span>
+                                    <x-action-ref :action="$this->event->action" :service="$this->event->service" />
                                     <x-icon name="fas.arrow-down" class="w-4 h-4 text-base-content/40 sm:hidden" />
                                     <x-icon name="fas.arrow-right" class="w-4 h-4 text-base-content/40 hidden sm:block" />
                                 </div>

--- a/resources/views/livewire/events/show.blade.php
+++ b/resources/views/livewire/events/show.blade.php
@@ -931,10 +931,7 @@ new class extends Component
                                     <div class="w-8 h-8 sm:w-10 sm:h-10 rounded-full bg-secondary/10 flex items-center justify-center">
                                         <x-icon name="fas.user" class="w-4 h-4 sm:w-5 sm:h-5 text-secondary" />
                                     </div>
-                                    <a href="{{ route('objects.show', $this->event->actor->id) }}"
-                                        class="font-medium text-secondary hover:underline text-sm sm:text-base">
-                                        {{ $this->event->actor->title }}
-                                    </a>
+                                    <x-object-ref :object="$this->event->actor" />
                                 </div>
                                 @endif
 
@@ -953,10 +950,7 @@ new class extends Component
                                     <div class="w-8 h-8 sm:w-10 sm:h-10 rounded-full bg-accent/10 flex items-center justify-center">
                                         <x-icon name="fas.arrow-trend-up" class="w-4 h-4 sm:w-5 sm:h-5 text-accent" />
                                     </div>
-                                    <a href="{{ route('objects.show', $this->event->target->id) }}"
-                                        class="font-medium text-accent hover:underline text-sm sm:text-base">
-                                        {{ $this->event->target->title }}
-                                    </a>
+                                    <x-object-ref :object="$this->event->target" />
                                 </div>
                                 @endif
                             </div>
@@ -1323,18 +1317,20 @@ new class extends Component
                         @endif
 
                         <!-- Related Entity -->
-                        <a href="{{ $route }}" class="flex items-center gap-2 flex-1 min-w-0 hover:text-accent transition-colors">
-                            <x-icon name="{{ $icon }}" class="w-4 h-4 flex-shrink-0" />
-                            <div class="min-w-0 flex-1">
-                                <div class="font-medium truncate text-sm">{{ $title }}</div>
-                                @if ($subtitle)
-                                <div class="text-xs text-base-content/60 truncate">{{ $subtitle }}</div>
-                                @endif
-                            </div>
-                        </a>
-
-                        <!-- Badge -->
-                        <span class="badge {{ $badgeClass }} badge-xs">{{ $badgeText }}</span>
+                        <div class="flex-1 min-w-0">
+                            @if ($relatedModel instanceof \App\Models\Event)
+                                <x-event-ref :event="$relatedModel" :showService="true" />
+                            @elseif ($relatedModel instanceof \App\Models\EventObject)
+                                <x-object-ref :object="$relatedModel" :showType="true" />
+                            @elseif ($relatedModel instanceof \App\Models\Block)
+                                <x-block-ref :block="$relatedModel" :showType="true" />
+                            @else
+                                <a href="{{ $route }}" class="flex items-center gap-2 hover:text-accent transition-colors">
+                                    <x-icon name="{{ $icon }}" class="w-4 h-4 flex-shrink-0" />
+                                    <span class="font-medium truncate text-sm">{{ $title }}</span>
+                                </a>
+                            @endif
+                        </div>
 
                         <!-- Value (if present) -->
                         @if ($relationship->value !== null)

--- a/resources/views/livewire/events/show.blade.php
+++ b/resources/views/livewire/events/show.blade.php
@@ -960,7 +960,7 @@ new class extends Component
                             @if ($tagsLoaded && $this->event->tags->isNotEmpty())
                             <div class="flex flex-wrap justify-center gap-2">
                                 @foreach ($this->event->tags as $tag)
-                                <x-spark-tag :tag="$tag" />
+                                <x-tag-ref :tag="$tag" />
                                 @endforeach
                             </div>
                             @elseif (! $tagsLoaded)
@@ -1206,7 +1206,7 @@ new class extends Component
                                                 @if ($relatedEvent->tags && count($relatedEvent->tags) > 0)
                                                 <span>·</span>
                                                 @foreach ($relatedEvent->tags as $tag)
-                                                <x-spark-tag :tag="$tag" size="xs" />
+                                                <x-tag-ref :tag="$tag" size="xs" />
                                                 @endforeach
                                                 @endif
                                             </div>
@@ -1663,7 +1663,7 @@ new class extends Component
                                     <x-metadata-row label="Tags" :copyable="false">
                                         <div class="flex flex-wrap gap-1">
                                             @foreach ($this->event->actor->tags as $tag)
-                                                <x-spark-tag :tag="$tag" size="xs" />
+                                                <x-tag-ref :tag="$tag" size="xs" />
                                             @endforeach
                                         </div>
                                     </x-metadata-row>
@@ -1694,7 +1694,7 @@ new class extends Component
                                     <x-metadata-row label="Tags" :copyable="false">
                                         <div class="flex flex-wrap gap-1">
                                             @foreach ($this->event->target->tags as $tag)
-                                                <x-spark-tag :tag="$tag" size="xs" />
+                                                <x-tag-ref :tag="$tag" size="xs" />
                                             @endforeach
                                         </div>
                                     </x-metadata-row>

--- a/resources/views/livewire/manage-event-tags.blade.php
+++ b/resources/views/livewire/manage-event-tags.blade.php
@@ -38,7 +38,7 @@
             </label>
             <div class="flex flex-wrap gap-2">
                 @foreach ($event->tags as $tag)
-                <x-spark-tag :tag="$tag" />
+                <x-tag-ref :tag="$tag" />
                 @endforeach
             </div>
         </div>

--- a/resources/views/livewire/manage-object-tags.blade.php
+++ b/resources/views/livewire/manage-object-tags.blade.php
@@ -38,7 +38,7 @@
             </label>
             <div class="flex flex-wrap gap-2">
                 @foreach ($object->tags as $tag)
-                <x-spark-tag :tag="$tag" />
+                <x-tag-ref :tag="$tag" />
                 @endforeach
             </div>
         </div>

--- a/resources/views/livewire/manage-relationships.blade.php
+++ b/resources/views/livewire/manage-relationships.blade.php
@@ -72,19 +72,21 @@
                                     <div class="text-xl text-base-content/40 font-mono">↔</div>
                                 @endif
 
-                                <!-- Related Entity -->
-                                <a href="{{ $route }}" class="flex items-center gap-2 flex-1 min-w-0 hover:text-accent transition-colors">
-                                    <x-icon name="{{ $icon }}" class="w-5 h-5 flex-shrink-0" />
-                                    <div class="min-w-0 flex-1">
-                                        <div class="font-medium truncate">{{ $title }}</div>
-                                        @if ($subtitle)
-                                            <div class="text-xs text-base-content/60 truncate">{{ $subtitle }}</div>
-                                        @endif
-                                    </div>
-                                </a>
-
-                                <!-- Badge -->
-                                <span class="badge {{ $badgeClass }} badge-sm">{{ $badgeText }}</span>
+                                <!-- Related Entity (using ref components with hover cards) -->
+                                <div class="flex-1 min-w-0">
+                                    @if ($relatedModel instanceof \App\Models\Event)
+                                        <x-event-ref :event="$relatedModel" :showService="true" />
+                                    @elseif ($relatedModel instanceof \App\Models\EventObject)
+                                        <x-object-ref :object="$relatedModel" :showType="true" />
+                                    @elseif ($relatedModel instanceof \App\Models\Block)
+                                        <x-block-ref :block="$relatedModel" :showType="true" />
+                                    @else
+                                        <a href="{{ $route }}" class="flex items-center gap-2 hover:text-accent transition-colors">
+                                            <x-icon name="{{ $icon }}" class="w-5 h-5 flex-shrink-0" />
+                                            <span class="font-medium truncate">{{ $title }}</span>
+                                        </a>
+                                    @endif
+                                </div>
 
                                 <!-- Value (if present) -->
                                 @if ($relationship->value !== null)

--- a/resources/views/livewire/money/show.blade.php
+++ b/resources/views/livewire/money/show.blade.php
@@ -94,7 +94,7 @@
                             @if ($account->tags->isNotEmpty())
                             <div class="flex flex-wrap justify-center sm:justify-start gap-2 mt-3">
                                 @foreach ($account->tags as $tag)
-                                <x-spark-tag :tag="$tag" size="sm" />
+                                <x-tag-ref :tag="$tag" size="sm" />
                                 @endforeach
                             </div>
                             @endif

--- a/resources/views/livewire/objects/show.blade.php
+++ b/resources/views/livewire/objects/show.blade.php
@@ -1436,49 +1436,45 @@ new class extends Component
                 <div class="space-y-3">
                     @foreach ($directEvents as $event)
                     <div class="border border-base-300 rounded-lg p-3 hover:bg-base-50 transition-colors bg-base-100">
-                        <a href="{{ route('events.show', $event->id) }}"
-                            class="block hover:text-primary transition-colors">
-                            <div class="flex items-start gap-3">
-                                <div class="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center flex-shrink-0 mt-1">
-                                    <x-icon name="fas.bolt" class="w-4 h-4 text-primary" />
-                                </div>
-                                <div class="flex-1 min-w-0">
-                                    <div class="flex items-start justify-between gap-2 mb-1">
-                                        <span class="font-medium">
-                                            {{ $this->formatAction($event->action) }}
-                                            @if (should_display_action_with_object($event->action, $event->service))
-                                                @if ($event->target && $event->target_id !== $this->object->id)
-                                                    <span class="text-base-content/80">{{ ' ' . $event->target->title }}</span>
-                                                @elseif ($event->actor && $event->actor_id !== $this->object->id)
-                                                    <span class="text-base-content/80">{{ ' ' . $event->actor->title }}</span>
-                                                @endif
-                                            @endif
-                                        </span>
-                                        @if ($event->value)
-                                        <span class="text-sm font-semibold text-primary">
-                                            {!! format_event_value_display($event->formatted_value, $event->value_unit, $event->service, $event->action, 'action') !!}
-                                        </span>
-                                        @endif
-                                    </div>
-                                    <div class="text-sm text-base-content/70 flex flex-wrap items-center gap-1">
-                                        <span>{{ $event->time->format('d/m/Y H:i') }}</span>
-                                        <span>·</span>
-                                        <x-badge :value="$event->service" class="badge-xs badge-outline" />
-                                        @if ($event->integration)
-                                        <span>·</span>
-                                        <x-badge :value="$event->integration->name" class="badge-xs badge-outline" />
-                                        @endif
-                                        @if ($event->tags && count($event->tags) > 0)
-                                        <span>·</span>
-                                        @foreach ($event->tags->take(3) as $tag)
-                                        <x-spark-tag :tag="$tag" size="xs" />
-                                        @endforeach
-                                        @endif
-                                    </div>
-                                </div>
-                                <x-icon name="fas.chevron-right" class="w-4 h-4 text-base-content/40 flex-shrink-0 mt-1" />
+                        <div class="flex items-start gap-3">
+                            <div class="w-8 h-8 rounded-full bg-primary/10 flex items-center justify-center flex-shrink-0 mt-1">
+                                <x-icon name="fas.bolt" class="w-4 h-4 text-primary" />
                             </div>
-                        </a>
+                            <div class="flex-1 min-w-0">
+                                <div class="flex items-start justify-between gap-2 mb-1">
+                                    <div class="flex items-center flex-wrap gap-1">
+                                        <x-event-ref :event="$event" :showService="false" />
+                                        @if (should_display_action_with_object($event->action, $event->service))
+                                            @if ($event->target && $event->target_id !== $this->object->id)
+                                                <x-object-ref :object="$event->target" />
+                                            @elseif ($event->actor && $event->actor_id !== $this->object->id)
+                                                <x-object-ref :object="$event->actor" />
+                                            @endif
+                                        @endif
+                                    </div>
+                                    @if ($event->value)
+                                    <span class="text-sm font-semibold text-primary">
+                                        {!! format_event_value_display($event->formatted_value, $event->value_unit, $event->service, $event->action, 'action') !!}
+                                    </span>
+                                    @endif
+                                </div>
+                                <div class="text-sm text-base-content/70 flex flex-wrap items-center gap-1">
+                                    <span>{{ $event->time->format('d/m/Y H:i') }}</span>
+                                    <span>·</span>
+                                    @if ($event->integration)
+                                    <x-integration-ref :integration="$event->integration" :showStatus="false" />
+                                    @else
+                                    <x-badge :value="$event->service" class="badge-xs badge-outline" />
+                                    @endif
+                                    @if ($event->tags && count($event->tags) > 0)
+                                    <span>·</span>
+                                    @foreach ($event->tags->take(3) as $tag)
+                                    <x-spark-tag :tag="$tag" size="xs" />
+                                    @endforeach
+                                    @endif
+                                </div>
+                            </div>
+                        </div>
                     </div>
                     @endforeach
                 </div>
@@ -1757,18 +1753,20 @@ new class extends Component
                             @endif
 
                             <!-- Related Entity -->
-                            <a href="{{ $route }}" class="flex items-center gap-2 flex-1 min-w-0 hover:text-accent transition-colors">
-                                <x-icon name="{{ $icon }}" class="w-4 h-4 flex-shrink-0" />
-                                <div class="min-w-0 flex-1">
-                                    <div class="font-medium truncate text-sm">{{ $title }}</div>
-                                    @if ($subtitle)
-                                        <div class="text-xs text-base-content/60 truncate">{{ $subtitle }}</div>
-                                    @endif
-                                </div>
-                            </a>
-
-                            <!-- Badge -->
-                            <span class="badge {{ $badgeClass }} badge-xs">{{ $badgeText }}</span>
+                            <div class="flex-1 min-w-0">
+                                @if ($relatedModel instanceof \App\Models\Event)
+                                    <x-event-ref :event="$relatedModel" :showService="true" />
+                                @elseif ($relatedModel instanceof \App\Models\EventObject)
+                                    <x-object-ref :object="$relatedModel" :showType="true" />
+                                @elseif ($relatedModel instanceof \App\Models\Block)
+                                    <x-block-ref :block="$relatedModel" :showType="true" />
+                                @else
+                                    <a href="{{ $route }}" class="flex items-center gap-2 hover:text-accent transition-colors">
+                                        <x-icon name="{{ $icon }}" class="w-4 h-4 flex-shrink-0" />
+                                        <span class="font-medium truncate text-sm">{{ $title }}</span>
+                                    </a>
+                                @endif
+                            </div>
 
                             <!-- Value (if present) -->
                             @if ($relationship->value !== null)

--- a/resources/views/livewire/objects/show.blade.php
+++ b/resources/views/livewire/objects/show.blade.php
@@ -1598,12 +1598,12 @@ new class extends Component
                                     <div class="flex-1 min-w-0">
                                         <div class="flex items-start justify-between gap-2 mb-1">
                                             <span class="font-medium">
-                                                {{ $this->formatAction($event->action) }}
+                                                <x-action-ref :action="$event->action" :service="$event->service" variant="text" />
                                                 @if (should_display_action_with_object($event->action, $event->service))
                                                 @if ($event->target)
-                                                <span class="text-base-content/80">{{ ' ' . $event->target->title }}</span>
+                                                <x-object-ref :object="$event->target" variant="text" />
                                                 @elseif ($event->actor)
-                                                <span class="text-base-content/80">{{ ' ' . $event->actor->title }}</span>
+                                                <x-object-ref :object="$event->actor" variant="text" />
                                                 @endif
                                                 @endif
                                             </span>

--- a/resources/views/livewire/objects/show.blade.php
+++ b/resources/views/livewire/objects/show.blade.php
@@ -1383,13 +1383,6 @@ new class extends Component
                                     <span>{{ $this->object->url }}</span>
                                 </a>
                                 @endif
-                                @if ($this->object->media_url)
-                                <a href="{{ $this->object->media_url }}" target="_blank"
-                                    class="flex items-center gap-2 px-4 py-2 bg-info/10 hover:bg-info/20 text-info font-medium rounded-lg transition-colors">
-                                    <x-icon name="fas.image" class="w-4 h-4" />
-                                    <span>{{ $this->object->media_url }}</span>
-                                </a>
-                                @endif
                             </div>
                         </div>
                         @endif
@@ -1399,7 +1392,7 @@ new class extends Component
                             @if ($tagsLoaded && $this->object->tags->isNotEmpty())
                             <div class="flex flex-wrap justify-center gap-2">
                                 @foreach ($this->object->tags as $tag)
-                                <x-spark-tag :tag="$tag" />
+                                <x-tag-ref :tag="$tag" />
                                 @endforeach
                             </div>
                             @elseif (! $tagsLoaded)
@@ -1469,7 +1462,7 @@ new class extends Component
                                     @if ($event->tags && count($event->tags) > 0)
                                     <span>·</span>
                                     @foreach ($event->tags->take(3) as $tag)
-                                    <x-spark-tag :tag="$tag" size="xs" />
+                                    <x-tag-ref :tag="$tag" size="xs" />
                                     @endforeach
                                     @endif
                                 </div>
@@ -1646,7 +1639,7 @@ new class extends Component
                                             @if ($event->tags && count($event->tags) > 0)
                                             <span>·</span>
                                             @foreach ($event->tags as $tag)
-                                            <x-spark-tag :tag="$tag" size="xs" />
+                                            <x-tag-ref :tag="$tag" size="xs" />
                                             @endforeach
                                             @endif
                                         </div>

--- a/resources/views/livewire/tags/show.blade.php
+++ b/resources/views/livewire/tags/show.blade.php
@@ -141,7 +141,7 @@ new class extends Component {
                 <div class="flex-1 w-full">
                     <div class="mb-4 text-center sm:text-left">
                         <h2 class="text-xl sm:text-2xl lg:text-3xl font-bold text-base-content mb-2">
-                            <x-spark-tag :tag="$tag" />
+                            <x-tag-ref :tag="$tag" />
                         </h2>
                         <div class="text-sm text-base-content/70">
                             {{ $this->getTagTypeLabel($tag->type ?? 'untyped') }}
@@ -235,7 +235,7 @@ new class extends Component {
                                                 @if ($event->tags->isNotEmpty())
                                                     <div class="flex flex-wrap gap-1 mt-2">
                                                         @foreach ($event->tags as $eventTag)
-                                                            <x-spark-tag :tag="$eventTag" />
+                                                            <x-tag-ref :tag="$eventTag" />
                                                         @endforeach
                                                     </div>
                                                 @endif
@@ -298,7 +298,7 @@ new class extends Component {
                                                 @if ($object->tags->isNotEmpty())
                                                     <div class="flex flex-wrap gap-1 mt-2">
                                                         @foreach ($object->tags as $objectTag)
-                                                            <x-spark-tag :tag="$objectTag" />
+                                                            <x-tag-ref :tag="$objectTag" />
                                                         @endforeach
                                                     </div>
                                                 @endif


### PR DESCRIPTION
- **Add lazy-loaded info cards for entity references**
- **Use ref components in activity log and relationships views**
- **Add ref components to day view with block indicators**
- **Add ref components to show pages and admin tables**
- **Fix hover popover closing issue with delayed hide timeout**
- **Apply hover fix to spark-tag component**
- **Add text variant to object-ref and use plugin icons**
- **Fix PluginRegistry method name: all() -> getAllPlugins()**
- **Add action-ref component and use ref components on event show page**
- **Add action-ref component to admin events, block show, and object show pages**
- **Fix multiple popovers opening simultaneously**
- **Fix duplicate refs opening all popovers simultaneously**
- **Generate unique popover IDs on client-side with JavaScript**
- **:bug: Remove competing link**
- **:sparkles: Reference Cards! Bug fixes! Book blocks!**
