### PR TITLE
Fix TypeError when last_error is an array in saved bookmarks tab

### DIFF
--- a/resources/views/livewire/bookmarks/tabs/saved.blade.php
+++ b/resources/views/livewire/bookmarks/tabs/saved.blade.php
@@ -118,7 +118,7 @@
             @if ($page['last_error'])
             <div class="alert alert-error mt-2">
                 <x-icon name="fas.triangle-exclamation" class="w-5 h-5" />
-                <span class="text-sm">{{ $page['last_error'] }}</span>
+                <span class="text-sm">{{ is_array($page['last_error']) ? ($page['last_error']['message'] ?? json_encode($page['last_error'])) : $page['last_error'] }}</span>
             </div>
             @endif
         </div>


### PR DESCRIPTION
The saved bookmarks tab was failing with "htmlspecialchars(): Argument #1 ($string) must be of type string, array given" because last_error metadata can be stored as an array (with message/timestamp keys) rather than a string.

Now handles both formats: extracts the message key from arrays, or displays the string directly.