### PR TITLE
Fix duplicate visit counting when transactions are re-synced

### DIFF
--- a/app/Console/Commands/RecalculatePlaceVisitCounts.php
+++ b/app/Console/Commands/RecalculatePlaceVisitCounts.php
@@ -2,8 +2,8 @@
 
 namespace App\Console\Commands;
 
-use App\Models\Event;
 use App\Models\Place;
+use Exception;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 
@@ -134,7 +134,7 @@ class RecalculatePlaceVisitCounts extends Command
                 } else {
                     $stats['unchanged']++;
                 }
-            } catch (\Exception $e) {
+            } catch (Exception $e) {
                 $stats['errors']++;
                 $this->newLine();
                 $this->error("Error processing place {$place->id}: " . $e->getMessage());

--- a/app/Console/Commands/RecalculatePlaceVisitCounts.php
+++ b/app/Console/Commands/RecalculatePlaceVisitCounts.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Event;
+use App\Models\Place;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class RecalculatePlaceVisitCounts extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'places:recalculate-visit-counts
+                            {--dry-run : Preview changes without saving}
+                            {--force : Skip confirmation prompt}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Recalculate visit counts for all places based on actual event relationships';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle(): int
+    {
+        $this->info('Recalculating Place Visit Counts');
+        $this->newLine();
+
+        $isDryRun = $this->option('dry-run');
+
+        if ($isDryRun) {
+            $this->warn('DRY RUN MODE - No changes will be saved');
+            $this->newLine();
+        }
+
+        // Get all places
+        $places = Place::withoutGlobalScopes()->get();
+        $totalPlaces = $places->count();
+
+        if ($totalPlaces === 0) {
+            $this->info('No places found.');
+
+            return self::SUCCESS;
+        }
+
+        $this->info("Found {$totalPlaces} places to recalculate.");
+        $this->newLine();
+
+        // Confirm unless --force or --dry-run
+        if (! $isDryRun && ! $this->option('force')) {
+            if (! $this->confirm('This will update visit counts for all places. Continue?')) {
+                $this->warn('Operation cancelled.');
+
+                return self::FAILURE;
+            }
+            $this->newLine();
+        }
+
+        // Process places
+        $progressBar = $this->output->createProgressBar($totalPlaces);
+        $progressBar->start();
+
+        $stats = [
+            'total' => 0,
+            'updated' => 0,
+            'unchanged' => 0,
+            'errors' => 0,
+        ];
+
+        $changes = [];
+
+        foreach ($places as $place) {
+            $stats['total']++;
+
+            try {
+                // Count unique events linked to this place via "occurred_at" relationships
+                $actualVisitCount = DB::table('relationships')
+                    ->where('to_type', 'App\Models\EventObject')
+                    ->where('to_id', $place->id)
+                    ->where('type', 'occurred_at')
+                    ->whereNull('deleted_at')
+                    ->distinct('from_id')
+                    ->count('from_id');
+
+                $currentVisitCount = $place->visit_count ?? 0;
+
+                if ($actualVisitCount !== $currentVisitCount) {
+                    $changes[] = [
+                        'id' => $place->id,
+                        'title' => $place->title,
+                        'old_count' => $currentVisitCount,
+                        'new_count' => $actualVisitCount,
+                    ];
+
+                    if (! $isDryRun) {
+                        // Get first and last visit times from related events
+                        $eventTimes = DB::table('events')
+                            ->join('relationships', function ($join) use ($place) {
+                                $join->on('events.id', '=', 'relationships.from_id')
+                                    ->where('relationships.from_type', '=', 'App\Models\Event')
+                                    ->where('relationships.to_type', '=', 'App\Models\EventObject')
+                                    ->where('relationships.to_id', '=', $place->id)
+                                    ->where('relationships.type', '=', 'occurred_at')
+                                    ->whereNull('relationships.deleted_at');
+                            })
+                            ->whereNull('events.deleted_at')
+                            ->selectRaw('MIN(events.time) as first_visit, MAX(events.time) as last_visit')
+                            ->first();
+
+                        // Update place metadata
+                        $metadata = $place->metadata ?? [];
+                        $metadata['visit_count'] = $actualVisitCount;
+
+                        if ($eventTimes && $eventTimes->first_visit) {
+                            $metadata['first_visit_at'] = $eventTimes->first_visit;
+                        }
+
+                        if ($eventTimes && $eventTimes->last_visit) {
+                            $metadata['last_visit_at'] = $eventTimes->last_visit;
+                        }
+
+                        $place->metadata = $metadata;
+                        $place->save();
+                    }
+
+                    $stats['updated']++;
+                } else {
+                    $stats['unchanged']++;
+                }
+            } catch (\Exception $e) {
+                $stats['errors']++;
+                $this->newLine();
+                $this->error("Error processing place {$place->id}: " . $e->getMessage());
+            }
+
+            $progressBar->advance();
+        }
+
+        $progressBar->finish();
+        $this->newLine(2);
+
+        // Show results
+        if ($isDryRun) {
+            $this->info('DRY RUN RESULTS:');
+        } else {
+            $this->info('✓ Recalculation completed!');
+        }
+        $this->newLine();
+
+        $this->table(
+            ['Metric', 'Count'],
+            [
+                ['Total Places', $stats['total']],
+                ['Updated', $stats['updated']],
+                ['Unchanged', $stats['unchanged']],
+                ['Errors', $stats['errors']],
+            ]
+        );
+
+        // Show sample of changes if any
+        if (! empty($changes)) {
+            $this->newLine();
+            $this->info('Sample of changes (first 20):');
+            $this->newLine();
+
+            $sampleChanges = array_slice($changes, 0, 20);
+            $this->table(
+                ['Place ID', 'Title', 'Old Count', 'New Count', 'Difference'],
+                array_map(function ($change) {
+                    return [
+                        substr($change['id'], 0, 8) . '...',
+                        substr($change['title'], 0, 40),
+                        $change['old_count'],
+                        $change['new_count'],
+                        ($change['new_count'] - $change['old_count']) > 0 ? '+' . ($change['new_count'] - $change['old_count']) : ($change['new_count'] - $change['old_count']),
+                    ];
+                }, $sampleChanges)
+            );
+
+            if (count($changes) > 20) {
+                $this->info('... and ' . (count($changes) - 20) . ' more changes.');
+            }
+        }
+
+        if ($isDryRun) {
+            $this->newLine();
+            $this->info('Run without --dry-run to apply these changes.');
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Services/PlaceDetectionService.php
+++ b/app/Services/PlaceDetectionService.php
@@ -29,7 +29,6 @@ class PlaceDetectionService
         $existing = $this->findNearbyPlace($latitude, $longitude, $user, $searchRadiusMeters);
 
         if ($existing) {
-            $existing->recordVisit();
             Log::info('Matched existing place', [
                 'place_id' => $existing->id,
                 'title' => $existing->title,
@@ -138,7 +137,20 @@ class PlaceDetectionService
             $searchRadiusMeters
         );
 
-        $this->linkEventToPlace($event, $place);
+        // Check if this event is already linked to this place
+        $existingRelationship = Relationship::where('user_id', $user->id)
+            ->where('from_type', Event::class)
+            ->where('from_id', $event->id)
+            ->where('to_type', EventObject::class)
+            ->where('to_id', $place->id)
+            ->where('type', 'occurred_at')
+            ->first();
+
+        // Only create relationship and record visit if this is a new link
+        if (! $existingRelationship) {
+            $this->linkEventToPlace($event, $place);
+            $place->recordVisit();
+        }
 
         return $place;
     }

--- a/app/Services/PlaceDetectionService.php
+++ b/app/Services/PlaceDetectionService.php
@@ -129,6 +129,17 @@ class PlaceDetectionService
             return null;
         }
 
+        // Check if place already exists
+        $existingPlace = $this->findNearbyPlace(
+            $event->latitude,
+            $event->longitude,
+            $user,
+            $searchRadiusMeters
+        );
+
+        $isNewPlace = $existingPlace === null;
+
+        // Detect or create the place
         $place = $this->detectOrCreatePlace(
             $event->latitude,
             $event->longitude,
@@ -149,7 +160,12 @@ class PlaceDetectionService
         // Only create relationship and record visit if this is a new link
         if (! $existingRelationship) {
             $this->linkEventToPlace($event, $place);
-            $place->recordVisit();
+
+            // Only record visit if this is an existing place
+            // New places already have visit_count = 1 from creation
+            if (! $isNewPlace) {
+                $place->recordVisit();
+            }
         }
 
         return $place;

--- a/tests/Unit/Services/PlaceDetectionServiceTest.php
+++ b/tests/Unit/Services/PlaceDetectionServiceTest.php
@@ -67,8 +67,8 @@ class PlaceDetectionServiceTest extends TestCase
         // Should return existing place
         $this->assertEquals($existingPlace->id, $place->id);
 
-        // Visit count should increment
-        $this->assertEquals(6, $place->visit_count);
+        // Visit count should NOT increment when just detecting - only when linking an event
+        $this->assertEquals(5, $place->visit_count);
     }
 
     /**
@@ -322,5 +322,33 @@ class PlaceDetectionServiceTest extends TestCase
 
         $this->assertEquals(2, Place::count()); // Two places, one per user
         $this->assertEquals($this->user->id, $newPlace->user_id);
+    }
+
+    /**
+     * @test
+     */
+    public function reprocessing_same_event_does_not_increment_visit_count(): void
+    {
+        $integration = Integration::factory()->create(['user_id' => $this->user->id]);
+        $event = Event::factory()->create([
+            'integration_id' => $integration->id,
+            'latitude' => 51.5074,
+            'longitude' => -0.1278,
+            'location_address' => 'Starbucks, 123 Main St',
+        ]);
+
+        // First processing - creates place with visit_count = 1
+        $place = $this->service->detectAndLinkPlaceForEvent($event);
+
+        $this->assertNotNull($place);
+        $this->assertEquals(1, $place->visit_count);
+        $this->assertEquals(1, Relationship::where('type', 'occurred_at')->count());
+
+        // Reprocess same event (simulating re-sync) - should NOT increment visit count
+        $place2 = $this->service->detectAndLinkPlaceForEvent($event);
+
+        $this->assertEquals($place->id, $place2->id);
+        $this->assertEquals(1, $place2->visit_count); // Still 1, not 2
+        $this->assertEquals(1, Relationship::where('type', 'occurred_at')->count()); // Still only 1 relationship
     }
 }

--- a/tests/Unit/Services/PlaceDetectionServiceTest.php
+++ b/tests/Unit/Services/PlaceDetectionServiceTest.php
@@ -330,12 +330,10 @@ class PlaceDetectionServiceTest extends TestCase
     public function reprocessing_same_event_does_not_increment_visit_count(): void
     {
         $integration = Integration::factory()->create(['user_id' => $this->user->id]);
-        $event = Event::factory()->create([
-            'integration_id' => $integration->id,
-            'latitude' => 51.5074,
-            'longitude' => -0.1278,
-            'location_address' => 'Starbucks, 123 Main St',
-        ]);
+        $event = Event::factory()->create(['integration_id' => $integration->id]);
+
+        // Set location using the proper method
+        $event->setLocation(51.5074, -0.1278, 'Starbucks, 123 Main St', 'manual');
 
         // First processing - creates place with visit_count = 1
         $place = $this->service->detectAndLinkPlaceForEvent($event);


### PR DESCRIPTION
Problem:
- When integrations re-sync transactions (e.g., Monzo), the same transaction would increment place visit counts multiple times
- This resulted in inflated visit counts that were much higher than the actual number of unique visits

Root Cause:
- PlaceDetectionService::detectOrCreatePlace() was calling recordVisit() every time it found an existing place, regardless of whether the event was already linked to that place
- When the same event was reprocessed during re-syncs, it would increment the visit count again

Solution:
- Removed recordVisit() call from detectOrCreatePlace() - this method should only detect/create places, not track visits
- Added check in detectAndLinkPlaceForEvent() to see if the event is already linked to the place before creating relationship
- Only call recordVisit() when creating a NEW event-place relationship
- This ensures each unique event only increments visit count once

Changes:
- Modified PlaceDetectionService::detectOrCreatePlace() to not increment visit count (separates place detection from visit tracking)
- Modified PlaceDetectionService::detectAndLinkPlaceForEvent() to check for existing relationships before recording visits
- Updated unit test to reflect correct behavior (detecting a place should not increment visit count)
- Added new test to verify reprocessing same event doesn't increment visit count