### PR TITLE
Fix Flint to use period-based events and resolve UUID error

### DIFF
--- a/app/Jobs/Flint/SendDigestNotificationJob.php
+++ b/app/Jobs/Flint/SendDigestNotificationJob.php
@@ -68,7 +68,7 @@ class SendDigestNotificationJob implements ShouldQueue
                         })
                         ->where('time', '>=', $today);
                 })
-                ->with(['event.source'])
+                ->with(['event.target'])
                 ->orderBy('created_at', 'desc')
                 ->first();
 
@@ -93,9 +93,9 @@ class SendDigestNotificationJob implements ShouldQueue
             // Get all blocks for this event (insights, actions, etc.)
             $allBlocks = Block::where('event_id', $digestBlock->event_id)->get();
 
-            // Send notification
+            // Send notification (target is the day object)
             $this->user->notify(new DailyDigestReady(
-                digestObject: $digestBlock->event->source,
+                digestObject: $digestBlock->event->target,
                 period: $period,
                 blocks: $allBlocks->toArray()
             ));

--- a/app/Services/FlintBlockCreationService.php
+++ b/app/Services/FlintBlockCreationService.php
@@ -275,27 +275,40 @@ class FlintBlockCreationService
             ]
         );
 
-        // Create a new event for this analysis run
-        // Use synthetic source_id (like Monzo) to allow multiple events per day
-        // Day object goes in target_id, allowing all analysis events to relate to same day
-        $timestamp = now()->format('Y-m-d_H-i-s');
-        $syntheticSourceId = "flint_analysis_{$integration->id}_{$timestamp}";
+        // Determine period: morning (<12), afternoon (12-18:59), evening (>=19)
+        $hour = (int) now()->format('H');
+        if ($hour < 12) {
+            $period = 'morning';
+        } elseif ($hour < 19) {
+            $period = 'afternoon';
+        } else {
+            $period = 'evening';
+        }
 
-        $event = Event::create([
-            'integration_id' => $integration->id,
-            'source_id' => $syntheticSourceId,  // Unique synthetic ID
-            'actor_id' => $flintObject->id,      // The AI assistant
-            'target_id' => $dayObject->id,       // The day being analyzed
-            'time' => now(),
-            'service' => 'flint',
-            'domain' => 'online',
-            'action' => 'had_analysis',
-            'event_metadata' => [
-                'analysis_type' => 'multi_agent',
-                'timestamp' => now()->toIso8601String(),
-                'analysis_run_id' => $syntheticSourceId,
+        // Create synthetic source_id that's the same for all agents in this period
+        // This allows multiple agent calls (domain, cross-domain, actions, digest) to update the same event
+        $syntheticSourceId = "flint_analysis_{$dateString}_{$period}";
+
+        // Use updateOrCreate so all agents in this analysis run share the same event
+        $event = Event::updateOrCreate(
+            [
+                'integration_id' => $integration->id,
+                'source_id' => $syntheticSourceId,  // Unique per period
             ],
-        ]);
+            [
+                'actor_id' => $flintObject->id,      // The AI assistant
+                'target_id' => $dayObject->id,       // The day being analyzed
+                'time' => now(),
+                'service' => 'flint',
+                'domain' => 'online',
+                'action' => 'had_analysis',
+                'event_metadata' => [
+                    'analysis_type' => 'multi_agent',
+                    'period' => $period,
+                    'timestamp' => now()->toIso8601String(),
+                ],
+            ]
+        );
 
         return $event;
     }

--- a/tests/Feature/FlintMultiAgentSystemTest.php
+++ b/tests/Feature/FlintMultiAgentSystemTest.php
@@ -197,34 +197,38 @@ class FlintMultiAgentSystemTest extends TestCase
     }
 
     /** @test */
-    public function it_creates_separate_events_per_analysis_run_for_same_day()
+    public function it_creates_one_event_per_period_and_reuses_for_same_period()
     {
         $blockCreation = app(\App\Services\FlintBlockCreationService::class);
 
-        // Create first event (e.g., morning analysis)
+        // Create first event (e.g., morning analysis - first agent)
         $firstEvent = $blockCreation->getOrCreateFlintEvent($this->user);
         $firstEventId = $firstEvent->id;
 
-        // Small delay to ensure different timestamp
-        sleep(1);
-
-        // Call again - should create a new event (e.g., afternoon analysis)
+        // Call again in same period (e.g., second agent in same workflow)
+        // Should return/update the same event
         $secondEvent = $blockCreation->getOrCreateFlintEvent($this->user);
-        $this->assertNotEquals($firstEventId, $secondEvent->id, 'Should create a new event for each analysis run');
+        $this->assertEquals($firstEventId, $secondEvent->id, 'Should return same event for same period');
 
-        // Verify both events point to the same day object
-        $this->assertEquals($firstEvent->target_id, $secondEvent->target_id, 'Both events should point to the same day object');
+        // Verify event has correct structure
         $this->assertEquals('day', $firstEvent->target->concept);
         $this->assertEquals(now()->format('Y-m-d'), $firstEvent->target->title);
+        $this->assertStringStartsWith('flint_analysis_', $firstEvent->source_id);
 
-        // Verify multiple events exist for today
+        // Verify period is in metadata
+        $this->assertArrayHasKey('period', $firstEvent->event_metadata);
+        $this->assertContains($firstEvent->event_metadata['period'], ['morning', 'afternoon', 'evening']);
+
+        // Verify source_id format matches expected pattern
+        $expectedPattern = '/^flint_analysis_\d{4}-\d{2}-\d{2}_(morning|afternoon|evening)$/';
+        $this->assertMatchesRegularExpression($expectedPattern, $firstEvent->source_id);
+
+        // Verify only one event exists for this period
         $eventCount = Event::where('integration_id', $firstEvent->integration_id)
-            ->where('action', 'had_analysis')
-            ->where('service', 'flint')
-            ->whereDate('time', now())
+            ->where('source_id', $firstEvent->source_id)
             ->count();
 
-        $this->assertEquals(2, $eventCount, 'Should have two separate analysis events for today');
+        $this->assertEquals(1, $eventCount, 'Should only have one event for this period');
     }
 
     /** @test */


### PR DESCRIPTION
Fixed two critical issues:

1. Multiple events per workflow: Each agent (domain, cross-domain, actions, digest) was creating a separate event. Now all agents in one analysis run share the same event via updateOrCreate.

2. UUID error: source_id is a synthetic string, but the source() relationship tried to load it as a UUID. Changed to use target relationship instead.

Changes:

Source ID Pattern:
- Changed from: flint_analysis_{integration_id}_{timestamp}
- Changed to: flint_analysis_{YYYY-MM-DD}_{period}
- Periods: morning (<12), afternoon (12-18:59), evening (>=19:00)
- Matches user's requested 7pm cutoff for evening

Event Strategy:
- Use updateOrCreate instead of create
- All agents in same period share one event
- Event reused across domain agents, cross-domain, actions, digest
- Results in 1 event per period (max 3 per day) instead of 4+ events

Relationship Fix:
- Changed SendDigestNotificationJob from event.source to event.target
- target = day object (EventObject with concept: 'day')
- source_id remains synthetic string for uniqueness constraint only

Test Updates:
- Now expects same event for same period (not different events)
- Verifies source_id pattern matches expected format
- Confirms period metadata is present and valid
- Validates only one event exists per period

Structure:
  EventObject (Day: 2025-12-29) ├─ Event (Morning Analysis) → All morning blocks ├─ Event (Afternoon Analysis) → All afternoon blocks └─ Event (Evening Analysis) → All evening blocks