### PR TITLE
✨ GoCardless EUA reconfirmation, TfL Oyster integration, and UI improvements

### DIFF
--- a/resources/views/livewire/auth/register.blade.php
+++ b/resources/views/livewire/auth/register.blade.php
@@ -8,10 +8,14 @@ use Illuminate\Validation\Rules;
 use Livewire\Attributes\Layout;
 use Livewire\Volt\Component;
 
-new #[Layout('components.layouts.auth')] class extends Component {
+new #[Layout('components.layouts.auth')] class extends Component
+{
     public string $name = '';
+
     public string $email = '';
+
     public string $password = '';
+
     public string $password_confirmation = '';
 
     /**
@@ -21,7 +25,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
     {
         $validated = $this->validate([
             'name' => ['required', 'string', 'max:255'],
-            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:' . User::class],
+            'email' => ['required', 'string', 'lowercase', 'email', 'max:255', 'unique:'.User::class],
             'password' => ['required', 'string', 'confirmed', Rules\Password::defaults()],
         ]);
 
@@ -92,7 +96,7 @@ new #[Layout('components.layouts.auth')] class extends Component {
         </div>
     </form>
 
-    <div class="space-x-1 rtl:space-x-reverse text-center text-sm text-zinc-600 dark:text-zinc-400">
+    <div class="space-x-1 rtl:space-x-reverse text-center text-sm text-zinc-600 dark:text-zinc-300">
         <span>{{ __('Already have an account?') }}</span>
         <flux:link :href="route('login')" wire:navigate>{{ __('Log in') }}</flux:link>
     </div>

--- a/resources/views/livewire/go-cardless-reconfirm-banner.blade.php
+++ b/resources/views/livewire/go-cardless-reconfirm-banner.blade.php
@@ -3,50 +3,52 @@
         $bankName = $group->auth_metadata['gocardless_institution_name'] ?? 'Bank';
     @endphp
 
-    <flux:card class="mb-6 border-l-4 border-orange-500">
-        <div class="flex items-start gap-4">
+    <div class="alert alert-warning mb-6 border-l-4 border-warning">
+        <div class="flex items-start gap-4 w-full">
             <div class="flex-shrink-0">
-                <flux:icon.exclamation-triangle variant="solid" class="size-6 text-orange-500"/>
+                <x-icon name="fas.triangle-exclamation" class="w-6 h-6 text-warning" />
             </div>
 
             <div class="flex-1">
-                <flux:heading size="lg" class="mb-2">
+                <h3 class="text-lg font-semibold text-base-content mb-2">
                     {{ $bankName }} Connection Expired
-                </flux:heading>
+                </h3>
 
-                <flux:text class="mb-4 text-zinc-600 dark:text-zinc-400">
+                <p class="text-sm text-base-content/80 mb-4">
                     Your {{ $bankName }} connection needs to be renewed. This is required every 90 days for security. Your transaction history will not be affected.
-                </flux:text>
+                </p>
 
                 @error('general')
-                    <flux:error class="mb-4">
-                        {{ $message }}
-                    </flux:error>
+                    <div class="alert alert-error mb-4">
+                        <x-icon name="fas.circle-exclamation" class="w-5 h-5" />
+                        <span>{{ $message }}</span>
+                    </div>
                 @enderror
 
                 <div class="flex gap-3">
-                    <flux:button
+                    <button
                         wire:click="attemptReconfirmation"
                         wire:loading.attr="disabled"
-                        variant="primary"
+                        class="btn btn-primary"
                     >
                         <span wire:loading.remove wire:target="attemptReconfirmation,createNewEua">
                             Reconnect {{ $bankName }}
                         </span>
                         <span wire:loading wire:target="attemptReconfirmation,createNewEua">
+                            <span class="loading loading-spinner loading-sm"></span>
                             Loading...
                         </span>
-                    </flux:button>
+                    </button>
 
-                    <flux:button
+                    <button
                         wire:click="createNewEua"
                         wire:loading.attr="disabled"
-                        variant="ghost"
+                        class="btn btn-ghost"
                     >
                         Connect Different Account
-                    </flux:button>
+                    </button>
                 </div>
             </div>
         </div>
-    </flux:card>
+    </div>
 </div>


### PR DESCRIPTION
## Summary

This PR includes several improvements and new features:

### GoCardless EUA Reconfirmation Flow
- Implement automatic detection of expired GoCardless EUAs (End User Agreements)
- Add reconfirmation banner and flow for renewing expired bank connections
- Add `HandleExpiredEuaJob` to manage EUA expiry and reauthorization
- Add `GoCardlessEuaExpiredException` for proper error handling
- Improve EUA summary field checking to detect expiry status
- Add comprehensive unit tests for EUA expiry detection

### TfL Oyster Integration
- Add complete Oyster card integration for London transport tracking
- Parse Oyster journey and transaction data from emails
- Intelligent transport mode detection (Tube, Bus, Overground, etc.)
- Station lookup and journey linking functionality
- Support for both PDF and CSV Oyster statements
- Create events for journeys, top-ups, and auto top-ups
- Comprehensive test coverage for parsing and transport mode detection

### Places & Events
- Use event-ref cards on places show page for better UX

### UI Component Fixes
- **Fix GoCardless reconnection banner** - replace non-existent Flux components with DaisyUI/Mary UI
- Improve dark mode text contrast (zinc-400 → zinc-300)
- Use semantic DaisyUI color tokens for better theme support
- Add DaisyUI loading spinner for better UX
- Fix bookmark error handling when last_error is an array

### Configuration
- Add Conductor workspace configuration  
- Update environment configuration for local development
- Add Oyster S3 bucket configuration

## Test plan

- [ ] GoCardless EUA expiry is detected correctly
- [ ] Reconfirmation banner displays properly in light and dark mode
- [ ] Reconfirmation flow works end-to-end
- [ ] Oyster email parsing works for PDFs and CSVs
- [ ] Oyster journeys are created and linked correctly
- [ ] Transport mode detection is accurate
- [ ] Places page shows event-ref cards correctly
- [ ] All tests pass (`sail artisan test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)