### PR TITLE
⚡ Fix N+1 queries across job pipeline and views

### DIFF
--- a/app/Jobs/Base/BaseProcessingJob.php
+++ b/app/Jobs/Base/BaseProcessingJob.php
@@ -20,6 +20,7 @@ use Sentry\Severity;
 use Sentry\Tracing\SpanContext;
 use Sentry\Tracing\SpanStatus;
 use Sentry\Tracing\TransactionContext;
+use Spatie\Tags\Tag;
 use Throwable;
 
 abstract class BaseProcessingJob implements ShouldQueue
@@ -149,6 +150,7 @@ abstract class BaseProcessingJob implements ShouldQueue
     protected function createEvents(array $eventData): Collection
     {
         $events = collect();
+        $eventTagsMap = [];
 
         foreach ($eventData as $data) {
             // Skip if event already exists to prevent duplicate key violations
@@ -208,23 +210,9 @@ abstract class BaseProcessingJob implements ShouldQueue
                     }
                 }
 
-                // Attach tags if provided in payload (supports optional typed tags)
-                if (isset($data['tags']) && is_array($data['tags'])) {
-                    foreach ($data['tags'] as $tag) {
-                        if (is_array($tag)) {
-                            $name = (string) ($tag['name'] ?? '');
-                            $type = $tag['type'] ?? null;
-                            if ($name !== '') {
-                                if ($type) {
-                                    $event->attachTag($name, (string) $type);
-                                } else {
-                                    $event->attachTag($name, 'spark_tag');
-                                }
-                            }
-                        } elseif (is_string($tag) && $tag !== '') {
-                            $event->attachTag($tag, 'spark_tag');
-                        }
-                    }
+                // Store tags for batch processing (prevents N+1 queries)
+                if (isset($data['tags']) && is_array($data['tags']) && ! empty($data['tags'])) {
+                    $eventTagsMap[$data['source_id']] = $data['tags'];
                 }
 
                 // Set location and link to place if route data is present (Apple Health workouts)
@@ -286,6 +274,11 @@ abstract class BaseProcessingJob implements ShouldQueue
             }
         }
 
+        // Batch attach all tags at once to prevent N+1 queries
+        if (! empty($eventTagsMap)) {
+            $this->attachTagsInBatch($events, $eventTagsMap);
+        }
+
         return $events;
     }
 
@@ -330,6 +323,9 @@ abstract class BaseProcessingJob implements ShouldQueue
     protected function downloadImagesToMediaLibrary(Collection $events): void
     {
         $mediaHelper = app(\App\Services\Media\MediaDownloadHelper::class);
+
+        // Eager load relationships to prevent N+1 queries
+        $events->load(['blocks', 'target', 'actor']);
 
         foreach ($events as $event) {
             // Download images from blocks with media_url
@@ -439,6 +435,64 @@ abstract class BaseProcessingJob implements ShouldQueue
                         'error' => $e->getMessage(),
                     ]);
                 }
+            }
+        }
+    }
+
+    /**
+     * Batch attach tags to multiple events to prevent N+1 queries.
+     * Fetches all needed tags upfront and attaches them using IDs.
+     */
+    protected function attachTagsInBatch(Collection $events, array $eventTagsMap): void
+    {
+        if (empty($eventTagsMap)) {
+            return;
+        }
+
+        // Step 1: Collect all unique tags across all events
+        $allTags = collect($eventTagsMap)
+            ->flatten(1)
+            ->unique(function ($tag) {
+                $name = is_array($tag) ? ($tag['name'] ?? '') : $tag;
+                $type = is_array($tag) ? ($tag['type'] ?? 'spark_tag') : 'spark_tag';
+
+                return "{$type}:{$name}";
+            })
+            ->filter(fn ($tag) => ! empty(is_array($tag) ? ($tag['name'] ?? '') : $tag));
+
+        // Step 2: Batch fetch/create all tags upfront (one query per unique tag)
+        $tagsByKey = collect();
+        foreach ($allTags as $tag) {
+            $name = is_array($tag) ? ($tag['name'] ?? '') : $tag;
+            $type = is_array($tag) ? ($tag['type'] ?? 'spark_tag') : 'spark_tag';
+            $key = "{$type}:{$name}";
+
+            if (! $tagsByKey->has($key)) {
+                $tagObject = Tag::findOrCreate($name, $type);
+                $tagsByKey->put($key, $tagObject);
+            }
+        }
+
+        // Step 3: Attach tags to events using IDs (no additional queries)
+        foreach ($events as $event) {
+            $eventTags = $eventTagsMap[$event->source_id] ?? [];
+            if (empty($eventTags)) {
+                continue;
+            }
+
+            $tagIds = collect($eventTags)
+                ->map(function ($tag) use ($tagsByKey) {
+                    $name = is_array($tag) ? ($tag['name'] ?? '') : $tag;
+                    $type = is_array($tag) ? ($tag['type'] ?? 'spark_tag') : 'spark_tag';
+
+                    return $tagsByKey->get("{$type}:{$name}")?->id;
+                })
+                ->filter()
+                ->unique()
+                ->toArray();
+
+            if (! empty($tagIds)) {
+                $event->tags()->syncWithoutDetaching($tagIds);
             }
         }
     }

