### PR TITLE
Fix Google Calendar token refresh invalid_grant error

### DIFF
--- a/app/Integrations/GoogleCalendar/GoogleCalendarPlugin.php
+++ b/app/Integrations/GoogleCalendar/GoogleCalendarPlugin.php
@@ -789,6 +789,7 @@ class GoogleCalendarPlugin extends OAuthPlugin
         ], [
             'client_id' => $this->clientId,
             'grant_type' => 'refresh_token',
+            'redirect_uri' => $this->redirectUri,
         ]);
 
         $hub = SentrySdk::getCurrentHub();
@@ -801,6 +802,7 @@ class GoogleCalendarPlugin extends OAuthPlugin
             'client_secret' => $this->clientSecret,
             'grant_type' => 'refresh_token',
             'refresh_token' => $group->refresh_token,
+            'redirect_uri' => $this->redirectUri,
         ]);
         $span?->finish();
 


### PR DESCRIPTION
Add missing redirect_uri parameter to token refresh request. According to OAuth 2.0 specifications, when redirect_uri is included in the initial authorization code exchange, it must also be included in subsequent refresh token requests for security validation. This was causing Google to reject refresh attempts with 'invalid_grant' error (400 status).

Changes:
- Add redirect_uri parameter to refresh token POST request
- Update API request logging to include redirect_uri for debugging

Fixes the error:
[staging.ERROR: Failed to refresh Google Calendar token {"group_id":"...","status":400,"response":"{\"error\": \"invalid_grant\", \"error_description\": \"Bad Request\"}"}]