### PR TITLE
:recycle: Consolidate loading tiers and add skeleton loaders

### DIFF
--- a/app/Livewire/Day.php
+++ b/app/Livewire/Day.php
@@ -42,9 +42,7 @@ class Day extends Component
 
     // Progressive Loading State Flags
     public bool $coreEventsLoaded = false;
-    public bool $integrationLoaded = false;
-    public bool $tagsLoaded = false;
-    public bool $blocksLoaded = false;
+    public bool $additionalDataLoaded = false;
     public bool $dayNoteLoaded = false;
     public bool $checkinStatusLoaded = false;
     public bool $cardStreamsLoaded = false;
@@ -144,67 +142,27 @@ class Day extends Component
     }
 
     /**
-     * Tier 2: Load integration
-     * Integration provides important context about the data source
+     * Tier 2: Load additional data (integration, tags, blocks)
+     * These provide context and details for the events
      */
-    public function loadIntegration(): void
+    public function loadAdditionalData(): void
     {
-        if ($this->integrationLoaded || ! $this->coreEventsLoaded || $this->allEvents === null || $this->allEvents->isEmpty()) {
+        if ($this->additionalDataLoaded || ! $this->coreEventsLoaded || $this->allEvents === null || $this->allEvents->isEmpty()) {
             return;
         }
 
-        // Load integration relationship
-        $this->allEvents->load(['integration']);
+        // Load integration, tags, and blocks relationships together
+        $this->allEvents->load(['integration', 'tags', 'blocks']);
 
-        Log::info('Day: Loaded integration', [
+        Log::info('Day: Loaded additional data (integration, tags, blocks)', [
             'count' => $this->allEvents->count(),
         ]);
 
-        $this->integrationLoaded = true;
+        $this->additionalDataLoaded = true;
     }
 
     /**
-     * Tier 3: Load tags
-     * Tags provide categorization and filtering capabilities
-     */
-    public function loadTags(): void
-    {
-        if ($this->tagsLoaded || ! $this->coreEventsLoaded || $this->allEvents === null || $this->allEvents->isEmpty()) {
-            return;
-        }
-
-        // Load tags relationship
-        $this->allEvents->load(['tags']);
-
-        Log::info('Day: Loaded tags', [
-            'count' => $this->allEvents->count(),
-        ]);
-
-        $this->tagsLoaded = true;
-    }
-
-    /**
-     * Tier 4: Load blocks
-     * Blocks provide additional detail but are lower priority
-     */
-    public function loadBlocks(): void
-    {
-        if ($this->blocksLoaded || ! $this->coreEventsLoaded || $this->allEvents === null || $this->allEvents->isEmpty()) {
-            return;
-        }
-
-        // Load blocks relationship
-        $this->allEvents->load(['blocks']);
-
-        Log::info('Day: Loaded blocks', [
-            'count' => $this->allEvents->count(),
-        ]);
-
-        $this->blocksLoaded = true;
-    }
-
-    /**
-     * Tier 5: Load day note (eager, but lower priority)
+     * Tier 3: Load day note (eager, but lower priority)
      */
     public function loadDayNote(): void
     {
@@ -268,7 +226,7 @@ class Day extends Component
     }
 
     /**
-     * Tier 5: Load check-in status
+     * Tier 3: Load check-in status
      */
     public function loadCheckinStatus(): void
     {
@@ -282,7 +240,7 @@ class Day extends Component
     }
 
     /**
-     * Tier 6: Load card streams for FAB (background, lowest priority)
+     * Tier 4: Load card streams for FAB (background, lowest priority)
      */
     public function loadCardStreams(): void
     {
@@ -1014,11 +972,9 @@ class Day extends Component
     {
         return [
             1 => ['loadCoreEvents'],                        // Critical: Events with actor & target
-            2 => ['loadIntegration'],                       // Important: Integration context
-            3 => ['loadTags'],                              // Important: Tags for categorization
-            4 => ['loadBlocks'],                            // Additional: Block details
-            5 => ['loadDayNote', 'loadCheckinStatus'],      // Nice-to-have: Day note + checkin
-            6 => ['loadCardStreams'],                       // Background: FAB streams
+            2 => ['loadAdditionalData'],                    // Important: Integration, tags, blocks
+            3 => ['loadDayNote', 'loadCheckinStatus'],      // Nice-to-have: Day note + checkin
+            4 => ['loadCardStreams'],                       // Background: FAB streams
         ];
     }
 

--- a/resources/views/livewire/day.blade.php
+++ b/resources/views/livewire/day.blade.php
@@ -203,15 +203,21 @@
                                 <div class="mt-1 text-sm text-base-content/70 flex items-center flex-wrap gap-1">
                                     {{ to_user_timezone($firstEvent->time, auth()->user())->format(' H:i') }} ·
                                     <span title="{{ to_user_timezone($firstEvent->time, auth()->user())->toDayDateTimeString() }}">{{ to_user_timezone($firstEvent->time, auth()->user())->diffForHumans() }}</span>
-                                    @if ($integrationLoaded && $firstEvent->integration)
+                                    @if (!$additionalDataLoaded)
+                                    <span class="hidden sm:inline">·</span>
+                                    <span class="sm:hidden w-full"></span>
+                                    <div class="skeleton h-5 w-24"></div>
+                                    @else
+                                    @if ($firstEvent->integration)
                                     <span class="hidden sm:inline">·</span>
                                     <span class="sm:hidden w-full"></span>
                                     <x-integration-ref :integration="$firstEvent->integration" :showStatus="false" />
                                     @endif
-                                    @if ($tagsLoaded && $firstEvent->tags && count($firstEvent->tags) > 0)
+                                    @if ($firstEvent->tags && count($firstEvent->tags) > 0)
                                     <span class="hidden sm:inline">·</span>
                                     <span class="sm:hidden w-full"></span>
                                     @foreach ($firstEvent->tags ?? [] as $tag)<x-tag-ref :tag="$tag" size="md" fill />@endforeach
+                                    @endif
                                     @endif
                                 </div>
                             </div>
@@ -231,22 +237,28 @@
                                 <div class="mt-1 text-sm text-base-content/70 flex items-center flex-wrap gap-1">
                                     {{ to_user_timezone($firstEvent->time, auth()->user())->format(' H:i') }} ·
                                     <span title="{{ to_user_timezone($firstEvent->time, auth()->user())->toDayDateTimeString() }}">{{ to_user_timezone($firstEvent->time, auth()->user())->diffForHumans() }}</span>
-                                    @if ($integrationLoaded && $firstEvent->integration)
+                                    @if (!$additionalDataLoaded)
+                                    <span class="hidden sm:inline">·</span>
+                                    <span class="sm:hidden w-full"></span>
+                                    <div class="skeleton h-5 w-32"></div>
+                                    @else
+                                    @if ($firstEvent->integration)
                                     <span class="hidden sm:inline">·</span>
                                     <span class="sm:hidden w-full"></span>
                                     <x-integration-ref :integration="$firstEvent->integration" :showStatus="false" />
                                     @endif
-                                    @if ($tagsLoaded && $firstEvent->tags && count($firstEvent->tags) > 0)
+                                    @if ($firstEvent->tags && count($firstEvent->tags) > 0)
                                     <span class="hidden sm:inline">·</span>
                                     <span class="sm:hidden w-full"></span>
                                     @foreach ($firstEvent->tags ?? [] as $tag)<x-tag-ref :tag="$tag" size="md" fill />@endforeach
                                     @endif
-                                    @if ($blocksLoaded && $firstEvent->blocks && count($firstEvent->blocks) > 0)
+                                    @if ($firstEvent->blocks && count($firstEvent->blocks) > 0)
                                     <span class="hidden sm:inline">·</span>
                                     <span class="sm:hidden w-full"></span>
                                     @foreach ($firstEvent->blocks->take(3) as $block)<x-block-ref :block="$block" :showType="false" />@endforeach
                                     @if (count($firstEvent->blocks) > 3)
                                     <span class="badge badge-ghost badge-sm">+{{ count($firstEvent->blocks) - 3 }}</span>
+                                    @endif
                                     @endif
                                     @endif
                                 </div>
@@ -282,22 +294,28 @@
                         </div>
                         <div class="mt-1 text-sm text-base-content/70 flex items-center flex-wrap gap-1">
                             <span title="{{ to_user_timezone($event->time, auth()->user())->toDayDateTimeString() }}">{{ to_user_timezone($event->time, auth()->user())->diffForHumans() }}</span>
-                            @if ($integrationLoaded && $event->integration)
+                            @if (!$additionalDataLoaded)
+                            <span class="hidden sm:inline">·</span>
+                            <span class="sm:hidden w-full"></span>
+                            <div class="skeleton h-4 w-20"></div>
+                            @else
+                            @if ($event->integration)
                             <span class="hidden sm:inline">·</span>
                             <span class="sm:hidden w-full"></span>
                             <x-integration-ref :integration="$event->integration" :showStatus="false" />
                             @endif
-                            @if ($tagsLoaded && $event->tags && count($event->tags) > 0)
+                            @if ($event->tags && count($event->tags) > 0)
                             <span class="hidden sm:inline">·</span>
                             <span class="sm:hidden w-full"></span>
                             @foreach ($event->tags ?? [] as $tag)<x-tag-ref :tag="$tag" size="sm" />@endforeach
                             @endif
-                            @if ($blocksLoaded && $event->blocks && count($event->blocks) > 0)
+                            @if ($event->blocks && count($event->blocks) > 0)
                             <span class="hidden sm:inline">·</span>
                             <span class="sm:hidden w-full"></span>
                             @foreach ($event->blocks->take(2) as $block)<x-block-ref :block="$block" :showType="false" />@endforeach
                             @if (count($event->blocks) > 2)
                             <span class="badge badge-ghost badge-xs">+{{ count($event->blocks) - 2 }}</span>
+                            @endif
                             @endif
                             @endif
                         </div>


### PR DESCRIPTION
- Keep target and actor objects loading in Tier 1 (critical for display)
- Consolidate integration, tags, and blocks into single Tier 2 (loadAdditionalData)
- Simplify from 6 tiers down to 4 tiers for better performance
- Add skeleton loaders to show loading state for integration/tags/blocks
- Skeleton loaders appear while Tier 2 data is being fetched
- Improves perceived performance with visual feedback