### PR TITLE
Refactor Flint to create one event per analysis run

### DIFF
--- a/app/Services/FlintBlockCreationService.php
+++ b/app/Services/FlintBlockCreationService.php
@@ -208,6 +208,7 @@ class FlintBlockCreationService
 
     /**
      * Get or create Flint event for a user
+     * Creates one event per analysis run (multiple per day), all linked to the day object
      */
     public function getOrCreateFlintEvent(User $user): Event
     {
@@ -240,7 +241,7 @@ class FlintBlockCreationService
             ]
         );
 
-        // Get or create the Flint EventObject
+        // Get or create the Flint EventObject (represents the AI assistant)
         $flintObject = EventObject::firstOrCreate(
             [
                 'user_id' => $user->id,
@@ -256,37 +257,45 @@ class FlintBlockCreationService
             ]
         );
 
-        // Get or create event for today's analysis run
-        // Use updateOrCreate to respect the unique constraint on (integration_id, source_id)
-        // and update the timestamp and metadata each time it runs
+        // Get or create the day object (shared across all events today)
         $today = now()->startOfDay();
-        $dedupeKey = sprintf(
-            'flint_analysis_%s_%s',
-            $integration->id,
-            $today->format('Y-m-d')
-        );
+        $dateString = $today->format('Y-m-d');
 
-        // Use updateOrCreate with the unique constraint fields
-        // This will find existing event by integration_id + source_id, or create new one
-        $event = Event::updateOrCreate(
+        $dayObject = EventObject::firstOrCreate(
             [
-                'integration_id' => $integration->id,
-                'source_id' => $flintObject->id,
+                'user_id' => $user->id,
+                'concept' => 'day',
+                'type' => 'day',
+                'title' => $dateString,
             ],
             [
-                'actor_id' => $flintObject->id,
-                'target_id' => $flintObject->id,
                 'time' => $today,
-                'service' => 'flint',
-                'domain' => 'online',
-                'action' => 'had_analysis',
-                'event_metadata' => [
-                    'analysis_type' => 'multi_agent',
-                    'timestamp' => now()->toIso8601String(),
-                    'dedupe_key' => $dedupeKey,
-                ],
+                'content' => null,
+                'metadata' => [],
             ]
         );
+
+        // Create a new event for this analysis run
+        // Use synthetic source_id (like Monzo) to allow multiple events per day
+        // Day object goes in target_id, allowing all analysis events to relate to same day
+        $timestamp = now()->format('Y-m-d_H-i-s');
+        $syntheticSourceId = "flint_analysis_{$integration->id}_{$timestamp}";
+
+        $event = Event::create([
+            'integration_id' => $integration->id,
+            'source_id' => $syntheticSourceId,  // Unique synthetic ID
+            'actor_id' => $flintObject->id,      // The AI assistant
+            'target_id' => $dayObject->id,       // The day being analyzed
+            'time' => now(),
+            'service' => 'flint',
+            'domain' => 'online',
+            'action' => 'had_analysis',
+            'event_metadata' => [
+                'analysis_type' => 'multi_agent',
+                'timestamp' => now()->toIso8601String(),
+                'analysis_run_id' => $syntheticSourceId,
+            ],
+        ]);
 
         return $event;
     }

--- a/tests/Feature/FlintMultiAgentSystemTest.php
+++ b/tests/Feature/FlintMultiAgentSystemTest.php
@@ -197,26 +197,34 @@ class FlintMultiAgentSystemTest extends TestCase
     }
 
     /** @test */
-    public function it_deduplicates_flint_events_for_same_day()
+    public function it_creates_separate_events_per_analysis_run_for_same_day()
     {
         $blockCreation = app(\App\Services\FlintBlockCreationService::class);
 
-        // Create first event
+        // Create first event (e.g., morning analysis)
         $firstEvent = $blockCreation->getOrCreateFlintEvent($this->user);
         $firstEventId = $firstEvent->id;
 
-        // Call again - should return the same event
-        $secondEvent = $blockCreation->getOrCreateFlintEvent($this->user);
-        $this->assertEquals($firstEventId, $secondEvent->id, 'Should return the same event for the same day');
+        // Small delay to ensure different timestamp
+        sleep(1);
 
-        // Verify only one event exists
+        // Call again - should create a new event (e.g., afternoon analysis)
+        $secondEvent = $blockCreation->getOrCreateFlintEvent($this->user);
+        $this->assertNotEquals($firstEventId, $secondEvent->id, 'Should create a new event for each analysis run');
+
+        // Verify both events point to the same day object
+        $this->assertEquals($firstEvent->target_id, $secondEvent->target_id, 'Both events should point to the same day object');
+        $this->assertEquals('day', $firstEvent->target->concept);
+        $this->assertEquals(now()->format('Y-m-d'), $firstEvent->target->title);
+
+        // Verify multiple events exist for today
         $eventCount = Event::where('integration_id', $firstEvent->integration_id)
             ->where('action', 'had_analysis')
             ->where('service', 'flint')
             ->whereDate('time', now())
             ->count();
 
-        $this->assertEquals(1, $eventCount, 'Should only have one event for today');
+        $this->assertEquals(2, $eventCount, 'Should have two separate analysis events for today');
     }
 
     /** @test */


### PR DESCRIPTION
Changed from single perpetually-updated event to creating one event per analysis run (2-3 per day), following the pattern used by Monzo and other integrations.

Architecture:
- One EventObject per day (concept: 'day', type: 'day') - shared resource
- One Event per analysis run with unique synthetic source_id
- All blocks attach to their specific analysis event
- All events point to the same day object via target_id

Example structure:
  EventObject (Day: 2025-12-29) ├─ Event (Morning Analysis 06:00) → Blocks ├─ Event (Afternoon Analysis 12:00) → Blocks └─ Event (Evening Analysis 18:00) → Blocks

Changes:
- Use synthetic source_id (like Monzo): "flint_analysis_{id}_{timestamp}"
- Create day object following standard pattern (concept: 'day')
- Each analysis creates new event, not updateOrCreate
- Day object goes in target_id, not source_id
- Flint assistant object goes in actor_id

Benefits:
- Clean temporal separation of analysis runs
- Blocks grouped by analysis time, not all lumped together
- Respects unique constraint without workarounds
- Follows established patterns in codebase
- Easy to query "morning vs afternoon" insights

Updated test to verify:
- New event created per analysis run
- All events point to same day object
- Multiple events allowed per day