### PR TITLE
Fix PostgreSQL bigint type error in receipt matching

### DIFF
--- a/app/Jobs/Data/Receipt/FindReceiptForTransactionJob.php
+++ b/app/Jobs/Data/Receipt/FindReceiptForTransactionJob.php
@@ -46,7 +46,7 @@ class FindReceiptForTransactionJob implements ShouldQueue
                 ->whereBetween('time', [$startTime, $endTime])
                 ->where(function ($query) {
                     // Amount within ±10% of transaction
-                    $tolerance = $this->transactionEvent->value * 0.1;
+                    $tolerance = (int) ($this->transactionEvent->value * 0.1);
                     $query->whereBetween('value', [
                         max(0, $this->transactionEvent->value - $tolerance),
                         $this->transactionEvent->value + $tolerance,


### PR DESCRIPTION
## Summary
Fixes a PostgreSQL error in `FindReceiptForTransactionJob` where floating-point tolerance calculations were being used in a BETWEEN clause on a bigint column.

## Problem
The 10% tolerance calculation (`$value * 0.1`) was producing float values (e.g., 265089.6 and 323998.4), which PostgreSQL cannot use with bigint columns, causing "invalid input syntax for type bigint" errors.

## Solution
Cast the tolerance calculation to `(int)` to ensure integer bounds, following the established pattern in `ReceiptTransactionMatcher` which already handles this correctly.

## Testing
- Verified with manual tinker tests that the calculation produces integers
- All ReceiptTransactionMatcher tests pass
- Database query executes successfully with integer bounds

🧪 Generated with [Claude Code](https://claude.com/claude-code)