### PR TITLE
Fix Flint job failures by adding missing queue configuration

### DIFF
--- a/config/horizon.php
+++ b/config/horizon.php
@@ -75,6 +75,15 @@ return [
                 'memory' => 256,
                 'tries' => 1,
             ],
+            'supervisor-5' => [
+                'connection' => 'redis',
+                'queue' => ['flint'],
+                'balance' => 'auto',
+                'maxProcesses' => 2,
+                'memory' => 512,
+                'tries' => 1,
+                'timeout' => 900,
+            ],
         ],
 
         'staging' => [
@@ -110,6 +119,15 @@ return [
                 'memory' => 256,
                 'tries' => 1,
             ],
+            'supervisor-5' => [
+                'connection' => 'redis',
+                'queue' => ['flint'],
+                'balance' => 'auto',
+                'maxProcesses' => 2,
+                'memory' => 512,
+                'tries' => 1,
+                'timeout' => 900,
+            ],
         ],
 
         'local' => [
@@ -144,6 +162,15 @@ return [
                 'maxProcesses' => 1,
                 'memory' => 256,
                 'tries' => 1,
+            ],
+            'supervisor-5' => [
+                'connection' => 'redis',
+                'queue' => ['flint'],
+                'balance' => 'auto',
+                'maxProcesses' => 2,
+                'memory' => 512,
+                'tries' => 1,
+                'timeout' => 900,
             ],
         ],
     ],

--- a/routes/console.php
+++ b/routes/console.php
@@ -129,7 +129,7 @@ Schedule::call(function () {
                     'is_weekend' => $isWeekend,
                 ]);
 
-                dispatch(new RunPreDigestRefreshJob($user, $scheduleTime));
+                dispatch(new RunPreDigestRefreshJob($user, $scheduleTime))->onQueue('flint');
                 // Job will auto-chain to RunDigestGenerationJob when agents complete
 
                 $preDigestDispatched++;
@@ -145,7 +145,7 @@ Schedule::call(function () {
                     'is_weekend' => $isWeekend,
                 ]);
 
-                dispatch(new SendDigestNotificationJob($user, $scheduleTime));
+                dispatch(new SendDigestNotificationJob($user, $scheduleTime))->onQueue('flint');
 
                 $notificationDispatched++;
             }
@@ -178,7 +178,7 @@ Schedule::call(function () {
     ]);
 
     foreach ($users as $user) {
-        dispatch(new RunPatternDetectionJob($user));
+        dispatch(new RunPatternDetectionJob($user))->onQueue('flint');
     }
 })
     ->weeklyOn(0, '04:00')


### PR DESCRIPTION
The Flint jobs were failing with "attempted too many times" errors because they were being dispatched to a 'flint' queue that didn't exist in the Horizon configuration. This caused jobs to not be processed properly, leading to silent failures without exceptions being caught.

Changes:
- Added 'flint' queue supervisor to Horizon config for all environments (production, staging, local) with:
  * 2 max processes
  * 512MB memory (higher for AI processing needs)
  * 1 try (respects job-level tries setting)
  * 900 second timeout (15 min, allows headroom for 10 min job timeout)

- Updated all Flint job dispatches in console.php to explicitly use the 'flint' queue:
  * RunPreDigestRefreshJob
  * SendDigestNotificationJob
  * RunPatternDetectionJob

This ensures Flint jobs are properly queued and processed by dedicated workers.