### PR TITLE
Add missing source relationship to Event model

### DIFF
--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -112,6 +112,11 @@ class Event extends Model
         return $this->belongsTo(Integration::class)->withTrashed();
     }
 
+    public function source()
+    {
+        return $this->belongsTo(EventObject::class, 'source_id')->withTrashed();
+    }
+
     public function actor()
     {
         return $this->belongsTo(EventObject::class, 'actor_id')->withTrashed();
@@ -556,7 +561,7 @@ class Event extends Model
      */
     public function scopeWithStandardRelations($query)
     {
-        return $query->with(['actor', 'target', 'integration', 'tags']);
+        return $query->with(['source', 'actor', 'target', 'integration', 'tags']);
     }
 
     /**
@@ -572,7 +577,7 @@ class Event extends Model
      */
     public function scopeForDetail($query)
     {
-        return $query->with(['actor', 'target', 'blocks', 'integration', 'tags']);
+        return $query->with(['source', 'actor', 'target', 'blocks', 'integration', 'tags']);
     }
 
     /**


### PR DESCRIPTION
The SendDigestNotificationJob was trying to eager load 'event.source' and access $event->source, but the Event model didn't have a source() relationship defined, even though the source_id field exists.

Added the missing relationship and updated the scope methods to include it in standard relationship loading.

Changes:
- Added source() relationship to Event model (similar to actor/target)
- Updated scopeWithStandardRelations() to include 'source'
- Updated scopeForDetail() to include 'source'

This fixes the "Call to undefined relationship [source]" error.