### PR TITLE
📱 Add mobile /me endpoint returning authenticated user profile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,35 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+Spark is a Laravel 12 and Livewire 3 application. Core PHP code lives in `app/`, with integration plugins under `app/Integrations/`, console commands in `app/Console/Commands/`, and helpers in `app/Support/`. Routes are split by surface in `routes/web.php`, `routes/api.php`, `routes/mobile.php`, and related files. Database migrations, factories, and seeders are in `database/`. Frontend entry points are in `resources/js/` and `resources/css/`, built by Vite into `public/`. Tests are in `tests/Unit/` and `tests/Feature/`. Architecture and integration notes are in `docs/Architecture/` and `docs/Integrations/`.
+
+## Build, Test, and Development Commands
+
+Use Laravel Sail for local development unless a task explicitly targets the host environment.
+
+- `sail up -d`: start the application services.
+- `composer dev`: run Laravel server, Horizon, Pail logs, and Vite together.
+- `sail npm run dev`: start the Vite development server.
+- `sail npm run build`: build production frontend assets.
+- `sail artisan migrate`: apply database migrations.
+- `sail artisan test`: run the full test suite.
+- `sail artisan test --filter TestName`: run one test or filtered group.
+- `sail bin duster fix`: format and fix PHP style issues.
+- `sail bin duster lint`: check PHP style without changing files.
+
+## Coding Style & Naming Conventions
+
+PHP targets 8.4 and follows Laravel conventions with PSR-4 namespaces under `App\\`. Use 4-space indentation for PHP and descriptive class names, for example `MediaDeduplicationService` or `FetchSpotifyData`. Prefer existing framework patterns. JavaScript and CSS are formatted with Prettier through lint-staged; avoid unrelated formatting churn.
+
+## Testing Guidelines
+
+PHPUnit is configured in `phpunit.xml` with separate Unit and Feature suites. Put focused service tests in `tests/Unit/` and request, integration, or database behavior tests in `tests/Feature/`. Name tests after the behavior under test, using existing patterns such as `CurrencyConversionServiceTest` or `TransactionLinkingTest`. The test environment uses PostgreSQL (`DB_CONNECTION=pgsql`), array cache/session drivers, and synchronous queues.
+
+## Commit & Pull Request Guidelines
+
+Recent commits use gitmoji-prefixed subjects, for example `:sparkles: New endpoints (#785)` and `:arrow_up_small: Update dependency axios to v1.15.2`. Keep commits short and meaningful because release automation depends on gitmoji. Branch new work from `dev`, not `main`. Pull requests should include a concise description, linked references when relevant, test results, and screenshots for visible UI changes.
+
+## Agent-Specific Instructions
+
+Read `CLAUDE.md` and the relevant `docs/Architecture/` page before changing shared data model, integration, media, queue, or task pipeline behavior. Do not overwrite unrelated local changes; this repository may have user edits in progress.

--- a/app/Http/Controllers/Api/V1/Mobile/FeedController.php
+++ b/app/Http/Controllers/Api/V1/Mobile/FeedController.php
@@ -7,8 +7,11 @@ use App\Http\Resources\Compact\CompactEventResource;
 use App\Integrations\PluginRegistry;
 use App\Services\Mobile\EventFeed;
 use App\Support\CursorPaginator;
+use Carbon\Carbon;
+use Exception;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use InvalidArgumentException;
 
 class FeedController extends Controller
 {
@@ -31,11 +34,26 @@ class FeedController extends Controller
             ], 422);
         }
 
