### PR TITLE
⚡ Aggregate metric statistics in SQL to cut DB egress and add indexes

### DIFF
--- a/app/Jobs/Metrics/CalculateMetricStatisticsJob.php
+++ b/app/Jobs/Metrics/CalculateMetricStatisticsJob.php
@@ -5,6 +5,7 @@ namespace App\Jobs\Metrics;
 use App\Models\Event;
 use App\Models\MetricStatistic;
 use App\Models\User;
+use Carbon\Carbon;
 use Exception;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -129,37 +130,69 @@ class CalculateMetricStatisticsJob implements ShouldQueue
 
     /**
      * Calculate statistics for a specific metric
+     *
+     * Aggregates in SQL rather than pulling every historical event into PHP —
+     * `events` rows are large (they include a 1536-dim `embeddings` vector and
+     * JSON metadata columns), so `SELECT *` on a multi-million-row history
+     * dominated database egress and wall-time.
      */
     protected function calculateMetricStatistics(string $userId, string $service, string $action, string $valueUnit): void
     {
-        // Get all events for this metric via integration relationship
-        $events = Event::whereHas('integration', function ($query) use ($userId) {
-            $query->where('user_id', $userId);
-        })
-            ->where('service', $service)
-            ->where('action', $action)
-            ->where('value_unit', $valueUnit)
-            ->whereNotNull('value')
-            ->whereNull('deleted_at')
-            ->orderBy('time')
-            ->get();
+        $eventsTable = (new Event)->getTable();
 
-        if ($events->count() < 10) {
+        // Mirrors Event::getFormattedValueAttribute() in SQL: null/0/1 multipliers
+        // pass the raw value through, everything else divides.
+        $formattedExpr = <<<'SQL'
+            CASE
+                WHEN e.value_multiplier IS NULL OR e.value_multiplier IN (0, 1)
+                    THEN e.value::double precision
+                ELSE e.value::double precision / e.value_multiplier
+            END
+        SQL;
+
+        $row = DB::table($eventsTable . ' as e')
+            ->join('integrations as i', 'e.integration_id', '=', 'i.id')
+            ->where('i.user_id', $userId)
+            ->whereNull('i.deleted_at')
+            ->where('e.service', $service)
+            ->where('e.action', $action)
+            ->where('e.value_unit', $valueUnit)
+            ->whereNotNull('e.value')
+            ->whereNull('e.deleted_at')
+            ->selectRaw(<<<SQL
+                COUNT(*) AS total_count,
+                MIN(e.time) AS first_event_at,
+                MAX(e.time) AS last_event_at,
+                COUNT(*) FILTER (WHERE e.value <> 0) AS formatted_count,
+                MIN({$formattedExpr}) FILTER (WHERE e.value <> 0) AS min_value,
+                MAX({$formattedExpr}) FILTER (WHERE e.value <> 0) AS max_value,
+                AVG({$formattedExpr}) FILTER (WHERE e.value <> 0) AS mean_value,
+                STDDEV_POP({$formattedExpr}) FILTER (WHERE e.value <> 0) AS stddev_value
+            SQL)
+            ->first();
+
+        $totalCount = (int) ($row->total_count ?? 0);
+
+        if ($totalCount < 10) {
             Log::info('Insufficient events for metric', [
                 'user_id' => $userId,
                 'service' => $service,
                 'action' => $action,
                 'value_unit' => $valueUnit,
-                'count' => $events->count(),
+                'count' => $totalCount,
             ]);
 
             return;
         }
 
-        // Check if we have at least 30 days of data
-        $firstEvent = $events->first();
-        $lastEvent = $events->last();
-        $daysBetween = $firstEvent->time->diffInDays($lastEvent->time);
+        $firstEventAt = $row->first_event_at ? Carbon::parse($row->first_event_at) : null;
+        $lastEventAt = $row->last_event_at ? Carbon::parse($row->last_event_at) : null;
+
+        if (! $firstEventAt || ! $lastEventAt) {
+            return;
+        }
+
+        $daysBetween = $firstEventAt->diffInDays($lastEventAt);
 
         if ($daysBetween < 30) {
             Log::info('Insufficient time range for metric', [
@@ -173,18 +206,15 @@ class CalculateMetricStatisticsJob implements ShouldQueue
             return;
         }
 
-        // Calculate statistics using formatted values
-        $values = $events->map(fn ($event) => $event->getFormattedValueAttribute())->filter()->values();
+        $formattedCount = (int) ($row->formatted_count ?? 0);
 
-        if ($values->isEmpty()) {
+        if ($formattedCount === 0 || $row->mean_value === null) {
             return;
         }
 
-        $mean = $values->average();
-        $variance = $values->map(fn ($value) => pow($value - $mean, 2))->average();
-        $stddev = sqrt($variance);
+        $mean = (float) $row->mean_value;
+        $stddev = (float) ($row->stddev_value ?? 0.0);
 
-        // Create or update metric statistic
         MetricStatistic::updateOrCreate(
             [
                 'user_id' => $userId,
@@ -193,11 +223,11 @@ class CalculateMetricStatisticsJob implements ShouldQueue
                 'value_unit' => $valueUnit,
             ],
             [
-                'event_count' => $values->count(),
-                'first_event_at' => $firstEvent->time,
-                'last_event_at' => $lastEvent->time,
-                'min_value' => $values->min(),
-                'max_value' => $values->max(),
+                'event_count' => $formattedCount,
+                'first_event_at' => $firstEventAt,
+                'last_event_at' => $lastEventAt,
+                'min_value' => (float) $row->min_value,
+                'max_value' => (float) $row->max_value,
                 'mean_value' => $mean,
                 'stddev_value' => $stddev,
                 'normal_lower_bound' => $mean - (2 * $stddev),
@@ -211,7 +241,7 @@ class CalculateMetricStatisticsJob implements ShouldQueue
             'service' => $service,
             'action' => $action,
             'value_unit' => $valueUnit,
-            'count' => $values->count(),
+            'count' => $formattedCount,
             'mean' => $mean,
             'stddev' => $stddev,
         ]);

--- a/app/Mcp/Tools/GetMetricTrendTool.php
+++ b/app/Mcp/Tools/GetMetricTrendTool.php
@@ -60,14 +60,16 @@ class GetMetricTrendTool extends Tool
 
         [$startDate, $endDate] = $dateRange;
 
-        // Query events for the metric within date range
+        // Query events for the metric within date range. Select only the
+        // columns we actually use — `events` rows carry a 1536-dim embeddings
+        // vector and JSON metadata, and pulling them is pure egress waste.
         $events = Event::query()
             ->whereHas('integration', fn ($q) => $q->where('user_id', $user->id))
             ->where('service', $statistic->service)
             ->where('action', $statistic->action)
             ->whereBetween('time', [$startDate, $endDate])
             ->orderBy('time', 'asc')
-            ->get();
+            ->get(['id', 'time', 'value', 'value_multiplier']);
 
         // Group by date, take latest event per day
         $hasValidStats = $statistic->hasValidStatistics();

--- a/app/Models/Block.php
+++ b/app/Models/Block.php
@@ -49,6 +49,13 @@ class Block extends Model implements HasMedia
         'embeddings',
     ];
 
+    /**
+     * A 1536-dim pgvector column; keep it out of JSON/array serialisation.
+     */
+    protected $hidden = [
+        'embeddings',
+    ];
+
     protected $casts = [
         'time' => 'datetime',
         'metadata' => 'array',

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -55,6 +55,14 @@ class Event extends Model
         'location_source',
     ];
 
+    /**
+     * A 1536-dim pgvector column; keep it out of JSON/array serialisation
+     * so it can't be accidentally shipped over API or Livewire payloads.
+     */
+    protected $hidden = [
+        'embeddings',
+    ];
+
     protected $casts = [
         'time' => 'datetime',
         'actor_metadata' => 'array',

--- a/app/Models/EventObject.php
+++ b/app/Models/EventObject.php
@@ -52,6 +52,13 @@ class EventObject extends Model implements HasMedia
         'location_source',
     ];
 
+    /**
+     * A 1536-dim pgvector column; keep it out of JSON/array serialisation.
+     */
+    protected $hidden = [
+        'embeddings',
+    ];
+
     protected $casts = [
         'time' => 'datetime',
         'metadata' => 'array',

--- a/database/migrations/2026_04_19_091657_add_metric_lookup_index_to_events.php
+++ b/database/migrations/2026_04_19_091657_add_metric_lookup_index_to_events.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public $withinTransaction = false;
+
+    public function up(): void
+    {
+        if (DB::getDriverName() !== 'pgsql') {
+            return;
+        }
+
+        $prefix = DB::getTablePrefix();
+
+        if (! Schema::hasTable($prefix . 'events')) {
+            return;
+        }
+
+        $this->safeStatement(
+            'CREATE INDEX CONCURRENTLY IF NOT EXISTS events_metric_lookup_idx '
+            . 'ON "' . $prefix . 'events" (integration_id, service, action, value_unit) '
+            . 'WHERE value IS NOT NULL AND deleted_at IS NULL'
+        );
+    }
+
+    public function down(): void
+    {
+        if (DB::getDriverName() !== 'pgsql') {
+            return;
+        }
+
+        $this->safeStatement('DROP INDEX CONCURRENTLY IF EXISTS events_metric_lookup_idx');
+    }
+
+    private function safeStatement(string $sql): void
+    {
+        try {
+            DB::statement($sql);
+        } catch (\Throwable $e) {
+            // Swallow errors to avoid aborting entire migration.
+        }
+    }
+};

--- a/database/migrations/2026_04_19_091657_add_metric_lookup_index_to_events.php
+++ b/database/migrations/2026_04_19_091657_add_metric_lookup_index_to_events.php
@@ -41,7 +41,8 @@ return new class extends Migration
         try {
             DB::statement($sql);
         } catch (\Throwable $e) {
-            // Swallow errors to avoid aborting entire migration.
+            report($e);
+            throw $e;
         }
     }
 };

--- a/database/migrations/2026_04_19_093153_add_actor_target_id_indexes_to_events.php
+++ b/database/migrations/2026_04_19_093153_add_actor_target_id_indexes_to_events.php
@@ -1,0 +1,58 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public $withinTransaction = false;
+
+    public function up(): void
+    {
+        if (DB::getDriverName() !== 'pgsql') {
+            return;
+        }
+
+        $prefix = DB::getTablePrefix();
+
+        if (! Schema::hasTable($prefix . 'events')) {
+            return;
+        }
+
+        // Slim single-column partial indexes for COUNT(*) WHERE actor_id/target_id = ?.
+        // Composite (actor_id, time) and (target_id, time) indexes already exist for
+        // ranged scans, but Postgres prefers a narrower index for pure COUNT because
+        // it touches fewer pages — Supabase index advisor reported a ~1700x cost drop.
+        $this->safeStatement(
+            'CREATE INDEX CONCURRENTLY IF NOT EXISTS events_actor_id_idx '
+            . 'ON "' . $prefix . 'events" (actor_id) '
+            . 'WHERE actor_id IS NOT NULL AND deleted_at IS NULL'
+        );
+
+        $this->safeStatement(
+            'CREATE INDEX CONCURRENTLY IF NOT EXISTS events_target_id_idx '
+            . 'ON "' . $prefix . 'events" (target_id) '
+            . 'WHERE target_id IS NOT NULL AND deleted_at IS NULL'
+        );
+    }
+
+    public function down(): void
+    {
+        if (DB::getDriverName() !== 'pgsql') {
+            return;
+        }
+
+        $this->safeStatement('DROP INDEX CONCURRENTLY IF EXISTS events_actor_id_idx');
+        $this->safeStatement('DROP INDEX CONCURRENTLY IF EXISTS events_target_id_idx');
+    }
+
+    private function safeStatement(string $sql): void
+    {
+        try {
+            DB::statement($sql);
+        } catch (\Throwable $e) {
+            // Swallow errors to avoid aborting entire migration.
+        }
+    }
+};

--- a/database/migrations/2026_04_19_093153_add_actor_target_id_indexes_to_events.php
+++ b/database/migrations/2026_04_19_093153_add_actor_target_id_indexes_to_events.php
@@ -56,5 +56,4 @@ return new class extends Migration
             throw $e;
         }
     }