--- a/app/Jobs/Data/Oura/OuraActivityData.php
+++ b/app/Jobs/Data/Oura/OuraActivityData.php
@@ -46,8 +46,19 @@ class OuraActivityData extends BaseProcessingJob
             'activity_count' => count($activityItems),
         ]);
 
+        // Batch check existence to prevent N+1 queries
+        $sourceIds = collect($activityItems)
+            ->map(fn ($item) => $item['day'] ? "oura_activity_{$this->integration->id}_{$item['day']}" : null)
+            ->filter()
+            ->toArray();
+
+        $existingSourceIds = Event::where('integration_id', $this->integration->id)
+            ->whereIn('source_id', $sourceIds)
+            ->pluck('source_id')
+            ->flip(); // For O(1) lookup
+
         foreach ($activityItems as $item) {
-            $this->createEnhancedActivityEvent($plugin, $item);
+            $this->createEnhancedActivityEvent($plugin, $item, $existingSourceIds);
         }
 
         Log::info('OuraActivityData: Completed processing activity data', [
@@ -58,7 +69,7 @@ class OuraActivityData extends BaseProcessingJob
     /**
      * Create activity event with full API v2 field support
      */
-    private function createEnhancedActivityEvent(OuraPlugin $plugin, array $item): void
+    private function createEnhancedActivityEvent(OuraPlugin $plugin, array $item, \Illuminate\Support\Collection $existingSourceIds): void
     {
         $day = $item['day'] ?? null;
         if (! $day) {
@@ -66,10 +77,9 @@ class OuraActivityData extends BaseProcessingJob
         }
 
         $sourceId = "oura_activity_{$this->integration->id}_{$day}";
-        $exists = Event::where('source_id', $sourceId)
-            ->where('integration_id', $this->integration->id)
-            ->first();
-        if ($exists) {
+
+        // Check existence in memory (no query)
+        if ($existingSourceIds->has($sourceId)) {
             return;
         }
 

--- a/app/Jobs/Data/Oura/OuraSleepData.php
+++ b/app/Jobs/Data/Oura/OuraSleepData.php
@@ -36,8 +36,19 @@ class OuraSleepData extends BaseProcessingJob
             'sleep_count' => count($sleepItems),
         ]);
 
+        // Batch check existence to prevent N+1 queries
+        $sourceIds = collect($sleepItems)
+            ->map(fn ($item) => $item['day'] ? "oura_sleep_{$this->integration->id}_{$item['day']}" : null)
+            ->filter()
+            ->toArray();
+
+        $existingSourceIds = Event::where('integration_id', $this->integration->id)
+            ->whereIn('source_id', $sourceIds)
+            ->pluck('source_id')
+            ->flip(); // For O(1) lookup
+
         foreach ($sleepItems as $item) {
-            $this->createEnhancedSleepEvent($plugin, $item);
+            $this->createEnhancedSleepEvent($plugin, $item, $existingSourceIds);
         }
 
         Log::info('OuraSleepData: Completed processing sleep data', [
@@ -48,7 +59,7 @@ class OuraSleepData extends BaseProcessingJob
     /**
      * Create enhanced sleep event with full API v2 field support
      */
-    private function createEnhancedSleepEvent(OuraPlugin $plugin, array $item): void
+    private function createEnhancedSleepEvent(OuraPlugin $plugin, array $item, \Illuminate\Support\Collection $existingSourceIds): void
     {
         $day = $item['day'] ?? null;
         if (! $day) {
@@ -56,10 +67,9 @@ class OuraSleepData extends BaseProcessingJob
         }
 
         $sourceId = "oura_sleep_{$this->integration->id}_{$day}";
-        $exists = Event::where('source_id', $sourceId)
-            ->where('integration_id', $this->integration->id)
-            ->first();
-        if ($exists) {
+
+        // Check existence in memory (no query)
+        if ($existingSourceIds->has($sourceId)) {
             return;
         }
 

--- a/app/Jobs/Flint/ProcessCoachingResponseJob.php
+++ b/app/Jobs/Flint/ProcessCoachingResponseJob.php
@@ -214,32 +214,40 @@ PROMPT;
 
         // If patterns span multiple domains, look for cross-domain connections
         if (count($patternDomains) > 1) {
-            foreach ($patternDomains as $domain) {
-                $crossDomainPatterns = $patternLearning->findCrossDomainPatterns(
-                    $this->user,
-                    $domain
-                );
+            // Query all cross-domain patterns at once instead of per domain
+            $crossDomainPatterns = EventObject::where('user_id', $this->user->id)
+                ->where('concept', 'flint')
+                ->where('type', 'learned_pattern')
+                ->whereNull('deleted_at')
+                ->whereRaw("jsonb_array_length((metadata::jsonb)->'domains') > 1")
+                ->where(function ($query) use ($patternDomains) {
+                    foreach ($patternDomains as $domain) {
+                        $query->orWhereRaw("(metadata::jsonb)->'domains' @> ?", [json_encode([$domain])]);
+                    }
+                })
+                ->where('time', '>=', now()->subDays(90))
+                ->orderByRaw("(metadata->>'confidence_score')::numeric DESC")
+                ->get();
 
-                if ($crossDomainPatterns->isNotEmpty()) {
-                    // Store cross-domain connections in the coaching session metadata
-                    $metadata = $this->coachingSession->metadata;
-                    $metadata['cross_domain_insights'] = $crossDomainPatterns
-                        ->map(fn ($pattern) => [
-                            'pattern_id' => $pattern->id,
-                            'title' => $pattern->title,
-                            'domains' => $pattern->metadata['domains'] ?? [],
-                            'confidence' => $pattern->metadata['confidence_score'] ?? 0.3,
-                        ])
-                        ->toArray();
+            if ($crossDomainPatterns->isNotEmpty()) {
+                // Store cross-domain connections in the coaching session metadata
+                $metadata = $this->coachingSession->metadata;
+                $metadata['cross_domain_insights'] = $crossDomainPatterns
+                    ->map(fn ($pattern) => [
+                        'pattern_id' => $pattern->id,
+                        'title' => $pattern->title,
+                        'domains' => $pattern->metadata['domains'] ?? [],
+                        'confidence' => $pattern->metadata['confidence_score'] ?? 0.3,
+                    ])
+                    ->toArray();
 
-                    $this->coachingSession->metadata = $metadata;
-                    $this->coachingSession->save();
+                $this->coachingSession->metadata = $metadata;
+                $this->coachingSession->save();
 
-                    Log::info('[Flint] [COACHING] Detected cross-domain connections', [
-                        'session_id' => $this->coachingSession->id,
-                        'connections' => count($crossDomainPatterns),
-                    ]);
-                }
+                Log::info('[Flint] [COACHING] Detected cross-domain connections', [
+                    'session_id' => $this->coachingSession->id,
+                    'connections' => count($crossDomainPatterns),
+                ]);
             }
         }
 
@@ -267,7 +275,7 @@ PROMPT;
 
         if ($anomalyId) {
             try {
-                $anomaly = MetricTrend::find($anomalyId);
+                $anomaly = MetricTrend::with('metricStatistic')->find($anomalyId);
                 if ($anomaly) {
                     $anomaly->acknowledge();
 
@@ -316,10 +324,35 @@ PROMPT;
         PatternLearningService $patternLearning,
         array $extractedPatterns
     ): void {
+        if (empty($extractedPatterns)) {
+            return;
+        }
+
         // Get the learned patterns that were just stored
         $learnedPatterns = $patternLearning->getLearnedPatterns($this->user, 0.3);
 
-        // For each new pattern, find and tag related events
+        // Get anomaly context once
+        $anomalyContext = $this->coachingSession->metadata['anomaly_context'] ?? [];
+        $service = $anomalyContext['service'] ?? null;
+        $action = $anomalyContext['action'] ?? null;
+
+        if (! $service || ! $action) {
+            return;
+        }
+
+        // Query events ONCE for all patterns (prevents N+1 queries)
+        $relatedEvents = Event::forUser($this->user->id)
+            ->where('service', $service)
+            ->where('action', $action)
+            ->where('time', '>=', now()->subDays(7))
+            ->limit(50)
+            ->get();
+
+        if ($relatedEvents->isEmpty()) {
+            return;
+        }
+
+        // For each new pattern, tag related events using the same event collection
         foreach ($extractedPatterns as $pattern) {
             $learnedPattern = $learnedPatterns->first(fn ($p) => $p->title === $pattern['title']);
 
@@ -327,26 +360,12 @@ PROMPT;
                 continue;
             }
 
-            // Find related events from the anomaly period
-            $anomalyContext = $this->coachingSession->metadata['anomaly_context'] ?? [];
-            $service = $anomalyContext['service'] ?? null;
-            $action = $anomalyContext['action'] ?? null;
-
-            if ($service && $action) {
-                $relatedEvents = Event::forUser($this->user->id)
-                    ->where('service', $service)
-                    ->where('action', $action)
-                    ->where('time', '>=', now()->subDays(7))
-                    ->limit(5)
-                    ->get();
-
-                foreach ($relatedEvents as $event) {
-                    $patternLearning->tagEventWithInsight(
-                        $event,
-                        $learnedPattern,
-                        $pattern['user_explanation']
-                    );
-                }
+            foreach ($relatedEvents->take(5) as $event) {
+                $patternLearning->tagEventWithInsight(
+                    $event,
+                    $learnedPattern,
+                    $pattern['user_explanation']
+                );
             }
         }
     }

--- a/app/Livewire/IntegrationDetails.php
+++ b/app/Livewire/IntegrationDetails.php
@@ -243,23 +243,37 @@ class IntegrationDetails extends Component
             return [];
         }
 
-        return collect($pluginClass::getActionTypes())->map(function ($action, $key) {
+        $actionTypes = $pluginClass::getActionTypes();
+        $actionKeys = array_keys($actionTypes);
+
+        // Get all counts in one query using groupBy
+        $actionCounts = Event::where('integration_id', $this->integration->id)
+            ->selectRaw('action, count(*) as count')
+            ->whereIn('action', $actionKeys)
+            ->groupBy('action')
+            ->pluck('count', 'action');
+
+        // Get all recent events in one query, then group by action
+        $allRecentEvents = Event::where('integration_id', $this->integration->id)
+            ->whereIn('action', $actionKeys)
+            ->with('target')
+            ->orderBy('created_at', 'desc')
+            ->get();
+
+        $recentByAction = $allRecentEvents->groupBy('action')
+            ->map(fn ($group) => $group->take(5));
+
+        // Get newest events (top 1 per action) from the recent events
+        $newestByAction = $allRecentEvents->groupBy('action')
+            ->map(fn ($group) => $group->first());
+
+        return collect($actionTypes)->map(function ($action, $key) use ($actionCounts, $recentByAction, $newestByAction) {
             return [
                 'key' => $key,
                 'action' => $action,
-                'count' => Event::where('integration_id', $this->integration->id)
-                    ->where('action', $key)
-                    ->count(),
-                'recent' => Event::where('integration_id', $this->integration->id)
-                    ->where('action', $key)
-                    ->with('target')
-                    ->orderBy('created_at', 'desc')
-                    ->limit(5)
-                    ->get(),
-                'newest' => Event::where('integration_id', $this->integration->id)
-                    ->where('action', $key)
-                    ->orderBy('created_at', 'desc')
-                    ->first(),
+                'count' => $actionCounts[$key] ?? 0,
+                'recent' => $recentByAction[$key] ?? collect(),
+                'newest' => $newestByAction[$key] ?? null,
             ];
         })->toArray();
     }
@@ -271,41 +285,57 @@ class IntegrationDetails extends Component
             return [];
         }
 
-        return collect($pluginClass::getObjectTypes())->map(function ($object, $key) {
+        $objectTypes = $pluginClass::getObjectTypes();
+        $objectTypeKeys = array_keys($objectTypes);
+
+        // Get all object IDs associated with this integration's events
+        $objectIds = Event::where('integration_id', $this->integration->id)
+            ->select('actor_id', 'target_id')
+            ->get()
+            ->flatMap(fn ($event) => [$event->actor_id, $event->target_id])
+            ->filter()
+            ->unique()
+            ->values();
+
+        // If no objects found, return early
+        if ($objectIds->isEmpty()) {
+            return collect($objectTypes)->map(function ($object, $key) {
+                return [
+                    'key' => $key,
+                    'object' => $object,
+                    'count' => 0,
+                    'recent' => collect(),
+                    'newest' => null,
+                ];
+            })->toArray();
+        }
+
+        // Get counts grouped by type
+        $objectCounts = EventObject::whereIn('id', $objectIds)
+            ->whereIn('type', $objectTypeKeys)
+            ->selectRaw('type, count(*) as count')
+            ->groupBy('type')
+            ->pluck('count', 'type');
+
+        // Get all objects of these types, ordered by created_at
+        $allObjects = EventObject::whereIn('id', $objectIds)
+            ->whereIn('type', $objectTypeKeys)
+            ->orderBy('created_at', 'desc')
+            ->get();
+
+        $recentByType = $allObjects->groupBy('type')
+            ->map(fn ($group) => $group->take(5));
+
+        $newestByType = $allObjects->groupBy('type')
+            ->map(fn ($group) => $group->first());
+
+        return collect($objectTypes)->map(function ($object, $key) use ($objectCounts, $recentByType, $newestByType) {
             return [
                 'key' => $key,
                 'object' => $object,
-                'count' => EventObject::where('type', $key)
-                    ->where(function ($query) {
-                        $query->whereHas('actorEvents', function ($q) {
-                            $q->where('integration_id', $this->integration->id);
-                        })->orWhereHas('targetEvents', function ($q) {
-                            $q->where('integration_id', $this->integration->id);
-                        });
-                    })
-                    ->count(),
-                'recent' => EventObject::where('type', $key)
-                    ->where(function ($query) {
-                        $query->whereHas('actorEvents', function ($q) {
-                            $q->where('integration_id', $this->integration->id);
-                        })->orWhereHas('targetEvents', function ($q) {
-                            $q->where('integration_id', $this->integration->id);
-                        });
-                    })
-                    ->with(['actorEvents', 'targetEvents'])
-                    ->orderBy('created_at', 'desc')
-                    ->limit(5)
-                    ->get(),
-                'newest' => EventObject::where('type', $key)
-                    ->where(function ($query) {
-                        $query->whereHas('actorEvents', function ($q) {
-                            $q->where('integration_id', $this->integration->id);
-                        })->orWhereHas('targetEvents', function ($q) {
-                            $q->where('integration_id', $this->integration->id);
-                        });
-                    })
-                    ->orderBy('created_at', 'desc')
-                    ->first(),
+                'count' => $objectCounts[$key] ?? 0,
+                'recent' => $recentByType[$key] ?? collect(),
+                'newest' => $newestByType[$key] ?? null,
             ];
         })->toArray();
     }
@@ -317,29 +347,53 @@ class IntegrationDetails extends Component
             return [];
         }
 
-        return collect($pluginClass::getBlockTypes())->map(function ($block, $key) {
+        $blockTypes = $pluginClass::getBlockTypes();
+        $blockTypeKeys = array_keys($blockTypes);
+
+        // Get all event IDs for this integration
+        $eventIds = Event::where('integration_id', $this->integration->id)
+            ->pluck('id');
+
+        // If no events found, return early
+        if ($eventIds->isEmpty()) {
+            return collect($blockTypes)->map(function ($block, $key) {
+                return [
+                    'key' => $key,
+                    'block' => $block,
+                    'count' => 0,
+                    'recent' => collect(),
+                    'newest' => null,
+                ];
+            })->toArray();
+        }
+
+        // Get counts grouped by block_type
+        $blockCounts = Block::whereIn('event_id', $eventIds)
+            ->whereIn('block_type', $blockTypeKeys)
+            ->selectRaw('block_type, count(*) as count')
+            ->groupBy('block_type')
+            ->pluck('count', 'block_type');
+
+        // Get all blocks of these types, ordered by created_at
+        $allBlocks = Block::whereIn('event_id', $eventIds)
+            ->whereIn('block_type', $blockTypeKeys)
+            ->with('event')
+            ->orderBy('created_at', 'desc')
+            ->get();
+
+        $recentByType = $allBlocks->groupBy('block_type')
+            ->map(fn ($group) => $group->take(5));
+
+        $newestByType = $allBlocks->groupBy('block_type')
+            ->map(fn ($group) => $group->first());
+
+        return collect($blockTypes)->map(function ($block, $key) use ($blockCounts, $recentByType, $newestByType) {
             return [
                 'key' => $key,
                 'block' => $block,
-                'count' => Block::where('block_type', $key)
-                    ->whereHas('event', function ($query) {
-                        $query->where('integration_id', $this->integration->id);
-                    })
-                    ->count(),
-                'recent' => Block::where('block_type', $key)
-                    ->whereHas('event', function ($query) {
-                        $query->where('integration_id', $this->integration->id);
-                    })
-                    ->with('event')
-                    ->orderBy('created_at', 'desc')
-                    ->limit(5)
-                    ->get(),
-                'newest' => Block::where('block_type', $key)
-                    ->whereHas('event', function ($query) {
-                        $query->where('integration_id', $this->integration->id);
-                    })
-                    ->orderBy('created_at', 'desc')
-                    ->first(),
+                'count' => $blockCounts[$key] ?? 0,
+                'recent' => $recentByType[$key] ?? collect(),
+                'newest' => $newestByType[$key] ?? null,
             ];
         })->toArray();
     }

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -9,6 +9,7 @@ use Clickbar\Magellan\Data\Geometries\Point;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Collection;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Spatie\Activitylog\LogOptions;
@@ -670,6 +671,57 @@ class Event extends Model
             'location && ST_MakeEnvelope(?, ?, ?, ?, 4326)',
             [$west, $south, $east, $north]
         );
+    }
+
+    /**
+     * Create or update multiple blocks efficiently using batch operations.
+     * Prevents N+1 queries by pre-loading existing blocks.
+     */
+    public function createBlocksInBatch(array $blocksData): Collection
+    {
+        if (empty($blocksData)) {
+            return collect();
+        }
+
+        // Step 1: Pre-load ALL existing blocks for this event (1 query)
+        $existingBlocks = $this->blocks()
+            ->whereNull('deleted_at')
+            ->get()
+            ->keyBy(fn ($block) => $block->title . '::' . ($block->block_type ?? 'null'));
+
+        $blocksToUpdate = [];
+        $blocksToCreate = [];
+        $resultBlocks = collect();
+
+        foreach ($blocksData as $blockData) {
+            $key = $blockData['title'] . '::' . ($blockData['block_type'] ?? 'null');
+
+            if ($existingBlocks->has($key)) {
+                // Update existing block
+                $existingBlock = $existingBlocks->get($key);
+                $existingBlock->fill($blockData);
+                $blocksToUpdate[] = $existingBlock;
+                $resultBlocks->push($existingBlock);
+            } else {
+                // Prepare for creation
+                $blockData['event_id'] = $this->id;
+                $blockData['time'] = $blockData['time'] ?? $this->time;
+                $blocksToCreate[] = $blockData;
+            }
+        }
+
+        // Batch update
+        foreach ($blocksToUpdate as $block) {
+            $block->save();
+        }
+
+        // Batch create
+        foreach ($blocksToCreate as $blockData) {
+            $block = Block::create($blockData);
+            $resultBlocks->push($block);
+        }
+
+        return $resultBlocks;
     }
 
     /**

--- a/app/Services/PatternLearningService.php
+++ b/app/Services/PatternLearningService.php
@@ -314,30 +314,33 @@ class PatternLearningService
             return $pattern;
         }
 
-        $crossDomainConnections = [];
-
-        foreach ($domains as $domain) {
-            // Find other patterns in this domain
-            $relatedPatterns = $this->findCrossDomainPatterns($user, $domain, 90);
-
-            foreach ($relatedPatterns as $relatedPattern) {
-                if ($relatedPattern->id === $pattern->id) {
-                    continue;
+        // Query all related cross-domain patterns in one go instead of per domain
+        $relatedPatterns = EventObject::where('user_id', $user->id)
+            ->where('concept', 'flint')
+            ->where('type', 'learned_pattern')
+            ->where('id', '!=', $pattern->id)
+            ->whereNull('deleted_at')
+            ->whereRaw("jsonb_array_length((metadata::jsonb)->'domains') > 1")
+            ->where(function ($query) use ($domains) {
+                foreach ($domains as $domain) {
+                    $query->orWhereRaw("(metadata::jsonb)->'domains' @> ?", [json_encode([$domain])]);
                 }
+            })
+            ->where('time', '>=', now()->subDays(90))
+            ->orderByRaw("(metadata->>'confidence_score')::numeric DESC")
+            ->get();
 
-                $crossDomainConnections[] = [
-                    'pattern_id' => $relatedPattern->id,
-                    'title' => $relatedPattern->title,
-                    'domains' => $relatedPattern->metadata['domains'] ?? [],
-                    'confidence' => $relatedPattern->metadata['confidence_score'] ?? 0.3,
-                    'explanation' => $relatedPattern->metadata['user_explanation'] ?? '',
-                ];
-            }
-        }
+        if ($relatedPatterns->isNotEmpty()) {
+            $crossDomainConnections = $relatedPatterns->map(fn ($relatedPattern) => [
+                'pattern_id' => $relatedPattern->id,
+                'title' => $relatedPattern->title,
+                'domains' => $relatedPattern->metadata['domains'] ?? [],
+                'confidence' => $relatedPattern->metadata['confidence_score'] ?? 0.3,
+                'explanation' => $relatedPattern->metadata['user_explanation'] ?? '',
+            ])->take(5)->toArray();
 
-        if (! empty($crossDomainConnections)) {
             $metadata = $pattern->metadata;
-            $metadata['cross_domain_connections'] = array_slice($crossDomainConnections, 0, 5);
+            $metadata['cross_domain_connections'] = $crossDomainConnections;
             $pattern->metadata = $metadata;
             $pattern->save();
 

--- a/resources/views/livewire/updates/index.blade.php
+++ b/resources/views/livewire/updates/index.blade.php
@@ -3,13 +3,14 @@ use App\Jobs\ProcessIntegrationData;
 use App\Jobs\RunIntegrationTask;
 use App\Models\ActionProgress;
 use App\Models\Integration;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Bus;
 use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\DB;
 use App\Models\User;
-use Illuminate\Support\Facades\Auth;
 use Livewire\Volt\Component;
 use Mary\Traits\Toast;
-use Carbon\Carbon;
 
 new class extends Component {
     use Toast;
@@ -48,7 +49,7 @@ new class extends Component {
         /** @var User $user */
         $user = Auth::user();
         $query = $user->integrations()
-            ->with('user')
+            ->with('user', 'group')
             ->orderBy('last_successful_update_at', 'asc')
             ->orderBy('created_at', 'asc')
             ;
@@ -73,7 +74,23 @@ new class extends Component {
 
         $userIntegrations = $query->get();
 
-        $integrationsData = $userIntegrations->map(function ($integration) {
+        // Batch load last event times for webhook/manual integrations to avoid N+1
+        $webhookManualIntegrationIds = $userIntegrations->filter(function ($integration) {
+            $pluginClass = App\Integrations\PluginRegistry::getPlugin($integration->service);
+            return $pluginClass && in_array($pluginClass::getServiceType(), ['webhook', 'manual']);
+        })->pluck('id');
+
+        $lastEventTimes = [];
+        if ($webhookManualIntegrationIds->isNotEmpty()) {
+            $lastEventTimes = DB::table('dev_events')
+                ->select('integration_id', DB::raw('MAX(time) as last_time'))
+                ->whereIn('integration_id', $webhookManualIntegrationIds)
+                ->groupBy('integration_id')
+                ->pluck('last_time', 'integration_id')
+                ->toArray();
+        }
+
+        $integrationsData = $userIntegrations->map(function ($integration) use ($lastEventTimes) {
             $batchName = null;
             $batchProgress = null;
             $migrationPhase = null;
@@ -189,11 +206,11 @@ new class extends Component {
                 // leave sweep values null on error
             }
 
-            // Get last event time for webhook/manual integrations
+            // Get last event time for webhook/manual integrations from batched data
             $lastEventTime = null;
             $pluginClass = App\Integrations\PluginRegistry::getPlugin($integration->service);
             if ($pluginClass && in_array($pluginClass::getServiceType(), ['webhook', 'manual'])) {
-                $lastEventTime = $integration->getLastEventTime();
+                $lastEventTime = isset($lastEventTimes[$integration->id]) ? Carbon::parse($lastEventTimes[$integration->id]) : null;
             }
 
             return [

--- a/tests/Unit/Jobs/TagBatchAttachmentTest.php
+++ b/tests/Unit/Jobs/TagBatchAttachmentTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Tests\Unit\Jobs;
+
+use App\Jobs\Base\BaseProcessingJob;
+use App\Models\Event;
+use App\Models\Integration;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class TagBatchAttachmentTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @test
+     */
+    public function it_batch_attaches_tags_without_n_plus_one()
+    {
+        $integration = Integration::factory()->create();
+
+        // Create 10 events with 3 tags each
+        $eventData = [];
+        for ($i = 0; $i < 10; $i++) {
+            $eventData[] = [
+                'source_id' => 'test_event_' . $i,
+                'time' => now()->subHours($i),
+                'domain' => 'test',
+                'action' => 'test_action',
+                'actor' => [
+                    'concept' => 'user',
+                    'type' => 'test_user',
+                    'title' => 'Test User ' . $i,
+                ],
+                'target' => [
+                    'concept' => 'object',
+                    'type' => 'test_object',
+                    'title' => 'Test Object ' . $i,
+                ],
+                'tags' => ['tag1', 'tag2', 'tag3'],
+            ];
+        }
+
+        $job = new class($integration, $eventData) extends BaseProcessingJob
+        {
+            protected function getServiceName(): string
+            {
+                return 'test';
+            }
+
+            protected function getJobType(): string
+            {
+                return 'tag_batch_test';
+            }
+
+            protected function process(): void
+            {
+                $this->createEvents($this->rawData);
+            }
+        };
+
+        // Enable query logging
+        DB::enableQueryLog();
+
+        // Execute the job
+        $job->handle();
+
+        // Get query log
+        $queries = DB::getQueryLog();
+
+        // Filter for tag-related queries
+        $tagQueries = collect($queries)->filter(function ($query) {
+            return str_contains($query['query'], 'tags') ||
+                   str_contains($query['query'], 'taggables');
+        })->count();
+
+        // With batching: Should be ~20-35 tag queries (3 tag creates + 10 syncs + overhead)
+        // Without batching: Would be 60+ queries (10 events × 3 tags × 2 queries each)
+        $this->assertLessThan(50, $tagQueries, "Expected fewer than 50 tag queries with batching, got {$tagQueries}");
+
+        // Verify all events were created with tags
+        $createdEvents = Event::where('integration_id', $integration->id)->get();
+        $this->assertEquals(10, $createdEvents->count());
+
+        foreach ($createdEvents as $event) {
+            $this->assertEquals(3, $event->tags()->count(), "Event {$event->source_id} should have 3 tags");
+            $this->assertTrue($event->tags->pluck('name')->contains('tag1'));
+            $this->assertTrue($event->tags->pluck('name')->contains('tag2'));
+            $this->assertTrue($event->tags->pluck('name')->contains('tag3'));
+        }
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_mixed_tag_types()
+    {
+        $integration = Integration::factory()->create();
+
+        $eventData = [
+            [
+                'source_id' => 'test_event_1',
+                'time' => now(),
+                'domain' => 'test',
+                'action' => 'test_action',
+                'actor' => ['concept' => 'user', 'type' => 'test', 'title' => 'User'],
+                'target' => ['concept' => 'object', 'type' => 'test', 'title' => 'Object'],
+                'tags' => [
+                    'simple_tag',
+                    ['name' => 'typed_tag', 'type' => 'custom_type'],
+                ],
+            ],
+        ];
+
+        $job = new class($integration, $eventData) extends BaseProcessingJob
+        {
+            protected function getServiceName(): string
+            {
+                return 'test';
+            }
+
+            protected function getJobType(): string
+            {
+                return 'tag_type_test';
+            }
+
+            protected function process(): void
+            {
+                $this->createEvents($this->rawData);
+            }
+        };
+
+        $job->handle();
+
+        $event = Event::where('integration_id', $integration->id)->first();
+        $this->assertEquals(2, $event->tags()->count());
+
+        // Verify tag types
+        $simpleTags = $event->tags()->where('type', 'spark_tag')->get();
+        $customTags = $event->tags()->where('type', 'custom_type')->get();
+
+        $this->assertEquals(1, $simpleTags->count());
+        $this->assertEquals(1, $customTags->count());
+        $this->assertEquals('simple_tag', $simpleTags->first()->name);
+        $this->assertEquals('typed_tag', $customTags->first()->name);
+    }
+}

--- a/tests/Unit/Models/BlockBatchCreationTest.php
+++ b/tests/Unit/Models/BlockBatchCreationTest.php
@@ -1,0 +1,106 @@
+<?php
+
+namespace Tests\Unit\Models;
+
+use App\Models\Block;
+use App\Models\Event;
+use App\Models\Integration;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\TestCase;
+
+class BlockBatchCreationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @test
+     */
+    public function it_creates_blocks_in_batch_without_n_plus_one()
+    {
+        $integration = Integration::factory()->create();
+        $event = Event::factory()->create([
+            'integration_id' => $integration->id,
+        ]);
+
+        $blocksData = [
+            ['title' => 'Heart Rate', 'block_type' => 'hr', 'value' => 75],
+            ['title' => 'Calories', 'block_type' => 'cal', 'value' => 250],
+            ['title' => 'Steps', 'block_type' => 'steps', 'value' => 5000],
+        ];
+
+        DB::enableQueryLog();
+        $blocks = $event->createBlocksInBatch($blocksData);
+        $queries = DB::getQueryLog();
+
+        // Should have: 1 pre-load query + 3 inserts = 4 queries max
+        // Without batching: Would be 3 existence checks + 3 inserts = 6 queries minimum
+        $this->assertLessThan(6, count($queries), 'Expected fewer than 6 queries with batching, got ' . count($queries));
+        $this->assertCount(3, $blocks);
+
+        // Verify blocks were created
+        $this->assertEquals(3, $event->blocks()->count());
+        $this->assertNotNull($event->blocks()->where('title', 'Heart Rate')->first());
+        $this->assertNotNull($event->blocks()->where('title', 'Calories')->first());
+        $this->assertNotNull($event->blocks()->where('title', 'Steps')->first());
+    }
+
+    /**
+     * @test
+     */
+    public function it_updates_existing_blocks_in_batch()
+    {
+        $integration = Integration::factory()->create();
+        $event = Event::factory()->create([
+            'integration_id' => $integration->id,
+        ]);
+
+        // Create initial blocks
+        $initialBlocksData = [
+            ['title' => 'Heart Rate', 'block_type' => 'hr', 'value' => 75],
+            ['title' => 'Calories', 'block_type' => 'cal', 'value' => 250],
+        ];
+        $event->createBlocksInBatch($initialBlocksData);
+
+        $this->assertEquals(2, $event->blocks()->count());
+        $this->assertEquals(75, $event->blocks()->where('title', 'Heart Rate')->first()->value);
+
+        // Update existing blocks
+        $updatedBlocksData = [
+            ['title' => 'Heart Rate', 'block_type' => 'hr', 'value' => 80], // Updated value
+            ['title' => 'Calories', 'block_type' => 'cal', 'value' => 300], // Updated value
+            ['title' => 'Steps', 'block_type' => 'steps', 'value' => 5000], // New block
+        ];
+
+        DB::enableQueryLog();
+        $blocks = $event->createBlocksInBatch($updatedBlocksData);
+        $queries = DB::getQueryLog();
+
+        // Should be efficient even with updates (1 load + 2 updates + 1 insert + overhead)
+        $this->assertLessThanOrEqual(8, count($queries));
+        $this->assertCount(3, $blocks);
+
+        // Verify blocks were updated
+        $event->refresh();
+        $this->assertEquals(3, $event->blocks()->count());
+        $this->assertEquals(80, $event->blocks()->where('title', 'Heart Rate')->first()->value);
+        $this->assertEquals(300, $event->blocks()->where('title', 'Calories')->first()->value);
+        $this->assertEquals(5000, $event->blocks()->where('title', 'Steps')->first()->value);
+    }
+
+    /**
+     * @test
+     */
+    public function it_handles_empty_blocks_data_gracefully()
+    {
+        $integration = Integration::factory()->create();
+        $event = Event::factory()->create([
+            'integration_id' => $integration->id,
+        ]);
+
+        $blocks = $event->createBlocksInBatch([]);
+
+        $this->assertCount(0, $blocks);
+        $this->assertEquals(0, $event->blocks()->count());
+    }
+}


### PR DESCRIPTION
## Summary
- Batch tag attachment in BaseProcessingJob to prevent N+1 tag queries
- Batch event existence checks in Oura data processors
- Batch cross-domain pattern detection in ProcessCoachingResponseJob and PatternLearningService
- Refactor IntegrationDetails to fetch all counts/objects in single queries
- Add efficient batch block creation method to Event model
- Optimize last event time queries in updates view

## Test plan
- New unit tests verify batch tag attachment prevents N+1 queries
- New tests verify batch block creation and updates
- All existing tests continue to pass

🤖 Generated with Claude Code