+        $dateParam = $request->query('date');
+        $date = null;
+
+        if ($dateParam !== null) {
+            try {
+                $parsed = Carbon::createFromFormat('Y-m-d', is_string($dateParam) ? $dateParam : '');
+                if ($parsed === false || $parsed->format('Y-m-d') !== $dateParam) {
+                    throw new InvalidArgumentException;
+                }
+                $date = $parsed;
+            } catch (Exception) {
+                return response()->json(['message' => 'Invalid date. Use YYYY-MM-DD format.'], 422);
+            }
+        }
+
         $cursor = $request->query('cursor');
         $limit = (int) $request->query('limit', CursorPaginator::DEFAULT_LIMIT);
 
         [$events, $nextCursor, $hasMore] = CursorPaginator::paginate(
-            $this->eventFeed->query($request->user(), is_string($domain) ? $domain : null),
+            $this->eventFeed->query($request->user(), is_string($domain) ? $domain : null, $date),
             is_string($cursor) && $cursor !== '' ? $cursor : null,
             $limit,
             timeColumn: 'time',

--- a/app/Http/Controllers/Api/V1/Mobile/MeController.php
+++ b/app/Http/Controllers/Api/V1/Mobile/MeController.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Mobile;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Returns the authenticated user's profile.
+ *
+ * Used by the iOS client on bootstrap (to cache user ID for Reverb channel
+ * subscription) and on every Today view appear (to render the hero title).
+ */
+class MeController extends Controller
+{
+    public function __invoke(Request $request): JsonResponse
+    {
+        $user = $request->user();
+
+        return response()->json([
+            'id' => (string) $user->getKey(),
+            'name' => $user->name,
+            'email' => $user->email,
+            'timezone' => $user->getTimezone(),
+            'avatar_url' => null,
+        ]);
+    }
+}

--- a/app/Http/Controllers/Api/V1/Mobile/MetricsController.php
+++ b/app/Http/Controllers/Api/V1/Mobile/MetricsController.php
@@ -27,9 +27,9 @@ class MetricsController extends Controller
             ->orderBy('action')
             ->get();
 
-        return response()->json([
-            'data' => CompactMetricResource::collection($metrics)->resolve($request),
-        ]);
+        return response()->json(
+            CompactMetricResource::collection($metrics)->resolve($request),
+        );
     }
 
     /**
@@ -51,17 +51,37 @@ class MetricsController extends Controller
             ], 404);
         }
 
-        $payload = $this->trendService->trend(
-            $user,
-            $metric,
-            $request->query('from', '30_days_ago'),
-            $request->query('to', 'today'),
-        );
+        [$from, $to] = $this->dateRangeForRequest($request);
+
+        $payload = $this->trendService->trend($user, $metric, $from, $to);
 
         if ($payload === null) {
             return response()->json(['message' => 'Invalid date range.'], 422);
         }
 
         return response()->json($payload);
+    }
+
+    /**
+     * @return array{0: string, 1: string}
+     */
+    private function dateRangeForRequest(Request $request): array
+    {
+        $range = $request->query('range');
+
+        if (! is_string($range)) {
+            return [
+                $request->query('from', '30_days_ago'),
+                $request->query('to', 'today'),
+            ];
+        }
+
+        return match ($range) {
+            '7d' => ['6_days_ago', 'today'],
+            '30d' => ['29_days_ago', 'today'],
+            '90d' => ['89_days_ago', 'today'],
+            '1y' => ['364_days_ago', 'today'],
+            default => [$range, $range],
+        };
     }
 }

--- a/app/Http/Resources/Compact/CompactEventResource.php
+++ b/app/Http/Resources/Compact/CompactEventResource.php
@@ -67,6 +67,13 @@ class CompactEventResource extends JsonResource
             if ($tldr) {
                 $data['tldr'] = $tldr->getContent();
             }
+
+            $paragraph = $this->blocks->firstWhere('block_type', 'fetch_summary_paragraph')
+                ?? $this->blocks->firstWhere('block_type', 'newsletter_summary_paragraph');
+
+            if ($paragraph) {
+                $data['summary_paragraph'] = $paragraph->getContent();
+            }
         }
 
         return $data;

--- a/app/Http/Resources/Compact/CompactMetricResource.php
+++ b/app/Http/Resources/Compact/CompactMetricResource.php
@@ -2,9 +2,11 @@
 
 namespace App\Http\Resources\Compact;
 