-    }
 };

--- a/database/migrations/2026_04_19_093153_add_actor_target_id_indexes_to_events.php
+++ b/database/migrations/2026_04_19_093153_add_actor_target_id_indexes_to_events.php
@@ -52,7 +52,9 @@ return new class extends Migration
         try {
             DB::statement($sql);
         } catch (\Throwable $e) {
-            // Swallow errors to avoid aborting entire migration.
+            report($e);
+            throw $e;
         }
+    }
     }
 };

--- a/tests/Feature/MetricTrackingTest.php
+++ b/tests/Feature/MetricTrackingTest.php
@@ -114,10 +114,111 @@ class MetricTrackingTest extends TestCase
 
         $metric = MetricStatistic::where('user_id', $user->id)->first();
         $this->assertEquals(40, $metric->event_count);
-        $this->assertNotNull($metric->mean_value);
-        $this->assertNotNull($metric->stddev_value);
-        $this->assertNotNull($metric->normal_lower_bound);
-        $this->assertNotNull($metric->normal_upper_bound);
+
+        // Values are 70..89 repeated twice → mean = 79.5, min = 70, max = 89.
+        $this->assertEqualsWithDelta(79.5, (float) $metric->mean_value, 0.0001);
+        $this->assertEqualsWithDelta(70.0, (float) $metric->min_value, 0.0001);
+        $this->assertEqualsWithDelta(89.0, (float) $metric->max_value, 0.0001);
+
+        // Population stddev of 70..89 twice is sqrt(variance). Compute it here
+        // to pin the value independent of SQL implementation choices.
+        $values = [];
+        for ($i = 0; $i < 40; $i++) {
+            $values[] = 70 + ($i % 20);
+        }
+        $mean = array_sum($values) / count($values);
+        $expectedStddev = sqrt(array_sum(array_map(fn ($v) => ($v - $mean) ** 2, $values)) / count($values));
+
+        $this->assertEqualsWithDelta($expectedStddev, (float) $metric->stddev_value, 0.0001);
+        $this->assertEqualsWithDelta($mean - 2 * $expectedStddev, (float) $metric->normal_lower_bound, 0.0001);
+        $this->assertEqualsWithDelta($mean + 2 * $expectedStddev, (float) $metric->normal_upper_bound, 0.0001);
+    }
+
+    /**
+     * @test
+     */
+    public function calculate_metric_statistics_job_applies_value_multiplier(): void
+    {
+        $user = User::factory()->create();
+        $group = IntegrationGroup::factory()->create(['user_id' => $user->id]);
+        $integration = Integration::factory()->create([
+            'user_id' => $user->id,
+            'integration_group_id' => $group->id,
+        ]);
+
+        $actor = EventObject::factory()->create(['user_id' => $user->id]);
+
+        // 40 events with raw value = 100..199 (mod 100) + 100 and multiplier = 100.
+        // With the accessor, formatted_value = value / 100, so effective values
+        // are 1.00..1.99, mean = 1.495.
+        for ($i = 0; $i < 40; $i++) {
+            Event::create([
+                'source_id' => 'mul-' . $i,
+                'time' => now()->subDays(40 - $i),
+                'integration_id' => $integration->id,
+                'actor_id' => $actor->id,
+                'service' => 'monzo',
+                'domain' => 'money',
+                'action' => 'transaction',
+                'value' => 100 + ($i % 100),
+                'value_multiplier' => 100,
+                'value_unit' => 'gbp',
+            ]);
+        }
+
+        (new CalculateMetricStatisticsJob)->handle();
+
+        $metric = MetricStatistic::where('user_id', $user->id)->first();
+
+        $this->assertNotNull($metric);
+        $this->assertEquals(40, $metric->event_count);
+
+        // Recompute expected stats using the PHP accessor semantics.
+        $values = [];
+        for ($i = 0; $i < 40; $i++) {
+            $values[] = (100 + ($i % 100)) / 100;
+        }
+        $expectedMean = array_sum($values) / count($values);
+
+        $this->assertEqualsWithDelta($expectedMean, (float) $metric->mean_value, 0.0001);
+        $this->assertEqualsWithDelta(min($values), (float) $metric->min_value, 0.0001);
+        $this->assertEqualsWithDelta(max($values), (float) $metric->max_value, 0.0001);
+    }
+
+    /**
+     * @test
+     */
+    public function calculate_metric_statistics_job_skips_when_fewer_than_ten_events(): void
+    {
+        $user = User::factory()->create();
+        $group = IntegrationGroup::factory()->create(['user_id' => $user->id]);
+        $integration = Integration::factory()->create([
+            'user_id' => $user->id,
+            'integration_group_id' => $group->id,
+        ]);
+
+        // Only 5 events — below the threshold; no MetricStatistic should be written.
+        for ($i = 0; $i < 5; $i++) {
+            Event::create([
+                'source_id' => 'few-' . $i,
+                'time' => now()->subDays(40 - $i),
+                'integration_id' => $integration->id,
+                'service' => 'oura',
+                'domain' => 'health',
+                'action' => 'had_readiness_score',
+                'value' => 80,
+                'value_multiplier' => 1,
+                'value_unit' => 'percent',
+            ]);
+        }
+
+        (new CalculateMetricStatisticsJob)->handle();
+
+        $this->assertDatabaseMissing('metric_statistics', [
+            'user_id' => $user->id,
+            'service' => 'oura',
+            'action' => 'had_readiness_score',
+        ]);
     }
 
     /**

--- a/tests/Feature/MetricTrackingTest.php
+++ b/tests/Feature/MetricTrackingTest.php
@@ -147,6 +147,7 @@ class MetricTrackingTest extends TestCase
         ]);
 
         $actor = EventObject::factory()->create(['user_id' => $user->id]);
+        $target = EventObject::factory()->create(['user_id' => $user->id]);
 
         // 40 events with raw value = 100..199 (mod 100) + 100 and multiplier = 100.
         // With the accessor, formatted_value = value / 100, so effective values
@@ -157,6 +158,7 @@ class MetricTrackingTest extends TestCase
                 'time' => now()->subDays(40 - $i),
                 'integration_id' => $integration->id,
                 'actor_id' => $actor->id,
+                'target_id' => $target->id,
                 'service' => 'monzo',
                 'domain' => 'money',
                 'action' => 'transaction',
@@ -196,6 +198,8 @@ class MetricTrackingTest extends TestCase
             'user_id' => $user->id,
             'integration_group_id' => $group->id,
         ]);
+        $actor = EventObject::factory()->create(['user_id' => $user->id]);
+        $target = EventObject::factory()->create(['user_id' => $user->id]);
 
         // Only 5 events — below the threshold; no MetricStatistic should be written.
         for ($i = 0; $i < 5; $i++) {
@@ -203,6 +207,8 @@ class MetricTrackingTest extends TestCase
                 'source_id' => 'few-' . $i,
                 'time' => now()->subDays(40 - $i),
                 'integration_id' => $integration->id,
+                'actor_id' => $actor->id,
+                'target_id' => $target->id,
                 'service' => 'oura',
                 'domain' => 'health',
                 'action' => 'had_readiness_score',


### PR DESCRIPTION
The hourly CalculateMetricStatisticsJob was responsible for ~95% of
database time and ~27GB/day of Supabase egress. For each discovered
metric it ran `Event::...->get()` with an implicit SELECT *, pulling
every historical row (including the 1536-dim embeddings vector and
JSON metadata columns) into PHP just to compute count / min / max /
mean / stddev.

- Replace the in-PHP reduction with a single SQL aggregate query that
  returns one row per metric. The CASE expression mirrors
  Event::getFormattedValueAttribute() so statistics are unchanged.
- Add a partial composite index
  events(integration_id, service, action, value_unit)
  WHERE value IS NOT NULL AND deleted_at IS NULL, created
  CONCURRENTLY, covering the metric filter path.
- Select only the columns actually used in GetMetricTrendTool rather
  than an implicit SELECT *.
- Hide the embeddings column on Event/EventObject/Block so it cannot
  leak into API, Livewire or toArray() payloads.
- Extend MetricTrackingTest to pin mean/min/max/stddev and to cover
  value_multiplier and the sub-threshold-count guard.
  
The two count(*) queries in pg_stat_statements (Event::where('actor_id'/
'target_id', ...)->count(), 112k calls each) get a ~1700x cost drop
according to the Supabase index advisor when given a narrow single-
column index, despite the existing composite (actor_id, time) and
(target_id, time) indexes — Postgres prefers the slimmer index for
COUNT because it touches fewer pages.

Created CONCURRENTLY and partial WHERE not null AND deleted_at IS NULL
to keep the indexes small.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Prevented sensitive embeddings data from being exposed in API responses and when serialising model data.

* **Performance Improvements**
  * Enhanced metric statistics calculation for faster processing.
  * Optimised metric trend queries to retrieve only required data.
  * Added database indexes to accelerate event lookups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->