+use App\Integrations\PluginRegistry;
 use App\Models\MetricStatistic;
 use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Str;
 
 /**
  * @mixin MetricStatistic
@@ -18,14 +20,52 @@ class CompactMetricResource extends JsonResource
     {
         return [
             'id' => $this->id,
-            'identifier' => $this->getIdentifier(),
+            'identifier' => $this->mobileIdentifier(),
             'display_name' => $this->getDisplayName(),
             'service' => $this->service,
+            'domain' => $this->domain(),
             'action' => $this->action,
             'unit' => $this->value_unit,
             'event_count' => $this->event_count,
             'mean' => $this->mean_value !== null ? (float) $this->mean_value : null,
             'last_event_at' => $this->last_event_at?->toIso8601String(),
         ];
+    }
+
+    private function mobileIdentifier(): string
+    {
+        return $this->service . '.' . Str::after($this->action, 'had_');
+    }
+
+    private function domain(): string
+    {
+        $action = Str::after($this->action, 'had_');
+
+        if (in_array($action, [
+            'steps',
+            'step_count',
+            'calories',
+            'active_calories',
+            'active_energy',
+            'basal_energy_burned',
+            'total_calories',
+            'distance',
+            'equivalent_walking_distance',
+            'workout',
+        ], true)) {
+            return 'activity';
+        }
+
+        if (in_array($this->service, ['monzo', 'gocardless', 'financial', 'receipt'], true)) {
+            return 'money';
+        }
+
+        if (in_array($this->service, ['spotify', 'screen_time', 'goodreads', 'untappd'], true)) {
+            return 'media';
+        }
+
+        $pluginClass = PluginRegistry::getPlugin($this->service);
+
+        return $pluginClass ? $pluginClass::getDomain() : 'health';
     }
 }

--- a/app/Services/Mobile/EventFeed.php
+++ b/app/Services/Mobile/EventFeed.php
@@ -5,6 +5,7 @@ namespace App\Services\Mobile;
 use App\Mcp\Helpers\DateParser;
 use App\Models\Event;
 use App\Models\User;
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Collection;
 
@@ -82,7 +83,7 @@ class EventFeed
      *
      * @return Builder<Event>
      */
-    public function query(User $user, ?string $domain = null): Builder
+    public function query(User $user, ?string $domain = null, ?Carbon $date = null): Builder
     {
         $integrationIds = $user->integrations()->pluck('id')->all();
 
@@ -98,6 +99,12 @@ class EventFeed
 
         if ($domain !== null) {
             $query->where('domain', $domain);
+        }
+
+        if ($date !== null) {
+            $query->whereBetween('time', [$date->copy()->startOfDay(), $date->copy()->endOfDay()]);
+        } else {
+            $query->where('time', '<=', now());
         }
 
         return $query;

--- a/docs/mobile/MOBILE_API.md
+++ b/docs/mobile/MOBILE_API.md
@@ -249,10 +249,11 @@ See [CompactEvent](#compactevent) for the item schema.
 
 When `domain=knowledge`, each `CompactEvent` in the feed may include two additional optional fields:
 
-| Field              | Type   | Description                                                    |
-| ------------------ | ------ | -------------------------------------------------------------- |
-| `tldr`             | string | Single-sentence TL;DR from the associated block (if generated) |
-| `target.media_url` | string | OG image URL on the target object (e.g. article hero image)    |
+| Field               | Type   | Description                                                    |
+| ------------------- | ------ | -------------------------------------------------------------- |
+| `tldr`              | string | Single-sentence TL;DR from the associated block (if generated) |
+| `summary_paragraph` | string | Longer summary paragraph from the associated block (if exists) |
+| `target.media_url`  | string | OG image URL on the target object (e.g. article hero image)    |
 
 Both fields are omitted rather than `null` when not available.
 
@@ -316,24 +317,23 @@ Returns all metric identifiers and metadata for the authenticated user. Use this
 **Response `200`**
 
 ```json
-{
-    "data": [
-        {
-            "id": "uuid",
-            "identifier": "oura.had_sleep_score.percent",
-            "display_name": "Sleep Score",
-            "service": "oura",
-            "action": "had_sleep_score",
-            "unit": "percent",
-            "event_count": 180,
-            "mean": 83.1,
-            "last_event_at": "2025-01-15T08:00:00+00:00"
-        }
-    ]
-}
+[
+    {
+        "id": "uuid",
+        "identifier": "oura.sleep_score",
+        "display_name": "Sleep Score",
+        "service": "oura",
+        "domain": "health",
+        "action": "had_sleep_score",
+        "unit": "percent",
+        "event_count": 180,
+        "mean": 83.1,
+        "last_event_at": "2025-01-15T08:00:00+00:00"
+    }
+]
 ```
 
-Results are ordered by `service` then `action`. An empty `data` array is returned when no metrics have been computed yet.
+Results are ordered by `service` then `action`. An empty array is returned when no metrics have been computed yet.
 
 ---
 
@@ -349,6 +349,7 @@ Returns a metric trend with per-day values, summary statistics, and optional bas
 | --------- | ------ | ------------- | --------------------------------------------- |
 | `from`    | string | `30_days_ago` | Start date (`YYYY-MM-DD` or relative keyword) |
 | `to`      | string | `today`       | End date (`YYYY-MM-DD` or relative keyword)   |
+| `range`   | string | `null`        | Preset range: `7d`, `30d`, `90d`, or `1y`     |
 
 **Relative Date Keywords**: `today`, `yesterday`, `7_days_ago`, `30_days_ago`, `90_days_ago`
 
@@ -940,6 +941,7 @@ These schemas are stable contracts. The iOS client decodes them into Swift struc
     "identifier": "oura.sleep_score",
     "display_name": "Sleep Score",
     "service": "oura",
+    "domain": "health",
     "action": "sleep_score",
     "unit": "score",
     "event_count": 365,

--- a/docs/mobile/MOBILE_API.md
+++ b/docs/mobile/MOBILE_API.md
@@ -222,6 +222,12 @@ Cursor-paginated reverse-chronological feed of the user's events.
 | `cursor`  | string  | —       | Opaque cursor from a prior response                                    |
 | `limit`   | integer | 20      | Items per page (max 100)                                               |
 | `domain`  | string  | —       | Filter by domain: `health`, `money`, `media`, `knowledge`, or `online` |
+| `date`    | string  | —       | Restrict to a single calendar day (`YYYY-MM-DD`); past or future       |
+
+**Date behaviour**
+
+- **No `date`** (default): returns events up to and including the current moment, paging backwards. Future events are excluded.
+- **`date` specified**: returns only events whose `time` falls within that calendar day (midnight–23:59:59 UTC). Cursor pagination still applies within the day. Can be a past or future date.
 
 When `domain=knowledge` the response includes compact enrichment fields on each item — see [Knowledge Enrichment](#knowledge-enrichment) below.
 
@@ -235,7 +241,7 @@ When `domain=knowledge` the response includes compact enrichment fields on each 
 }
 ```
 
-**Response `422`** — Invalid domain value. The response includes a `hint` listing valid domains.
+**Response `422`** — Invalid domain value or malformed `date` parameter.
 
 See [CompactEvent](#compactevent) for the item schema.
 

--- a/routes/mobile.php
+++ b/routes/mobile.php
@@ -11,6 +11,7 @@ use App\Http\Controllers\Api\V1\Mobile\HealthController;
 use App\Http\Controllers\Api\V1\Mobile\IntegrationsController;
 use App\Http\Controllers\Api\V1\Mobile\LiveActivitiesController;
 use App\Http\Controllers\Api\V1\Mobile\MapController;
+use App\Http\Controllers\Api\V1\Mobile\MeController;
 use App\Http\Controllers\Api\V1\Mobile\MetricsController;
 use App\Http\Controllers\Api\V1\Mobile\ObjectsController;
 use App\Http\Controllers\Api\V1\Mobile\PingController;
@@ -35,6 +36,8 @@ use Illuminate\Support\Facades\Route;
 */
 
 Route::get('ping', PingController::class)->name('ping');
+
+Route::get('me', MeController::class)->name('me');
 
 Route::get('briefing/today', [BriefingController::class, 'today'])->name('briefing.today');
 

--- a/tests/Feature/Api/V1/Mobile/FeedControllerTest.php
+++ b/tests/Feature/Api/V1/Mobile/FeedControllerTest.php
@@ -145,6 +145,12 @@ class FeedControllerTest extends TestCase
             'metadata' => ['content' => 'A brief summary.'],
         ]);
 
+        Block::factory()->create([
+            'event_id' => $event->id,
+            'block_type' => 'fetch_summary_paragraph',
+            'metadata' => ['content' => 'A longer paragraph summary.'],
+        ]);
+
         Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
 
         $response = $this->getJson('/api/v1/mobile/feed?domain=knowledge')
@@ -153,6 +159,7 @@ class FeedControllerTest extends TestCase
         $item = $response->json('data.0');
         $this->assertSame('https://example.com/image.jpg', $item['target']['media_url']);
         $this->assertSame('A brief summary.', $item['tldr']);
+        $this->assertSame('A longer paragraph summary.', $item['summary_paragraph']);
     }
 
     #[Test]

--- a/tests/Feature/Api/V1/Mobile/FeedControllerTest.php
+++ b/tests/Feature/Api/V1/Mobile/FeedControllerTest.php
@@ -169,6 +169,58 @@ class FeedControllerTest extends TestCase
         $this->assertArrayNotHasKey('media_url', $item['target'] ?? []);
     }
 
+    #[Test]
+    public function default_feed_excludes_future_events(): void
+    {
+        $this->seedEvents(2);
+        $this->seedEventsAtTime(1, Carbon::now()->addDay());
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $response = $this->getJson('/api/v1/mobile/feed')->assertOk();
+
+        $this->assertCount(2, $response->json('data'));
+    }
+
+    #[Test]
+    public function date_parameter_returns_only_events_from_that_date(): void
+    {
+        $targetDate = Carbon::now()->subDays(3)->startOfDay();
+        $this->seedEventsAtTime(2, $targetDate->copy()->addHours(10));
+        $this->seedEvents(2);
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $response = $this->getJson('/api/v1/mobile/feed?date=' . $targetDate->format('Y-m-d'))->assertOk();
+
+        $this->assertCount(2, $response->json('data'));
+        foreach ($response->json('data') as $event) {
+            $this->assertSame($targetDate->format('Y-m-d'), Carbon::parse($event['time'])->format('Y-m-d'));
+        }
+    }
+
+    #[Test]
+    public function date_parameter_can_target_a_future_date(): void
+    {
+        $futureDate = Carbon::now()->addDays(2)->startOfDay();
+        $this->seedEventsAtTime(1, $futureDate->copy()->addHours(9));
+        $this->seedEvents(2);
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $response = $this->getJson('/api/v1/mobile/feed?date=' . $futureDate->format('Y-m-d'))->assertOk();
+
+        $this->assertCount(1, $response->json('data'));
+        $this->assertSame($futureDate->format('Y-m-d'), Carbon::parse($response->json('data.0.time'))->format('Y-m-d'));
+    }
+
+    #[Test]
+    public function rejects_invalid_date_format(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->getJson('/api/v1/mobile/feed?date=not-a-date')
+            ->assertStatus(422)
+            ->assertJsonStructure(['message']);
+    }
+
     protected function seedEvents(int $count, string $domain = 'money'): void
     {
         $actor = EventObject::factory()->create(['user_id' => $this->user->id]);
@@ -184,6 +236,27 @@ class FeedControllerTest extends TestCase
                 'value_multiplier' => 1,
                 'value_unit' => 'GBP',
                 'time' => Carbon::now()->subMinutes($i),
+                'actor_id' => $actor->id,
+                'target_id' => $target->id,
+            ]);
+        }
+    }
+
+    protected function seedEventsAtTime(int $count, Carbon $time, string $domain = 'money'): void
+    {
+        $actor = EventObject::factory()->create(['user_id' => $this->user->id]);
+        $target = EventObject::factory()->create(['user_id' => $this->user->id]);
+
+        foreach (range(0, $count - 1) as $i) {
+            Event::factory()->create([
+                'integration_id' => $this->integration->id,
+                'service' => 'monzo',
+                'domain' => $domain,
+                'action' => 'card_payment_to',
+                'value' => 10,
+                'value_multiplier' => 1,
+                'value_unit' => 'GBP',
+                'time' => $time->copy()->addMinutes($i),
                 'actor_id' => $actor->id,
                 'target_id' => $target->id,
             ]);

--- a/tests/Feature/Api/V1/Mobile/MeControllerTest.php
+++ b/tests/Feature/Api/V1/Mobile/MeControllerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Tests\Feature\Api\V1\Mobile;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class MeControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['ios.mobile_api_enabled' => true]);
+    }
+
+    #[Test]
+    public function requires_authentication(): void
+    {
+        $this->getJson('/api/v1/mobile/me')->assertStatus(401);
+    }
+
+    #[Test]
+    public function returns_user_profile_shape(): void
+    {
+        $user = User::factory()->create([
+            'name' => 'Will Scott',
+            'email' => 'will@example.com',
+        ]);
+
+        Sanctum::actingAs($user, ['ios:read']);
+
+        $this->getJson('/api/v1/mobile/me')
+            ->assertOk()
+            ->assertJsonStructure(['id', 'name', 'email', 'timezone', 'avatar_url'])
+            ->assertJsonPath('id', (string) $user->id)
+            ->assertJsonPath('name', 'Will Scott')
+            ->assertJsonPath('email', 'will@example.com')
+            ->assertJsonPath('avatar_url', null);
+    }
+
+    #[Test]
+    public function id_is_returned_as_string(): void
+    {
+        Sanctum::actingAs(User::factory()->create(), ['ios:read']);
+
+        $response = $this->getJson('/api/v1/mobile/me')->assertOk();
+
+        $this->assertIsString($response->json('id'));
+    }
+
+    #[Test]
+    public function timezone_defaults_to_utc(): void
+    {
+        Sanctum::actingAs(User::factory()->create(), ['ios:read']);
+
+        $this->getJson('/api/v1/mobile/me')
+            ->assertOk()
+            ->assertJsonPath('timezone', 'UTC');
+    }
+
+    #[Test]
+    public function etag_header_is_present(): void
+    {
+        Sanctum::actingAs(User::factory()->create(), ['ios:read']);
+
+        $this->getJson('/api/v1/mobile/me')
+            ->assertOk()
+            ->assertHeader('ETag');
+    }
+}

--- a/tests/Feature/Api/V1/Mobile/MetricsControllerTest.php
+++ b/tests/Feature/Api/V1/Mobile/MetricsControllerTest.php
@@ -57,10 +57,10 @@ class MetricsControllerTest extends TestCase
         $this->getJson('/api/v1/mobile/metrics')
             ->assertOk()
             ->assertJsonStructure([
-                [[
+                '*' => [
                     'id', 'identifier', 'display_name', 'service',
                     'domain', 'action', 'unit', 'event_count', 'mean', 'last_event_at',
-                ]],
+                ],
             ])
             ->assertJsonPath('0.identifier', 'oura.sleep_score')
             ->assertJsonPath('0.service', 'oura')

--- a/tests/Feature/Api/V1/Mobile/MetricsControllerTest.php
+++ b/tests/Feature/Api/V1/Mobile/MetricsControllerTest.php
@@ -57,13 +57,15 @@ class MetricsControllerTest extends TestCase
         $this->getJson('/api/v1/mobile/metrics')
             ->assertOk()
             ->assertJsonStructure([
-                'data' => [[
+                [[
                     'id', 'identifier', 'display_name', 'service',
-                    'action', 'unit', 'event_count', 'mean', 'last_event_at',
+                    'domain', 'action', 'unit', 'event_count', 'mean', 'last_event_at',
                 ]],
             ])
-            ->assertJsonPath('data.0.service', 'oura')
-            ->assertJsonPath('data.0.action', 'had_sleep_score');
+            ->assertJsonPath('0.identifier', 'oura.sleep_score')
+            ->assertJsonPath('0.service', 'oura')
+            ->assertJsonPath('0.domain', 'health')
+            ->assertJsonPath('0.action', 'had_sleep_score');
     }
 
     #[Test]
@@ -73,7 +75,7 @@ class MetricsControllerTest extends TestCase
 
         $this->getJson('/api/v1/mobile/metrics')
             ->assertOk()
-            ->assertJson(['data' => []]);
+            ->assertExactJson([]);
     }
 
     #[Test]
@@ -93,6 +95,24 @@ class MetricsControllerTest extends TestCase
             ])
             ->assertJsonPath('service', 'oura')
             ->assertJsonPath('action', 'had_sleep_score');
+    }
+
+    #[Test]
+    public function returns_trend_payload_for_range_query(): void
+    {
+        $this->seedMetric();
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        Carbon::setTestNow('2026-05-03 12:00:00');
+
+        try {
+            $this->getJson('/api/v1/mobile/metrics/oura.sleep_score?range=7d')
+                ->assertOk()
+                ->assertJsonPath('range.from', '2026-04-27')
+                ->assertJsonPath('range.to', '2026-05-03');
+        } finally {
+            Carbon::setTestNow();
+        }
     }
 
     #[Test]


### PR DESCRIPTION
- Add new `MeController` invokable endpoint at `GET /api/v1/mobile/me` that returns the authenticated user’s `id`, `name`, `email`, `timezone`, and `avatar_url` (null)
- Register the `me` route in `routes/mobile.php` to expose the controller under the mobile API
- Add `MeControllerTest` feature coverage:
  - verifies unauthenticated requests return 401
  - asserts response JSON structure and exact field values
  - ensures `id` is returned as a string
  - confirms timezone defaults to `UTC`
  - checks an `ETag` header is present
- Enable iOS mobile API behavior in tests via `config(['ios.mobile_api_enabled' => true])` to match runtime expectations