### PR TITLE
:recycle: Refactor Tasks

### DIFF
--- a/app/Console/Commands/BackfillOysterTransportTagsCommand.php
+++ b/app/Console/Commands/BackfillOysterTransportTagsCommand.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Integrations\Oyster\OysterTransportModeDetector;
+use App\Models\Event;
+use Illuminate\Console\Command;
+
+class BackfillOysterTransportTagsCommand extends Command
+{
+    protected $signature = 'oyster:backfill-transport-tags';
+
+    protected $description = 'Backfill transport_mode tags on existing Oyster journey events';
+
+    public function handle(): int
+    {
+        $query = Event::where('service', 'oyster')
+            ->whereIn('action', ['touched_in_at', 'touched_out_at'])
+            ->whereNotNull('event_metadata->transport_mode');
+
+        $total = $query->count();
+
+        if ($total === 0) {
+            $this->info('No Oyster journey events found.');
+
+            return self::SUCCESS;
+        }
+
+        $this->info("Backfilling transport_mode tags on {$total} events...");
+
+        $tagged = 0;
+        $skipped = 0;
+
+        $query->chunkById(200, function ($events) use (&$tagged, &$skipped) {
+            foreach ($events as $event) {
+                $mode = $event->event_metadata['transport_mode'] ?? null;
+
+                if (! $mode || $mode === OysterTransportModeDetector::MODE_UNKNOWN) {
+                    $skipped++;
+
+                    continue;
+                }
+
+                $event->attachTag($mode, 'transport_mode');
+                $tagged++;
+            }
+
+            $this->output->write('.');
+        });
+
+        $this->newLine();
+        $this->info("Done. Tagged: {$tagged}, Skipped (unknown/missing): {$skipped}");
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/TaskPipeline/MigrateTaskExecutionsCommand.php
+++ b/app/Console/Commands/TaskPipeline/MigrateTaskExecutionsCommand.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace App\Console\Commands\TaskPipeline;
+
+use App\Jobs\TaskPipeline\MigrateTaskExecutionsBatchJob;
+use App\Models\Block;
+use App\Models\Event;
+use App\Models\EventObject;
+use App\Models\Integration;
+use App\Services\TaskPipeline\TaskExecutionStore;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Model;
+
+class MigrateTaskExecutionsCommand extends Command
+{
+    protected $signature = 'task-pipeline:migrate-executions
+                            {--model= : Model type (event, block, object, integration)}
+                            {--batch-size=500 : Number of records per batch}
+                            {--limit= : Maximum records to scan per model type}
+                            {--dry-run : Count records without dispatching jobs}
+                            {--force : Overwrite existing task_executions rows}';
+
+    protected $description = 'Backfill legacy task execution metadata into the task_executions table';
+
+    public function handle(TaskExecutionStore $store): int
+    {
+        $modelTypes = $this->modelTypes();
+        $batchSize = max(1, (int) $this->option('batch-size'));
+        $limit = $this->option('limit') !== null ? max(1, (int) $this->option('limit')) : null;
+
+        if ($modelTypes === []) {
+            $this->error('Invalid --model value. Use event, block, object, or integration.');
+
+            return Command::FAILURE;
+        }
+
+        if ($this->option('dry-run')) {
+            return $this->dryRun($modelTypes, $store, $limit);
+        }
+
+        foreach ($modelTypes as $modelType => $modelClass) {
+            MigrateTaskExecutionsBatchJob::dispatch(
+                modelType: $modelType,
+                cursor: null,
+                batchSize: $batchSize,
+                limit: $limit,
+                force: (bool) $this->option('force'),
+            )->onConnection('redis')->onQueue('migration');
+
+            $this->line("Dispatched {$modelType} task execution migration to redis/migration.");
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param  array<string, class-string<Model>>  $modelTypes
+     */
+    protected function dryRun(array $modelTypes, TaskExecutionStore $store, ?int $limit): int
+    {
+        $rows = [];
+
+        foreach ($modelTypes as $modelType => $modelClass) {
+            $scanned = 0;
+            $withMetadata = 0;
+            $missingOwner = 0;
+            $invalidMetadata = 0;
+
+            $query = $modelClass::query()->orderBy('id');
+            if ($limit) {
+                $query->limit($limit);
+            }
+
+            $query->get()->each(function (Model $model) use ($store, &$scanned, &$withMetadata, &$missingOwner, &$invalidMetadata): void {
+                $scanned++;
+                $legacy = $store->getLegacyTaskExecutions($model);
+
+                if ($legacy === []) {
+                    return;
+                }
+
+                if (! is_array($legacy)) {
+                    $invalidMetadata++;
+
+                    return;
+                }
+
+                $withMetadata++;
+
+                if (! $store->resolveUserId($model)) {
+                    $missingOwner++;
+                }
+            });
+
+            $rows[] = [
+                'Model' => $modelType,
+                'Scanned' => $scanned,
+                'With metadata' => $withMetadata,
+                'Missing owner' => $missingOwner,
+                'Invalid metadata' => $invalidMetadata,
+                'Batches' => (int) ceil(max(1, $scanned) / max(1, (int) $this->option('batch-size'))),
+            ];
+        }
+
+        $this->table(['Model', 'Scanned', 'With metadata', 'Missing owner', 'Invalid metadata', 'Batches'], $rows);
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @return array<string, class-string<Model>>
+     */
+    protected function modelTypes(): array
+    {
+        $all = [
+            'event' => Event::class,
+            'block' => Block::class,
+            'object' => EventObject::class,
+            'integration' => Integration::class,
+        ];
+
+        $model = $this->option('model');
+
+        if (! $model) {
+            return $all;
+        }
+
+        return isset($all[$model]) ? [$model => $all[$model]] : [];
+    }
+}

--- a/app/Console/Commands/TaskPipeline/ProcessIncompleteTasksCommand.php
+++ b/app/Console/Commands/TaskPipeline/ProcessIncompleteTasksCommand.php
@@ -63,7 +63,7 @@ class ProcessIncompleteTasksCommand extends Command
             foreach ($filters as $key => $value) {
                 $filterStrings[] = "{$key}={$value}";
             }
-            $this->comment('Filters: '.implode(', ', $filterStrings));
+            $this->comment('Filters: ' . implode(', ', $filterStrings));
         }
 
         $this->newLine();
@@ -115,7 +115,7 @@ class ProcessIncompleteTasksCommand extends Command
         $batchSize = (int) $this->option('batch-size');
         $filters = $this->getFilters();
 
-        $this->info('Starting batch processing for '.count($modelTypes).' model type(s)...');
+        $this->info('Starting batch processing for ' . count($modelTypes) . ' model type(s)...');
         $this->newLine();
 
         // Create progress record (use first user as owner for system commands)
@@ -129,7 +129,7 @@ class ProcessIncompleteTasksCommand extends Command
         $progressRecord = ActionProgress::createProgress(
             $userId,
             'task_pipeline_batch',
-            'batch_'.now()->timestamp,
+            'batch_' . now()->timestamp,
             'starting',
             'Starting batch task pipeline processing...',
             0

--- a/app/Console/Commands/TaskPipeline/ProcessIncompleteTasksCommand.php
+++ b/app/Console/Commands/TaskPipeline/ProcessIncompleteTasksCommand.php
@@ -63,7 +63,7 @@ class ProcessIncompleteTasksCommand extends Command
             foreach ($filters as $key => $value) {
                 $filterStrings[] = "{$key}={$value}";
             }
-            $this->comment('Filters: ' . implode(', ', $filterStrings));
+            $this->comment('Filters: '.implode(', ', $filterStrings));
         }
 
         $this->newLine();
@@ -71,7 +71,6 @@ class ProcessIncompleteTasksCommand extends Command
         $modelTypes = $this->getModelTypes();
         $results = [];
         $totalIncomplete = 0;
-        $totalPrefillable = 0;
 
         foreach ($modelTypes as $modelClass => $modelName) {
             $this->comment("Scanning {$modelName} records...");
@@ -86,7 +85,6 @@ class ProcessIncompleteTasksCommand extends Command
             ];
 
             $totalIncomplete += $result['incomplete'];
-            $totalPrefillable += $result['prefillable'];
         }
 
         $this->newLine();
@@ -97,13 +95,11 @@ class ProcessIncompleteTasksCommand extends Command
             $results
         );
 
-        // Add totals row
         $batchSize = (int) $this->option('batch-size');
         $batchCount = (int) ceil($totalIncomplete / $batchSize);
 
         $this->newLine();
         $this->info("Would process {$totalIncomplete} models in {$batchCount} batches of {$batchSize}");
-        $this->info("Estimated embedding pre-fills: {$totalPrefillable}");
         $this->newLine();
         $this->comment('Run without --dry-run to execute.');
 
@@ -119,7 +115,7 @@ class ProcessIncompleteTasksCommand extends Command
         $batchSize = (int) $this->option('batch-size');
         $filters = $this->getFilters();
 
-        $this->info('Starting batch processing for ' . count($modelTypes) . ' model type(s)...');
+        $this->info('Starting batch processing for '.count($modelTypes).' model type(s)...');
         $this->newLine();
 
         // Create progress record (use first user as owner for system commands)
@@ -133,7 +129,7 @@ class ProcessIncompleteTasksCommand extends Command
         $progressRecord = ActionProgress::createProgress(
             $userId,
             'task_pipeline_batch',
-            'batch_' . now()->timestamp,
+            'batch_'.now()->timestamp,
             'starting',
             'Starting batch task pipeline processing...',
             0
@@ -149,7 +145,7 @@ class ProcessIncompleteTasksCommand extends Command
                 $batchSize,
                 $filters,
                 $progressRecord->id,
-                ['processed' => 0, 'examined' => 0, 'prefilled' => 0, 'failed' => 0]
+                ['processed' => 0, 'examined' => 0, 'failed' => 0]
             )->onQueue('tasks');
 
             $this->line("  ✓ {$modelName} batch job dispatched (offset: 0)");
@@ -189,7 +185,6 @@ class ProcessIncompleteTasksCommand extends Command
         $total = $query->count();
         $examined = 0;
         $incomplete = 0;
-        $prefillable = 0;
         $limit = $this->option('limit') ? (int) $this->option('limit') : null;
 
         if ($total === 0) {
@@ -197,20 +192,15 @@ class ProcessIncompleteTasksCommand extends Command
                 'total' => 0,
                 'examined' => 0,
                 'incomplete' => 0,
-                'prefillable' => 0,
             ];
         }
 
-        $query->orderBy('created_at', 'desc')->chunk(100, function ($models) use (&$examined, &$incomplete, &$prefillable, $limit) {
+        $query->orderBy('created_at', 'desc')->chunk(100, function ($models) use (&$examined, &$incomplete, $limit) {
             foreach ($models as $model) {
                 $examined++;
 
                 if ($this->hasIncompleteTasks($model)) {
                     $incomplete++;
-
-                    if ($this->canPrefillEmbedding($model)) {
-                        $prefillable++;
-                    }
 
                     if ($limit && $incomplete >= $limit) {
                         return false; // Stop chunking
@@ -223,7 +213,6 @@ class ProcessIncompleteTasksCommand extends Command
             'total' => $total,
             'examined' => $examined,
             'incomplete' => $incomplete,
-            'prefillable' => $prefillable,
         ];
     }
 
@@ -241,41 +230,13 @@ class ProcessIncompleteTasksCommand extends Command
         $executions = $this->getTaskExecutions($model);
 
         foreach ($applicableTasks as $task) {
-            // Special case: embedding with metadata
-            if ($task->key === 'generate_embedding') {
-                $metadataField = $this->getMetadataField($model);
-                $metadata = $model->$metadataField ?? [];
-
-                if (isset($metadata['embedding_generated_at']) && ! empty($model->embeddings)) {
-                    continue; // Completed
-                }
-            }
-
-            // Check execution status
             $lastAttempt = $executions[$task->key]['last_attempt'] ?? null;
             if (! $lastAttempt || $lastAttempt['status'] !== 'success') {
-                return true; // Found incomplete task
+                return true;
             }
         }
 
         return false;
-    }
-
-    /**
-     * Check if model can pre-fill embedding
-     */
-    protected function canPrefillEmbedding(Model $model): bool
-    {
-        $metadataField = $this->getMetadataField($model);
-        $metadata = $model->$metadataField ?? [];
-
-        if (! isset($metadata['embedding_generated_at']) || empty($model->embeddings)) {
-            return false;
-        }
-
-        $executions = $this->getTaskExecutions($model);
-
-        return ! isset($executions['generate_embedding']['last_success']);
     }
 
     /**

--- a/app/Http/Controllers/Api/TaskExecutionController.php
+++ b/app/Http/Controllers/Api/TaskExecutionController.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\TaskExecutionResource;
+use App\Models\TaskExecution;
+use Illuminate\Http\Request;
+
+class TaskExecutionController extends Controller
+{
+    public function index(Request $request)
+    {
+        $validated = $request->validate([
+            'status' => ['nullable', 'string'],
+            'task_key' => ['nullable', 'string'],
+            'entity_type' => ['nullable', 'string', 'in:event,block,object,integration'],
+            'entity_id' => ['nullable', 'uuid'],
+            'queue' => ['nullable', 'string'],
+            'from' => ['nullable', 'date'],
+            'to' => ['nullable', 'date'],
+            'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+        ]);
+
+        $query = TaskExecution::query()
+            ->forUser($request->user()->id)
+            ->when($validated['status'] ?? null, fn ($query, $value) => $query->where('status', $value))
+            ->when($validated['task_key'] ?? null, fn ($query, $value) => $query->where('task_key', $value))
+            ->when($validated['entity_type'] ?? null, fn ($query, $value) => $query->where('entity_type', $value))
+            ->when($validated['entity_id'] ?? null, fn ($query, $value) => $query->where('entity_id', $value))
+            ->when($validated['queue'] ?? null, fn ($query, $value) => $query->where('queue', $value))
+            ->when($validated['from'] ?? null, fn ($query, $value) => $query->where('updated_at', '>=', $value))
+            ->when($validated['to'] ?? null, fn ($query, $value) => $query->where('updated_at', '<=', $value))
+            ->latest('updated_at');
+
+        return TaskExecutionResource::collection(
+            $query->paginate($validated['per_page'] ?? 25)
+        );
+    }
+
+    public function show(Request $request, TaskExecution $taskExecution)
+    {
+        abort_unless($taskExecution->user_id === $request->user()->id, 404);
+
+        return new TaskExecutionResource($taskExecution);
+    }
+}

--- a/app/Http/Resources/TaskExecutionResource.php
+++ b/app/Http/Resources/TaskExecutionResource.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Models\TaskExecution;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin TaskExecution
+ */
+class TaskExecutionResource extends JsonResource
+{
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'user_id' => $this->user_id,
+            'entity_type' => $this->entity_type,
+            'entity_id' => $this->entity_id,
+            'task_key' => $this->task_key,
+            'task_name' => $this->task_name,
+            'status' => $this->status,
+            'attempts' => $this->attempts,
+            'triggered_by' => $this->triggered_by,
+            'started_at' => $this->started_at?->toIso8601String(),
+            'completed_at' => $this->completed_at?->toIso8601String(),
+            'queue' => $this->queue,
+            'queue_connection' => $this->queue_connection,
+            'job_id' => $this->job_id,
+            'error' => $this->error,
+            'waiting_for' => $this->waiting_for,
+            'blocked_by' => $this->blocked_by,
+            'changed_fields' => $this->changed_fields,
+            'history' => $this->history ?? [],
+            'last_success' => $this->last_success,
+            'created_at' => $this->created_at?->toIso8601String(),
+            'updated_at' => $this->updated_at?->toIso8601String(),
+        ];
+    }
+}

--- a/app/Integrations/Fetch/FetchPlugin.php
+++ b/app/Integrations/Fetch/FetchPlugin.php
@@ -4,12 +4,17 @@ namespace App\Integrations\Fetch;
 
 use App\Integrations\Base\ManualPlugin;
 use App\Integrations\Contracts\SupportsSpotlightCommands;
+use App\Integrations\Contracts\SupportsTaskPipeline;
+use App\Jobs\TaskPipeline\Tasks\FetchExtractContentTask;
+use App\Jobs\TaskPipeline\Tasks\FetchGenerateSummariesTask;
+use App\Models\Event;
 use App\Models\Integration;
 use App\Models\IntegrationGroup;
 use App\Models\User;
+use App\Services\TaskPipeline\TaskDefinition;
 use Throwable;
 
-class FetchPlugin extends ManualPlugin implements SupportsSpotlightCommands
+class FetchPlugin extends ManualPlugin implements SupportsSpotlightCommands, SupportsTaskPipeline
 {
     public static function getServiceType(): string
     {
@@ -214,6 +219,40 @@ class FetchPlugin extends ManualPlugin implements SupportsSpotlightCommands
                 'description' => 'Fetch system user',
                 'hidden' => true,
             ],
+        ];
+    }
+
+    public static function getTaskDefinitions(): array
+    {
+        return [
+            new TaskDefinition(
+                key: 'fetch_extract_content',
+                name: 'Fetch: Extract Content',
+                description: 'Extract clean Markdown from fetched article HTML using AI',
+                jobClass: FetchExtractContentTask::class,
+                appliesTo: ['event'],
+                conditions: ['service' => 'fetch', 'domain' => 'knowledge'],
+                runOnCreate: true,
+                runOnUpdate: false,
+                shouldRun: fn (Event $event) => $event->blocks()->where('block_type', 'fetch_content')->exists()
+                    && empty($event->target?->content),
+            ),
+            new TaskDefinition(
+                key: 'fetch_generate_summaries',
+                name: 'Fetch: Generate Summaries',
+                description: 'Generate AI summary blocks and tags for a fetched article',
+                jobClass: FetchGenerateSummariesTask::class,
+                appliesTo: ['event'],
+                conditions: ['service' => 'fetch', 'domain' => 'knowledge'],
+                dependencies: ['fetch_extract_content'],
+                runOnCreate: true,
+                runOnUpdate: false,
+                shouldRun: fn (Event $event) => ! empty($event->target?->content)
+                    && ! $event->blocks()->where('block_type', 'fetch_tldr')
+                        ->whereNotNull('metadata->content')
+                        ->whereNull('deleted_at')
+                        ->exists(),
+            ),
         ];
     }
 

--- a/app/Integrations/Hevy/HevyPlugin.php
+++ b/app/Integrations/Hevy/HevyPlugin.php
@@ -8,6 +8,7 @@ use App\Integrations\Contracts\SupportsTaskPipeline;
 use App\Jobs\Effects\Hevy\HevyAnalyzeProgressionEffect;
 use App\Jobs\Effects\Hevy\HevyAutoCoachEffect;
 use App\Jobs\Effects\Hevy\HevyUpdateRoutineEffect;
+use App\Jobs\TaskPipeline\Tasks\HevyAutoCoachTask;
 use App\Models\Block;
 use App\Models\Event;
 use App\Models\EventObject;
@@ -327,7 +328,7 @@ class HevyPlugin implements IntegrationPlugin, SupportsEffects, SupportsTaskPipe
                 key: 'hevy_auto_coach',
                 name: 'Hevy Auto Coach',
                 description: 'Automatically analyze workouts and update routines with progressive overload recommendations',
-                jobClass: HevyAutoCoachEffect::class,
+                jobClass: HevyAutoCoachTask::class,
                 appliesTo: ['event'],
                 conditions: [
                     'service' => 'hevy',
@@ -437,7 +438,7 @@ class HevyPlugin implements IntegrationPlugin, SupportsEffects, SupportsTaskPipe
             'limit' => 100,
         ]);
 
-        $endpoint = '/v1/workouts?' . $query;
+        $endpoint = '/v1/workouts?'.$query;
         $json = [];
         try {
             $json = $this->getJson($endpoint, $integration);
@@ -505,7 +506,7 @@ class HevyPlugin implements IntegrationPlugin, SupportsEffects, SupportsTaskPipe
                     'limit' => 100,
                 ]);
 
-                $endpoint = '/v1/routines?' . $query;
+                $endpoint = '/v1/routines?'.$query;
                 $json = $this->getJson($endpoint, $integration);
 
                 $routines = $json['routines'] ?? $json['data'] ?? [];
@@ -551,7 +552,7 @@ class HevyPlugin implements IntegrationPlugin, SupportsEffects, SupportsTaskPipe
     public function updateRoutine(Integration $integration, string $routineId, array $updates): array
     {
         $apiKey = (string) ($integration->configuration['api_key'] ?? $this->apiKey ?? '');
-        $url = $this->baseUrl . '/v1/routines/' . $routineId;
+        $url = $this->baseUrl.'/v1/routines/'.$routineId;
 
         log_integration_api_request('hevy', 'PUT', "/v1/routines/{$routineId}", ['api-key' => '***'], $updates, $integration->id);
 
@@ -561,7 +562,7 @@ class HevyPlugin implements IntegrationPlugin, SupportsEffects, SupportsTaskPipe
         log_integration_api_response('hevy', 'PUT', "/v1/routines/{$routineId}", $response->status(), $response->body(), $response->headers(), $integration->id);
 
         if (! $response->successful()) {
-            throw new RuntimeException('Hevy routine update failed: ' . $response->status() . ' - ' . $response->body());
+            throw new RuntimeException('Hevy routine update failed: '.$response->status().' - '.$response->body());
         }
 
         return $response->json() ?? [];
@@ -604,7 +605,7 @@ class HevyPlugin implements IntegrationPlugin, SupportsEffects, SupportsTaskPipe
                     'page' => $page,
                 ]);
 
-                $endpoint = '/v1/workouts?' . $query;
+                $endpoint = '/v1/workouts?'.$query;
                 $json = $this->getJson($endpoint, $integration);
 
                 $workouts = $json['workouts'] ?? $json['data'] ?? [];
@@ -690,7 +691,7 @@ class HevyPlugin implements IntegrationPlugin, SupportsEffects, SupportsTaskPipe
             'user_id' => $integration->user_id,
             'concept' => 'workout',
             'type' => 'hevy_workout',
-            'title' => $title . ' (' . substr($workoutId, 0, 8) . ')',
+            'title' => $title.' ('.substr($workoutId, 0, 8).')',
         ], [
             'time' => $startIso,
             'content' => Arr::get($workout, 'description') ?? 'Hevy workout',
@@ -794,7 +795,7 @@ class HevyPlugin implements IntegrationPlugin, SupportsEffects, SupportsTaskPipe
                 $event->createBlock([
                     'block_type' => 'exercise',
                     'time' => $startIso,
-                    'title' => $exerciseName . ' - Set ' . $setNum,
+                    'title' => $exerciseName.' - Set '.$setNum,
                     'metadata' => $metadata,
                     'url' => null,
                     'media_url' => null,
@@ -810,7 +811,7 @@ class HevyPlugin implements IntegrationPlugin, SupportsEffects, SupportsTaskPipe
                 $event->createBlock([
                     'block_type' => 'exercise_summary',
                     'time' => $startIso,
-                    'title' => $exerciseName . ' - Total Volume',
+                    'title' => $exerciseName.' - Total Volume',
                     'metadata' => [
                         'exercise_name' => $exerciseName,
                         'total_volume' => $exerciseVolume,
@@ -870,7 +871,7 @@ class HevyPlugin implements IntegrationPlugin, SupportsEffects, SupportsTaskPipe
                 'end_date' => $endDate,
                 'limit' => 100,
             ]);
-            $sweepEndpoint = '/v1/workouts?' . $sweepQuery;
+            $sweepEndpoint = '/v1/workouts?'.$sweepQuery;
             $sweepJson = $this->getJson($sweepEndpoint, $integration);
 
             $sweepItems = [];
@@ -911,7 +912,7 @@ class HevyPlugin implements IntegrationPlugin, SupportsEffects, SupportsTaskPipe
     {
         $apiKey = (string) ($integration->configuration['api_key'] ?? $this->apiKey ?? '');
         // In tests we allow empty; in production recommend providing api key
-        $url = Str::startsWith($endpoint, '/') ? $this->baseUrl . $endpoint : $this->baseUrl . '/' . ltrim($endpoint, '/');
+        $url = Str::startsWith($endpoint, '/') ? $this->baseUrl.$endpoint : $this->baseUrl.'/'.ltrim($endpoint, '/');
 
         $headers = ['api-key' => $apiKey];
 
@@ -939,7 +940,7 @@ class HevyPlugin implements IntegrationPlugin, SupportsEffects, SupportsTaskPipe
         );
 
         if (! $response->successful()) {
-            throw new RuntimeException('Hevy API request failed with status ' . $response->status());
+            throw new RuntimeException('Hevy API request failed with status '.$response->status());
         }
 
         return $response->json() ?? [];

--- a/app/Integrations/Hevy/HevyPlugin.php
+++ b/app/Integrations/Hevy/HevyPlugin.php
@@ -438,7 +438,7 @@ class HevyPlugin implements IntegrationPlugin, SupportsEffects, SupportsTaskPipe
             'limit' => 100,
         ]);
 
-        $endpoint = '/v1/workouts?'.$query;
+        $endpoint = '/v1/workouts?' . $query;
         $json = [];
         try {
             $json = $this->getJson($endpoint, $integration);
@@ -506,7 +506,7 @@ class HevyPlugin implements IntegrationPlugin, SupportsEffects, SupportsTaskPipe
                     'limit' => 100,
                 ]);
 
-                $endpoint = '/v1/routines?'.$query;
+                $endpoint = '/v1/routines?' . $query;
                 $json = $this->getJson($endpoint, $integration);
 
                 $routines = $json['routines'] ?? $json['data'] ?? [];
@@ -552,7 +552,7 @@ class HevyPlugin implements IntegrationPlugin, SupportsEffects, SupportsTaskPipe
     public function updateRoutine(Integration $integration, string $routineId, array $updates): array
     {
         $apiKey = (string) ($integration->configuration['api_key'] ?? $this->apiKey ?? '');
-        $url = $this->baseUrl.'/v1/routines/'.$routineId;
+        $url = $this->baseUrl . '/v1/routines/' . $routineId;
 
         log_integration_api_request('hevy', 'PUT', "/v1/routines/{$routineId}", ['api-key' => '***'], $updates, $integration->id);
 
@@ -562,7 +562,7 @@ class HevyPlugin implements IntegrationPlugin, SupportsEffects, SupportsTaskPipe
         log_integration_api_response('hevy', 'PUT', "/v1/routines/{$routineId}", $response->status(), $response->body(), $response->headers(), $integration->id);
 
         if (! $response->successful()) {
-            throw new RuntimeException('Hevy routine update failed: '.$response->status().' - '.$response->body());
+            throw new RuntimeException('Hevy routine update failed: ' . $response->status() . ' - ' . $response->body());
         }
 
         return $response->json() ?? [];
@@ -605,7 +605,7 @@ class HevyPlugin implements IntegrationPlugin, SupportsEffects, SupportsTaskPipe
                     'page' => $page,
                 ]);
 
-                $endpoint = '/v1/workouts?'.$query;
+                $endpoint = '/v1/workouts?' . $query;
                 $json = $this->getJson($endpoint, $integration);
 
                 $workouts = $json['workouts'] ?? $json['data'] ?? [];
@@ -691,7 +691,7 @@ class HevyPlugin implements IntegrationPlugin, SupportsEffects, SupportsTaskPipe
             'user_id' => $integration->user_id,
             'concept' => 'workout',
             'type' => 'hevy_workout',
-            'title' => $title.' ('.substr($workoutId, 0, 8).')',
+            'title' => $title . ' (' . substr($workoutId, 0, 8) . ')',
         ], [
             'time' => $startIso,
             'content' => Arr::get($workout, 'description') ?? 'Hevy workout',
@@ -795,7 +795,7 @@ class HevyPlugin implements IntegrationPlugin, SupportsEffects, SupportsTaskPipe
                 $event->createBlock([
                     'block_type' => 'exercise',
                     'time' => $startIso,
-                    'title' => $exerciseName.' - Set '.$setNum,
+                    'title' => $exerciseName . ' - Set ' . $setNum,
                     'metadata' => $metadata,
                     'url' => null,
                     'media_url' => null,
@@ -811,7 +811,7 @@ class HevyPlugin implements IntegrationPlugin, SupportsEffects, SupportsTaskPipe
                 $event->createBlock([
                     'block_type' => 'exercise_summary',
                     'time' => $startIso,
-                    'title' => $exerciseName.' - Total Volume',
+                    'title' => $exerciseName . ' - Total Volume',
                     'metadata' => [
                         'exercise_name' => $exerciseName,
                         'total_volume' => $exerciseVolume,
@@ -871,7 +871,7 @@ class HevyPlugin implements IntegrationPlugin, SupportsEffects, SupportsTaskPipe
                 'end_date' => $endDate,
                 'limit' => 100,
             ]);
-            $sweepEndpoint = '/v1/workouts?'.$sweepQuery;
+            $sweepEndpoint = '/v1/workouts?' . $sweepQuery;
             $sweepJson = $this->getJson($sweepEndpoint, $integration);
 
             $sweepItems = [];
@@ -912,7 +912,7 @@ class HevyPlugin implements IntegrationPlugin, SupportsEffects, SupportsTaskPipe
     {
         $apiKey = (string) ($integration->configuration['api_key'] ?? $this->apiKey ?? '');
         // In tests we allow empty; in production recommend providing api key
-        $url = Str::startsWith($endpoint, '/') ? $this->baseUrl.$endpoint : $this->baseUrl.'/'.ltrim($endpoint, '/');
+        $url = Str::startsWith($endpoint, '/') ? $this->baseUrl . $endpoint : $this->baseUrl . '/' . ltrim($endpoint, '/');
 
         $headers = ['api-key' => $apiKey];
 
@@ -940,7 +940,7 @@ class HevyPlugin implements IntegrationPlugin, SupportsEffects, SupportsTaskPipe
         );
 
         if (! $response->successful()) {
-            throw new RuntimeException('Hevy API request failed with status '.$response->status());
+            throw new RuntimeException('Hevy API request failed with status ' . $response->status());
         }
 
         return $response->json() ?? [];

--- a/app/Integrations/Newsletter/NewsletterPlugin.php
+++ b/app/Integrations/Newsletter/NewsletterPlugin.php
@@ -3,14 +3,19 @@
 namespace App\Integrations\Newsletter;
 
 use App\Integrations\Base\WebhookPlugin;
+use App\Integrations\Contracts\SupportsTaskPipeline;
 use App\Jobs\Data\Newsletter\ProcessNewsletterEmailJob;
+use App\Jobs\TaskPipeline\Tasks\NewsletterExtractContentTask;
+use App\Jobs\TaskPipeline\Tasks\NewsletterGenerateSummariesTask;
+use App\Models\Event;
 use App\Models\Integration;
+use App\Services\TaskPipeline\TaskDefinition;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
 use Throwable;
 
-class NewsletterPlugin extends WebhookPlugin
+class NewsletterPlugin extends WebhookPlugin implements SupportsTaskPipeline
 {
     public static function getIdentifier(): string
     {
@@ -137,6 +142,40 @@ class NewsletterPlugin extends WebhookPlugin
                 'description' => 'Newsletter system user (Me)',
                 'hidden' => true,
             ],
+        ];
+    }
+
+    public static function getTaskDefinitions(): array
+    {
+        return [
+            new TaskDefinition(
+                key: 'newsletter_extract_content',
+                name: 'Newsletter: Extract Content',
+                description: 'Extract clean Markdown from raw newsletter HTML using AI',
+                jobClass: NewsletterExtractContentTask::class,
+                appliesTo: ['event'],
+                conditions: ['service' => 'newsletter', 'domain' => 'knowledge'],
+                runOnCreate: true,
+                runOnUpdate: false,
+                shouldRun: fn (Event $event) => ! empty($event->event_metadata['raw_html'])
+                    && empty($event->target?->metadata['extracted_at']),
+            ),
+            new TaskDefinition(
+                key: 'newsletter_generate_summaries',
+                name: 'Newsletter: Generate Summaries',
+                description: 'Generate AI summary blocks and tags for a newsletter event',
+                jobClass: NewsletterGenerateSummariesTask::class,
+                appliesTo: ['event'],
+                conditions: ['service' => 'newsletter', 'domain' => 'knowledge'],
+                dependencies: ['newsletter_extract_content'],
+                runOnCreate: true,
+                runOnUpdate: false,
+                shouldRun: fn (Event $event) => ! empty($event->target?->content)
+                    && ! $event->blocks()->where('block_type', 'newsletter_tldr')
+                        ->whereNotNull('metadata->content')
+                        ->whereNull('deleted_at')
+                        ->exists(),
+            ),
         ];
     }
 

--- a/app/Jobs/Data/Fetch/ProcessFetchedContent.php
+++ b/app/Jobs/Data/Fetch/ProcessFetchedContent.php
@@ -213,18 +213,20 @@ class ProcessFetchedContent implements ShouldQueue
                 return;
             }
 
-            // Dispatch content extraction job
-            ExtractContentJob::dispatch(
-                $this->integration,
-                $event,
-                $this->webpage,
-                $this->extracted,
-                $sourceObjectId,
-                $sourceEventId,
-                $sourceIsObject
-            );
+            if ($isLinkable) {
+                // Linkable discovered URLs have no Event, so they stay on the direct job path.
+                ExtractContentJob::dispatch(
+                    $this->integration,
+                    null,
+                    $this->webpage,
+                    $this->extracted,
+                    $sourceObjectId,
+                    $sourceEventId,
+                    $sourceIsObject
+                );
+            }
 
-            Log::info('Fetch: Dispatched content extraction job', [
+            Log::info('Fetch: AI processing handoff complete', [
                 'event_id' => $event?->id,
                 'url' => $this->webpage->url,
                 'is_linkable' => $isLinkable,

--- a/app/Jobs/Data/Newsletter/ProcessNewsletterEmailJob.php
+++ b/app/Jobs/Data/Newsletter/ProcessNewsletterEmailJob.php
@@ -63,14 +63,6 @@ class ProcessNewsletterEmailJob implements ShouldQueue
             // Create newsletter event
             $event = $this->createNewsletterEvent($publication, $parsedEmail);
 
-            // Dispatch content extraction job
-            ExtractNewsletterContentJob::dispatch(
-                $this->integration,
-                $event,
-                $publication,
-                $parsedEmail['text_html'] ?: $parsedEmail['text_plain']
-            );
-
             Log::info('Newsletter: Successfully processed newsletter email', [
                 'integration_id' => $this->integration->id,
                 's3_object_key' => $this->s3ObjectKey,
@@ -302,6 +294,7 @@ class ProcessNewsletterEmailJob implements ShouldQueue
                 'email_received_at' => $receivedTime->toIso8601String(),
                 'email_message_id' => $parsedEmail['message_id'],
                 's3_object_key' => $this->s3ObjectKey,
+                'raw_html' => $parsedEmail['text_html'] ?: $parsedEmail['text_plain'],
             ],
         ];
 

--- a/app/Jobs/Data/Oyster/ProcessOysterEmailJob.php
+++ b/app/Jobs/Data/Oyster/ProcessOysterEmailJob.php
@@ -263,6 +263,11 @@ class ProcessOysterEmailJob implements ShouldQueue
                 $touchedInEvent->inheritLocationFromTarget();
             }
 
+            // Tag transport mode
+            if ($journey['transport_mode'] !== OysterTransportModeDetector::MODE_UNKNOWN) {
+                $touchedInEvent->attachTag($journey['transport_mode'], 'transport_mode');
+            }
+
             // Create touched_out event if there's a destination
             if (! empty($journey['destination'])) {
                 $destinationStation = $stationLookup->getOrCreateStationObject(
@@ -304,6 +309,11 @@ class ProcessOysterEmailJob implements ShouldQueue
                 // Inherit location from station
                 if ($destinationStation->location && ! $touchedOutEvent->location) {
                     $touchedOutEvent->inheritLocationFromTarget();
+                }
+
+                // Tag transport mode
+                if ($journey['transport_mode'] !== OysterTransportModeDetector::MODE_UNKNOWN) {
+                    $touchedOutEvent->attachTag($journey['transport_mode'], 'transport_mode');
                 }
             }
         }

--- a/app/Jobs/Metrics/CalculateMetricStatisticsJob.php
+++ b/app/Jobs/Metrics/CalculateMetricStatisticsJob.php
@@ -53,7 +53,8 @@ class CalculateMetricStatisticsJob implements ShouldQueue
                     $metricData->user_id,
                     $metricData->service,
                     $metricData->action,
-                    $metricData->value_unit
+                    $metricData->value_unit,
+                    $metricData->domain ?? 'health'
                 );
             }
 
@@ -84,12 +85,12 @@ class CalculateMetricStatisticsJob implements ShouldQueue
 
         return DB::table($eventsTable)
             ->join('integrations', $eventsTable . '.integration_id', '=', 'integrations.id')
-            ->select('integrations.user_id as user_id', $eventsTable . '.service', $eventsTable . '.action', $eventsTable . '.value_unit')
+            ->select('integrations.user_id as user_id', $eventsTable . '.service', $eventsTable . '.action', $eventsTable . '.value_unit', $eventsTable . '.domain')
             ->whereNull($eventsTable . '.deleted_at')
             ->whereNull('integrations.deleted_at')
             ->whereNotNull($eventsTable . '.value')
             ->whereNotNull($eventsTable . '.value_unit')
-            ->groupBy('integrations.user_id', $eventsTable . '.service', $eventsTable . '.action', $eventsTable . '.value_unit')
+            ->groupBy('integrations.user_id', $eventsTable . '.service', $eventsTable . '.action', $eventsTable . '.value_unit', $eventsTable . '.domain')
             ->having(DB::raw('COUNT(*)'), '>=', 10) // At least 10 events
             ->get()
             ->filter(function ($metricData) {
@@ -136,7 +137,7 @@ class CalculateMetricStatisticsJob implements ShouldQueue
      * JSON metadata columns), so `SELECT *` on a multi-million-row history
      * dominated database egress and wall-time.
      */
-    protected function calculateMetricStatistics(string $userId, string $service, string $action, string $valueUnit): void
+    protected function calculateMetricStatistics(string $userId, string $service, string $action, string $valueUnit, string $domain = 'health'): void
     {
         $eventsTable = (new Event)->getTable();
         $eventAlias = DB::getTablePrefix() . 'e';
@@ -151,6 +152,13 @@ class CalculateMetricStatisticsJob implements ShouldQueue
             END
         SQL;
 
+        $windowDays = MetricStatistic::DEFAULT_WINDOW_DAYS;
+
+        // Financial metrics legitimately record zero values (e.g. a spending category
+        // with no transactions on a given day). All other domains treat zero as "no
+        // reading" and exclude those events from baseline statistics.
+        $zeroFilter = ($domain !== 'money') ? "FILTER (WHERE {$eventAlias}.value <> 0)" : '';
+
         $row = DB::table($eventsTable . ' as e')
             ->join('integrations as i', 'e.integration_id', '=', 'i.id')
             ->where('i.user_id', $userId)
@@ -160,28 +168,34 @@ class CalculateMetricStatisticsJob implements ShouldQueue
             ->where('e.value_unit', $valueUnit)
             ->whereNotNull('e.value')
             ->whereNull('e.deleted_at')
+            ->where('e.time', '>=', now()->subDays($windowDays))
             ->selectRaw(<<<SQL
                 COUNT(*) AS total_count,
                 MIN({$eventAlias}.time) AS first_event_at,
                 MAX({$eventAlias}.time) AS last_event_at,
-                COUNT(*) FILTER (WHERE {$eventAlias}.value <> 0) AS formatted_count,
-                MIN({$formattedExpr}) FILTER (WHERE {$eventAlias}.value <> 0) AS min_value,
-                MAX({$formattedExpr}) FILTER (WHERE {$eventAlias}.value <> 0) AS max_value,
-                AVG({$formattedExpr}) FILTER (WHERE {$eventAlias}.value <> 0) AS mean_value,
-                STDDEV_POP({$formattedExpr}) FILTER (WHERE {$eventAlias}.value <> 0) AS stddev_value
+                COUNT(*) {$zeroFilter} AS formatted_count,
+                MIN({$formattedExpr}) {$zeroFilter} AS min_value,
+                MAX({$formattedExpr}) {$zeroFilter} AS max_value,
+                AVG({$formattedExpr}) {$zeroFilter} AS mean_value,
+                STDDEV_POP({$formattedExpr}) {$zeroFilter} AS stddev_value
             SQL)
             ->first();
 
         $totalCount = (int) ($row->total_count ?? 0);
 
+        $identifier = ['user_id' => $userId, 'service' => $service, 'action' => $action, 'value_unit' => $valueUnit];
+
         if ($totalCount < 10) {
-            Log::info('Insufficient events for metric', [
+            Log::info('Insufficient events for metric within window', [
                 'user_id' => $userId,
                 'service' => $service,
                 'action' => $action,
                 'value_unit' => $valueUnit,
                 'count' => $totalCount,
+                'window_days' => $windowDays,
             ]);
+
+            $this->clearMetricStatistics($identifier, $windowDays);
 
             return;
         }
@@ -196,13 +210,16 @@ class CalculateMetricStatisticsJob implements ShouldQueue
         $daysBetween = $firstEventAt->diffInDays($lastEventAt);
 
         if ($daysBetween < 30) {
-            Log::info('Insufficient time range for metric', [
+            Log::info('Insufficient time range for metric within window', [
                 'user_id' => $userId,
                 'service' => $service,
                 'action' => $action,
                 'value_unit' => $valueUnit,
                 'days' => $daysBetween,
+                'window_days' => $windowDays,
             ]);
+
+            $this->clearMetricStatistics($identifier, $windowDays);
 
             return;
         }
@@ -217,12 +234,7 @@ class CalculateMetricStatisticsJob implements ShouldQueue
         $stddev = (float) ($row->stddev_value ?? 0.0);
 
         MetricStatistic::updateOrCreate(
-            [
-                'user_id' => $userId,
-                'service' => $service,
-                'action' => $action,
-                'value_unit' => $valueUnit,
-            ],
+            $identifier,
             [
                 'event_count' => $formattedCount,
                 'first_event_at' => $firstEventAt,
@@ -233,6 +245,7 @@ class CalculateMetricStatisticsJob implements ShouldQueue
                 'stddev_value' => $stddev,
                 'normal_lower_bound' => $mean - (2 * $stddev),
                 'normal_upper_bound' => $mean + (2 * $stddev),
+                'baseline_window_days' => $windowDays,
                 'last_calculated_at' => now(),
             ]
         );
@@ -245,6 +258,29 @@ class CalculateMetricStatisticsJob implements ShouldQueue
             'count' => $formattedCount,
             'mean' => $mean,
             'stddev' => $stddev,
+            'window_days' => $windowDays,
+        ]);
+    }
+
+    /**
+     * Null out computed stats on an existing row so stale bounds are not used for anomaly detection.
+     *
+     * @param  array<string, string>  $identifier
+     */
+    protected function clearMetricStatistics(array $identifier, int $windowDays): void
+    {
+        MetricStatistic::where($identifier)->update([
+            'event_count' => 0,
+            'first_event_at' => null,
+            'last_event_at' => null,
+            'min_value' => null,
+            'max_value' => null,
+            'mean_value' => null,
+            'stddev_value' => null,
+            'normal_lower_bound' => null,
+            'normal_upper_bound' => null,
+            'baseline_window_days' => $windowDays,
+            'last_calculated_at' => now(),
         ]);
     }
 

--- a/app/Jobs/Metrics/DetectMetricAnomaliesJob.php
+++ b/app/Jobs/Metrics/DetectMetricAnomaliesJob.php
@@ -84,6 +84,12 @@ class DetectMetricAnomaliesJob implements ShouldQueue
         // Determine anomaly type
         $type = $isAnomalyHigh ? 'anomaly_high' : 'anomaly_low';
 
+        // Skip if the user has actively suppressed this direction
+        $suppressionColumn = $type === 'anomaly_high' ? 'anomaly_high_suppressed_until' : 'anomaly_low_suppressed_until';
+        if ($metricStatistic->{$suppressionColumn} && now()->isBefore($metricStatistic->{$suppressionColumn})) {
+            return;
+        }
+
         // Check if we've already recorded this anomaly
         $existingAnomaly = MetricTrend::where('metric_statistic_id', $metricStatistic->id)
             ->where('type', $type)
@@ -108,7 +114,7 @@ class DetectMetricAnomaliesJob implements ShouldQueue
             'baseline_value' => $metricStatistic->mean_value,
             'current_value' => $value,
             'deviation' => $deviation,
-            'significance_score' => min($deviation / 2, 1.0), // Normalize to 0-1 scale
+            'significance_score' => tanh($deviation / 2),
             'metadata' => [
                 'event_id' => $this->event->id,
                 'normal_lower_bound' => $metricStatistic->normal_lower_bound,

--- a/app/Jobs/Metrics/DetectMetricTrendsJob.php
+++ b/app/Jobs/Metrics/DetectMetricTrendsJob.php
@@ -231,6 +231,10 @@ class DetectMetricTrendsJob implements ShouldQueue
                         ],
                     ]);
 
+                    if ($metric->baseline_reset_suggested_at === null) {
+                        $metric->update(['baseline_reset_suggested_at' => now()]);
+                    }
+
                     Log::info('Detected monthly trend', [
                         'metric_id' => $metric->id,
                         'type' => $type,
@@ -310,6 +314,10 @@ class DetectMetricTrendsJob implements ShouldQueue
                             'comparison_end' => $comparisonEnd->toDateString(),
                         ],
                     ]);
+
+                    if ($metric->baseline_reset_suggested_at === null) {
+                        $metric->update(['baseline_reset_suggested_at' => now()]);
+                    }
 
                     Log::info('Detected quarterly trend', [
                         'metric_id' => $metric->id,

--- a/app/Jobs/RunIntegrationTask.php
+++ b/app/Jobs/RunIntegrationTask.php
@@ -47,10 +47,11 @@ class RunIntegrationTask implements ShouldQueue
                     throw new Exception('Invalid task_job_class');
                 }
 
-                // Optional whitelist enforcement for job classes
+                // Whitelist is always enforced. To add a new job class, update
+                // app.allowed_task_jobs in config/app.php (or ALLOWED_TASK_JOBS env var).
                 $allowedJobs = config('app.allowed_task_jobs');
-                if (is_array($allowedJobs) && ! in_array($jobClass, $allowedJobs, true)) {
-                    throw new Exception('Job class not allowed');
+                if (! in_array($jobClass, $allowedJobs, true)) {
+                    throw new Exception("Job class not in allowed_task_jobs whitelist: {$jobClass}");
                 }
 
                 $jobInstance = null;

--- a/app/Jobs/TaskPipeline/BaseTaskJob.php
+++ b/app/Jobs/TaskPipeline/BaseTaskJob.php
@@ -4,6 +4,7 @@ namespace App\Jobs\TaskPipeline;
 
 use App\Jobs\TaskPipeline\Concerns\InteractsWithTaskMetadata;
 use App\Services\TaskPipeline\TaskDefinition;
+use App\Services\TaskPipeline\TaskRegistry;
 use Exception;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -33,11 +34,33 @@ abstract class BaseTaskJob implements ShouldQueue
      */
     public function handle(): void
     {
+        $this->model->refresh();
+
+        if ($failedDependency = $this->firstFailedDependency($this->model, $this->task)) {
+            $this->updateStatus('blocked', [
+                'blocked_by' => $failedDependency,
+                'completed_at' => now()->toIso8601String(),
+            ]);
+
+            return;
+        }
+
+        if ($incompleteDependency = $this->firstIncompleteDependency($this->model, $this->task)) {
+            $this->updateStatus('waiting', [
+                'waiting_for' => $incompleteDependency,
+            ]);
+
+            $this->release(30);
+
+            return;
+        }
+
         $this->updateStatus('running');
 
         try {
             $this->execute();
             $this->updateStatus('success', ['completed_at' => now()->toIso8601String()]);
+            $this->dispatchDependentTasks();
 
         } catch (Exception $e) {
             // Report to Sentry with comprehensive context
@@ -101,6 +124,21 @@ abstract class BaseTaskJob implements ShouldQueue
         }
 
         $this->setTaskExecutions($this->model, $executions);
+    }
+
+    protected function dispatchDependentTasks(): void
+    {
+        $dependentTaskKeys = TaskRegistry::getDependentTaskKeys($this->task->key);
+
+        if ($dependentTaskKeys === []) {
+            return;
+        }
+
+        ProcessTaskPipelineJob::dispatch(
+            model: $this->model->fresh(),
+            trigger: 'manual',
+            taskFilter: $dependentTaskKeys,
+        )->onQueue('tasks');
     }
 
     /**

--- a/app/Jobs/TaskPipeline/BaseTaskJob.php
+++ b/app/Jobs/TaskPipeline/BaseTaskJob.php
@@ -4,6 +4,7 @@ namespace App\Jobs\TaskPipeline;
 
 use App\Jobs\TaskPipeline\Concerns\InteractsWithTaskMetadata;
 use App\Services\TaskPipeline\TaskDefinition;
+use App\Services\TaskPipeline\TaskExecutionStore;
 use App\Services\TaskPipeline\TaskRegistry;
 use Exception;
 use Illuminate\Bus\Queueable;
@@ -106,24 +107,13 @@ abstract class BaseTaskJob implements ShouldQueue
      */
     protected function updateStatus(string $status, array $additionalData = []): void
     {
-        $executions = $this->getTaskExecutions($this->model);
-
-        $executionData = array_merge([
-            'status' => $status,
-        ], $additionalData);
-
-        // Update last_attempt
-        $executions[$this->task->key]['last_attempt'] = array_merge(
-            $executions[$this->task->key]['last_attempt'] ?? [],
-            $executionData
+        app(TaskExecutionStore::class)->recordStatus(
+            model: $this->model,
+            task: $this->task,
+            status: $status,
+            data: $additionalData,
+            jobContext: $this,
         );
-
-        // Update last_success if applicable
-        if ($status === 'success') {
-            $executions[$this->task->key]['last_success'] = $executionData;
-        }
-
-        $this->setTaskExecutions($this->model, $executions);
     }
 
     protected function dispatchDependentTasks(): void

--- a/app/Jobs/TaskPipeline/Concerns/InteractsWithTaskMetadata.php
+++ b/app/Jobs/TaskPipeline/Concerns/InteractsWithTaskMetadata.php
@@ -2,8 +2,8 @@
 
 namespace App\Jobs\TaskPipeline\Concerns;
 
-use App\Models\Event;
 use App\Services\TaskPipeline\TaskDefinition;
+use App\Services\TaskPipeline\TaskExecutionStore;
 use App\Services\TaskPipeline\TaskRegistry;
 use Illuminate\Database\Eloquent\Model;
 
@@ -14,7 +14,7 @@ trait InteractsWithTaskMetadata
      */
     protected function getMetadataField(Model $model): string
     {
-        return $model instanceof Event ? 'event_metadata' : 'metadata';
+        return app(TaskExecutionStore::class)->metadataField($model);
     }
 
     /**
@@ -22,10 +22,7 @@ trait InteractsWithTaskMetadata
      */
     protected function getTaskExecutions(Model $model): array
     {
-        $field = $this->getMetadataField($model);
-        $metadata = $model->$field ?? [];
-
-        return $metadata['task_executions'] ?? [];
+        return app(TaskExecutionStore::class)->getTaskExecutions($model);
     }
 
     /**
@@ -33,13 +30,7 @@ trait InteractsWithTaskMetadata
      */
     protected function setTaskExecutions(Model $model, array $executions): void
     {
-        $field = $this->getMetadataField($model);
-        $metadata = $model->$field ?? [];
-        $metadata['task_executions'] = $executions;
-
-        $model->withoutEvents(function () use ($model, $field, $metadata) {
-            $model->update([$field => $metadata]);
-        });
+        app(TaskExecutionStore::class)->setTaskExecutions($model, $executions);
     }
 
     protected function taskSucceeded(Model $model, string $taskKey): bool

--- a/app/Jobs/TaskPipeline/Concerns/InteractsWithTaskMetadata.php
+++ b/app/Jobs/TaskPipeline/Concerns/InteractsWithTaskMetadata.php
@@ -3,6 +3,8 @@
 namespace App\Jobs\TaskPipeline\Concerns;
 
 use App\Models\Event;
+use App\Services\TaskPipeline\TaskDefinition;
+use App\Services\TaskPipeline\TaskRegistry;
 use Illuminate\Database\Eloquent\Model;
 
 trait InteractsWithTaskMetadata
@@ -38,5 +40,58 @@ trait InteractsWithTaskMetadata
         $model->withoutEvents(function () use ($model, $field, $metadata) {
             $model->update([$field => $metadata]);
         });
+    }
+
+    protected function taskSucceeded(Model $model, string $taskKey): bool
+    {
+        return $this->taskStatus($model, $taskKey) === 'success';
+    }
+
+    protected function taskFailed(Model $model, string $taskKey): bool
+    {
+        return in_array($this->taskStatus($model, $taskKey), ['failed', 'blocked'], true);
+    }
+
+    protected function taskStatus(Model $model, string $taskKey): ?string
+    {
+        $executions = $this->getTaskExecutions($model);
+
+        return $executions[$taskKey]['last_attempt']['status'] ?? null;
+    }
+
+    protected function firstFailedDependency(Model $model, TaskDefinition $task): ?string
+    {
+        foreach ($this->applicableDependencies($model, $task) as $dependencyKey) {
+            if ($this->taskFailed($model, $dependencyKey)) {
+                return $dependencyKey;
+            }
+        }
+
+        return null;
+    }
+
+    protected function firstIncompleteDependency(Model $model, TaskDefinition $task): ?string
+    {
+        foreach ($this->applicableDependencies($model, $task) as $dependencyKey) {
+            if (! $this->taskSucceeded($model, $dependencyKey)) {
+                return $dependencyKey;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Dependencies that do not apply to this model cannot complete for it, so they
+     * are ignored for runtime gating.
+     *
+     * @return array<int, string>
+     */
+    protected function applicableDependencies(Model $model, TaskDefinition $task): array
+    {
+        return array_values(array_filter(
+            $task->dependencies,
+            fn (string $dependencyKey) => TaskRegistry::getTask($dependencyKey)?->isApplicableTo($model) ?? false,
+        ));
     }
 }

--- a/app/Jobs/TaskPipeline/DispatchRetrospectiveAnomalyTasksJob.php
+++ b/app/Jobs/TaskPipeline/DispatchRetrospectiveAnomalyTasksJob.php
@@ -43,7 +43,7 @@ class DispatchRetrospectiveAnomalyTasksJob implements ShouldQueue
             ->chunk(100, function ($events) use (&$count) {
                 foreach ($events as $event) {
                     // Check if anomaly detection has already been run successfully
-                    $executions = $event->metadata['task_executions'] ?? [];
+                    $executions = $event->event_metadata['task_executions'] ?? [];
                     $lastAttempt = $executions['detect_anomalies']['last_attempt'] ?? null;
 
                     // Skip if already successfully detected

--- a/app/Jobs/TaskPipeline/DispatchRetrospectiveAnomalyTasksJob.php
+++ b/app/Jobs/TaskPipeline/DispatchRetrospectiveAnomalyTasksJob.php
@@ -3,6 +3,7 @@
 namespace App\Jobs\TaskPipeline;
 
 use App\Models\Event;
+use App\Services\TaskPipeline\TaskExecutionStore;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Bus\Dispatchable;
@@ -28,6 +29,7 @@ class DispatchRetrospectiveAnomalyTasksJob implements ShouldQueue
         Log::info('Starting scheduled retrospective anomaly detection');
 
         $count = 0;
+        $store = app(TaskExecutionStore::class);
 
         // Find all events with metrics from yesterday
         // This allows retrospective detection for:
@@ -40,10 +42,10 @@ class DispatchRetrospectiveAnomalyTasksJob implements ShouldQueue
                 now()->subDay()->startOfDay(),
                 now()->subDay()->endOfDay(),
             ])
-            ->chunk(100, function ($events) use (&$count) {
+            ->chunk(100, function ($events) use (&$count, $store) {
                 foreach ($events as $event) {
                     // Check if anomaly detection has already been run successfully
-                    $executions = $event->event_metadata['task_executions'] ?? [];
+                    $executions = $store->getTaskExecutions($event);
                     $lastAttempt = $executions['detect_anomalies']['last_attempt'] ?? null;
 
                     // Skip if already successfully detected

--- a/app/Jobs/TaskPipeline/MigrateTaskExecutionsBatchJob.php
+++ b/app/Jobs/TaskPipeline/MigrateTaskExecutionsBatchJob.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace App\Jobs\TaskPipeline;
+
+use App\Models\Block;
+use App\Models\Event;
+use App\Models\EventObject;
+use App\Models\Integration;
+use App\Models\TaskExecution;
+use App\Services\TaskPipeline\TaskExecutionStore;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use InvalidArgumentException;
+
+class MigrateTaskExecutionsBatchJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $timeout = 300;
+
+    public int $tries = 3;
+
+    public function __construct(
+        public string $modelType,
+        public ?string $cursor,
+        public int $batchSize = 500,
+        public ?int $limit = null,
+        public bool $force = false,
+        public array $stats = ['scanned' => 0, 'migrated' => 0, 'skipped' => 0, 'missing_owner' => 0, 'invalid_metadata' => 0],
+    ) {
+        $this->onConnection('redis');
+        $this->onQueue('migration');
+    }
+
+    public function handle(TaskExecutionStore $store): void
+    {
+        $modelClass = $this->modelClass();
+        $remaining = $this->limit ? max(0, $this->limit - $this->stats['scanned']) : $this->batchSize;
+
+        if ($remaining === 0) {
+            $this->logProgress(done: true);
+
+            return;
+        }
+
+        $take = min($this->batchSize, $remaining);
+        $query = $modelClass::query()->orderBy('id')->limit($take);
+
+        if ($this->cursor) {
+            $query->where('id', '>', $this->cursor);
+        }
+
+        $models = $query->get();
+
+        foreach ($models as $model) {
+            $this->stats['scanned']++;
+            $this->processModel($store, $model);
+        }
+
+        $this->cursor = $models->last()?->getKey();
+        $this->logProgress(done: $models->count() < $take);
+
+        if ($models->count() === $take && (! $this->limit || $this->stats['scanned'] < $this->limit)) {
+            static::dispatch(
+                modelType: $this->modelType,
+                cursor: $this->cursor,
+                batchSize: $this->batchSize,
+                limit: $this->limit,
+                force: $this->force,
+                stats: $this->stats,
+            )->onConnection('redis')->onQueue('migration');
+        }
+    }
+
+    protected function processModel(TaskExecutionStore $store, Model $model): void
+    {
+        $legacy = $store->getLegacyTaskExecutions($model);
+
+        if ($legacy === []) {
+            $this->stats['skipped']++;
+
+            return;
+        }
+
+        if (! is_array($legacy)) {
+            $this->stats['invalid_metadata']++;
+
+            return;
+        }
+
+        if (! $store->resolveUserId($model)) {
+            $this->stats['missing_owner']++;
+
+            return;
+        }
+
+        foreach ($legacy as $taskKey => $execution) {
+            if (! is_string($taskKey) || ! is_array($execution)) {
+                $this->stats['invalid_metadata']++;
+
+                continue;
+            }
+
+            if (! $this->force && TaskExecution::query()
+                ->forEntity($this->modelType, (string) $model->getKey())
+                ->where('task_key', $taskKey)
+                ->exists()) {
+                $this->stats['skipped']++;
+
+                continue;
+            }
+
+            if ($store->upsertFromLegacy($model, $taskKey, $execution, $this->force) !== null) {
+                $this->stats['migrated']++;
+            }
+        }
+    }
+
+    protected function logProgress(bool $done): void
+    {
+        Log::info('Task execution migration batch ' . ($done ? 'completed' : 'progress'), [
+            'model_type' => $this->modelType,
+            'cursor' => $this->cursor,
+            'batch_size' => $this->batchSize,
+            'limit' => $this->limit,
+            'force' => $this->force,
+            'stats' => $this->stats,
+        ]);
+    }
+
+    /**
+     * @return class-string<Model>
+     */
+    protected function modelClass(): string
+    {
+        return match ($this->modelType) {
+            'event' => Event::class,
+            'block' => Block::class,
+            'object' => EventObject::class,
+            'integration' => Integration::class,
+            default => throw new InvalidArgumentException("Unsupported model type [{$this->modelType}]"),
+        };
+    }
+}

--- a/app/Jobs/TaskPipeline/ProcessIncompleteBatchJob.php
+++ b/app/Jobs/TaskPipeline/ProcessIncompleteBatchJob.php
@@ -47,7 +47,6 @@ class ProcessIncompleteBatchJob implements ShouldQueue
             $this->stats = [
                 'processed' => 0,
                 'examined' => 0,
-                'prefilled' => 0,
                 'failed' => 0,
             ];
         }
@@ -118,14 +117,6 @@ class ProcessIncompleteBatchJob implements ShouldQueue
             return;
         }
 
-        // Pre-fill embedding tasks where applicable
-        $prefilled = 0;
-        foreach ($incompleteModels as $model) {
-            if ($this->preFillEmbeddingTask($model)) {
-                $prefilled++;
-            }
-        }
-
         // Create batch of ProcessTaskPipelineJob for each model
         $jobs = [];
         foreach ($incompleteModels as $model) {
@@ -140,7 +131,6 @@ class ProcessIncompleteBatchJob implements ShouldQueue
         // Update stats
         $this->stats['processed'] += $incompleteModels->count();
         $this->stats['examined'] += $examined;
-        $this->stats['prefilled'] += $prefilled;
 
         // Update progress
         $this->updateProgress();
@@ -201,7 +191,6 @@ class ProcessIncompleteBatchJob implements ShouldQueue
                                 $progress->markCompleted([
                                     'total_processed' => $stats['processed'],
                                     'total_examined' => $stats['examined'],
-                                    'total_prefilled' => $stats['prefilled'],
                                     'total_failed' => $stats['failed'],
                                 ]);
                             }
@@ -326,79 +315,13 @@ class ProcessIncompleteBatchJob implements ShouldQueue
         $executions = $this->getTaskExecutions($model);
 
         foreach ($applicableTasks as $task) {
-            // Special case: embedding with metadata
-            if ($task->key === 'generate_embedding') {
-                if ($this->hasCompletedEmbedding($model)) {
-                    continue;
-                }
-            }
-
-            // Check execution status
             $lastAttempt = $executions[$task->key]['last_attempt'] ?? null;
             if (! $lastAttempt || $lastAttempt['status'] !== 'success') {
-                return true; // Found incomplete task
+                return true;
             }
         }
 
         return false;
-    }
-
-    /**
-     * Check if model has completed embedding
-     */
-    protected function hasCompletedEmbedding(Model $model): bool
-    {
-        $metadataField = $this->getMetadataField($model);
-        $metadata = $model->$metadataField ?? [];
-
-        return isset($metadata['embedding_generated_at']) && ! empty($model->embeddings);
-    }
-
-    /**
-     * Pre-fill embedding task execution record if completed
-     */
-    protected function preFillEmbeddingTask(Model $model): bool
-    {
-        // Check if embedding is complete but not tracked
-        $metadataField = $this->getMetadataField($model);
-        $metadata = $model->$metadataField ?? [];
-
-        if (! isset($metadata['embedding_generated_at']) || empty($model->embeddings)) {
-            return false; // Not complete
-        }
-
-        // Check if already tracked
-        $executions = $this->getTaskExecutions($model);
-        if (isset($executions['generate_embedding']['last_success'])) {
-            return false; // Already tracked
-        }
-
-        // Pre-fill execution record
-        $executions['generate_embedding'] = [
-            'last_attempt' => [
-                'started_at' => $metadata['embedding_generated_at'],
-                'completed_at' => $metadata['embedding_generated_at'],
-                'status' => 'success',
-                'attempts' => 1,
-                'triggered_by' => 'backfill',
-            ],
-            'last_success' => [
-                'started_at' => $metadata['embedding_generated_at'],
-                'completed_at' => $metadata['embedding_generated_at'],
-                'status' => 'success',
-                'attempts' => 1,
-                'triggered_by' => 'backfill',
-            ],
-        ];
-
-        $this->setTaskExecutions($model, $executions);
-
-        Log::info('Pre-filled embedding task execution', [
-            'model_type' => get_class($model),
-            'model_id' => $model->id,
-        ]);
-
-        return true; // Pre-filled
     }
 
     /**
@@ -426,7 +349,6 @@ class ProcessIncompleteBatchJob implements ShouldQueue
                 'model_type' => $modelName,
                 'processed' => $this->stats['processed'],
                 'examined' => $this->stats['examined'],
-                'prefilled' => $this->stats['prefilled'],
                 'failed' => $this->stats['failed'],
             ]
         );
@@ -453,7 +375,6 @@ class ProcessIncompleteBatchJob implements ShouldQueue
         $progress->markCompleted([
             'total_processed' => $this->stats['processed'],
             'total_examined' => $this->stats['examined'],
-            'total_prefilled' => $this->stats['prefilled'],
             'total_failed' => $this->stats['failed'],
         ]);
     }

--- a/app/Jobs/TaskPipeline/ProcessTaskPipelineJob.php
+++ b/app/Jobs/TaskPipeline/ProcessTaskPipelineJob.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Bus\Dispatchable;
 use Illuminate\Queue\InteractsWithQueue;
 use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Collection;
 
 class ProcessTaskPipelineJob implements ShouldQueue
 {
@@ -31,11 +32,12 @@ class ProcessTaskPipelineJob implements ShouldQueue
 
     public function handle(): void
     {
-        $tasks = TaskRegistry::getTasksForModel($this->model, $this->trigger);
+        $applicableTasks = TaskRegistry::getTasksForModel($this->model, $this->trigger);
+        $tasks = $applicableTasks;
 
         // Apply task filter if provided
         if ($this->taskFilter) {
-            $tasks = $tasks->whereIn('key', $this->taskFilter);
+            $tasks = $this->expandTaskFilterWithDependencies($applicableTasks, $this->taskFilter);
         }
 
         // Filter out already-executed tasks (unless force)
@@ -70,9 +72,23 @@ class ProcessTaskPipelineJob implements ShouldQueue
      */
     protected function dispatchTask(TaskDefinition $task): void
     {
+        $this->model->refresh();
+
         // Check if applicable
         if (! $task->isApplicableTo($this->model)) {
             $this->markNotApplicable($task);
+
+            return;
+        }
+
+        if ($failedDependency = $this->firstFailedDependency($this->model, $task)) {
+            $this->markBlocked($task, $failedDependency);
+
+            return;
+        }
+
+        if ($incompleteDependency = $this->firstIncompleteDependency($this->model, $task)) {
+            $this->markWaiting($task, $incompleteDependency);
 
             return;
         }
@@ -115,5 +131,50 @@ class ProcessTaskPipelineJob implements ShouldQueue
             'completed_at' => now()->toIso8601String(),
             'triggered_by' => $this->trigger,
         ]);
+    }
+
+    protected function markWaiting(TaskDefinition $task, string $dependencyKey): void
+    {
+        $this->updateTaskStatus($task, 'waiting', [
+            'waiting_for' => $dependencyKey,
+            'triggered_by' => $this->trigger,
+            ...($this->changedFields ? ['changed_fields' => $this->changedFields] : []),
+        ]);
+    }
+
+    protected function markBlocked(TaskDefinition $task, string $dependencyKey): void
+    {
+        $this->updateTaskStatus($task, 'blocked', [
+            'blocked_by' => $dependencyKey,
+            'completed_at' => now()->toIso8601String(),
+            'triggered_by' => $this->trigger,
+            ...($this->changedFields ? ['changed_fields' => $this->changedFields] : []),
+        ]);
+    }
+
+    protected function expandTaskFilterWithDependencies(Collection $applicableTasks, array $taskFilter): Collection
+    {
+        $tasksByKey = $applicableTasks->keyBy('key');
+        $selected = collect();
+        $pendingKeys = $taskFilter;
+
+        while ($pendingKeys !== []) {
+            $taskKey = array_shift($pendingKeys);
+            $task = $tasksByKey->get($taskKey);
+
+            if (! $task || $selected->has($taskKey)) {
+                continue;
+            }
+
+            $selected->put($taskKey, $task);
+
+            foreach ($task->dependencies as $dependencyKey) {
+                if ($tasksByKey->has($dependencyKey) && ! $selected->has($dependencyKey)) {
+                    $pendingKeys[] = $dependencyKey;
+                }
+            }
+        }
+
+        return $selected->sortByDesc('priority')->values();
     }
 }

--- a/app/Jobs/TaskPipeline/ProcessTaskPipelineJob.php
+++ b/app/Jobs/TaskPipeline/ProcessTaskPipelineJob.php
@@ -4,6 +4,7 @@ namespace App\Jobs\TaskPipeline;
 
 use App\Jobs\TaskPipeline\Concerns\InteractsWithTaskMetadata;
 use App\Services\TaskPipeline\TaskDefinition;
+use App\Services\TaskPipeline\TaskExecutionStore;
 use App\Services\TaskPipeline\TaskRegistry;
 use Illuminate\Bus\Batchable;
 use Illuminate\Bus\Queueable;
@@ -112,13 +113,14 @@ class ProcessTaskPipelineJob implements ShouldQueue
      */
     protected function updateTaskStatus(TaskDefinition $task, string $status, array $data): void
     {
-        $executions = $this->getTaskExecutions($this->model);
-
-        $executions[$task->key]['last_attempt'] = array_merge($data, [
-            'status' => $status,
-        ]);
-
-        $this->setTaskExecutions($this->model, $executions);
+        app(TaskExecutionStore::class)->recordStatus(
+            model: $this->model,
+            task: $task,
+            status: $status,
+            data: $data,
+            jobContext: $this,
+            mergeLastAttempt: false,
+        );
     }
 
     /**

--- a/app/Jobs/TaskPipeline/ProcessTaskPipelineJob.php
+++ b/app/Jobs/TaskPipeline/ProcessTaskPipelineJob.php
@@ -2,9 +2,7 @@
 
 namespace App\Jobs\TaskPipeline;
 
-use App\Jobs\Base\BaseEffectJob;
 use App\Jobs\TaskPipeline\Concerns\InteractsWithTaskMetadata;
-use App\Models\Integration;
 use App\Services\TaskPipeline\TaskDefinition;
 use App\Services\TaskPipeline\TaskRegistry;
 use Illuminate\Bus\Batchable;
@@ -87,35 +85,8 @@ class ProcessTaskPipelineJob implements ShouldQueue
         // Dispatch to appropriate queue
         $jobClass = $task->jobClass;
 
-        // Check if job extends BaseEffectJob - they expect (Integration, array) instead of (Model, TaskDefinition)
-        if (is_subclass_of($jobClass, BaseEffectJob::class)) {
-            // Extract integration from the model
-            $integration = $this->model instanceof Integration
-                ? $this->model
-                : $this->model->integration;
-
-            if (! $integration) {
-                $this->updateTaskStatus($task, 'failed', [
-                    'error' => 'No integration found for effect job',
-                    'completed_at' => now()->toIso8601String(),
-                ]);
-
-                return;
-            }
-
-            // Prepare parameters from task metadata
-            $parameters = [
-                'task_key' => $task->key,
-                'triggered_by' => $this->trigger,
-                'model_type' => class_basename($this->model),
-                'model_id' => $this->model->id,
-            ];
-
-            dispatch(new $jobClass($integration, $parameters))->onQueue($task->queue);
-        } else {
-            // Standard task jobs expect (Model, TaskDefinition)
-            dispatch(new $jobClass($this->model, $task))->onQueue($task->queue);
-        }
+        // Standard task jobs expect (Model, TaskDefinition)
+        dispatch(new $jobClass($this->model, $task))->onQueue($task->queue);
     }
 
     /**

--- a/app/Jobs/TaskPipeline/ProcessTaskPipelineJob.php
+++ b/app/Jobs/TaskPipeline/ProcessTaskPipelineJob.php
@@ -26,6 +26,7 @@ class ProcessTaskPipelineJob implements ShouldQueue
         public string $trigger = 'created',
         public ?array $taskFilter = null,  // Only run specific tasks
         public bool $force = false,        // Re-run even if already executed
+        public array $changedFields = [],  // Fields that triggered an update run
     ) {}
 
     public function handle(): void
@@ -80,6 +81,7 @@ class ProcessTaskPipelineJob implements ShouldQueue
         $this->updateTaskStatus($task, 'pending', [
             'started_at' => now()->toIso8601String(),
             'triggered_by' => $this->trigger,
+            ...($this->changedFields ? ['changed_fields' => $this->changedFields] : []),
         ]);
 
         // Dispatch to appropriate queue

--- a/app/Jobs/TaskPipeline/Tasks/CalculateMetricStatsTask.php
+++ b/app/Jobs/TaskPipeline/Tasks/CalculateMetricStatsTask.php
@@ -44,7 +44,10 @@ class CalculateMetricStatsTask extends BaseTaskJob
             return;
         }
 
-        // Get all events for this metric via integration relationship
+        $domain = $this->model->domain;
+        $windowDays = MetricStatistic::DEFAULT_WINDOW_DAYS;
+
+        // Get events within the rolling window for this metric via integration relationship
         $events = Event::whereHas('integration', function ($query) use ($userId) {
             $query->where('user_id', $userId);
         })
@@ -53,40 +56,54 @@ class CalculateMetricStatsTask extends BaseTaskJob
             ->where('value_unit', $valueUnit)
             ->whereNotNull('value')
             ->whereNull('deleted_at')
+            ->where('time', '>=', now()->subDays($windowDays))
             ->orderBy('time')
             ->get();
 
+        $identifier = ['user_id' => $userId, 'service' => $service, 'action' => $action, 'value_unit' => $valueUnit];
+
         if ($events->count() < 10) {
-            Log::debug('Insufficient events for metric statistics', [
+            Log::debug('Insufficient events for metric statistics within window', [
                 'user_id' => $userId,
                 'service' => $service,
                 'action' => $action,
                 'value_unit' => $valueUnit,
                 'count' => $events->count(),
+                'window_days' => $windowDays,
             ]);
+
+            $this->clearMetricStatistics($identifier, $windowDays);
 
             return;
         }
 
-        // Check if we have at least 30 days of data
+        // Check if we have at least 30 days of data within the window
         $firstEvent = $events->first();
         $lastEvent = $events->last();
         $daysBetween = $firstEvent->time->diffInDays($lastEvent->time);
 
         if ($daysBetween < 30) {
-            Log::debug('Insufficient time range for metric statistics', [
+            Log::debug('Insufficient time range for metric statistics within window', [
                 'user_id' => $userId,
                 'service' => $service,
                 'action' => $action,
                 'value_unit' => $valueUnit,
                 'days' => $daysBetween,
+                'window_days' => $windowDays,
             ]);
+
+            $this->clearMetricStatistics($identifier, $windowDays);
 
             return;
         }
 
-        // Calculate statistics using formatted values
-        $values = $events->map(fn ($event) => $event->getFormattedValueAttribute())->filter()->values();
+        // Financial metrics legitimately record zero values (e.g. spending category
+        // with no transactions on a given day). All other domains treat zero as "no
+        // reading" and exclude those events from baseline statistics.
+        $includeZeros = $domain === 'money';
+        $values = $events->map(fn ($event) => $event->getFormattedValueAttribute())
+            ->filter(fn ($v) => $v !== null && ($includeZeros || $v != 0))
+            ->values();
 
         if ($values->isEmpty()) {
             return;
@@ -98,12 +115,7 @@ class CalculateMetricStatsTask extends BaseTaskJob
 
         // Create or update metric statistic
         MetricStatistic::updateOrCreate(
-            [
-                'user_id' => $userId,
-                'service' => $service,
-                'action' => $action,
-                'value_unit' => $valueUnit,
-            ],
+            $identifier,
             [
                 'event_count' => $values->count(),
                 'first_event_at' => $firstEvent->time,
@@ -114,6 +126,7 @@ class CalculateMetricStatsTask extends BaseTaskJob
                 'stddev_value' => $stddev,
                 'normal_lower_bound' => $mean - (2 * $stddev),
                 'normal_upper_bound' => $mean + (2 * $stddev),
+                'baseline_window_days' => $windowDays,
                 'last_calculated_at' => now(),
             ]
         );
@@ -126,6 +139,29 @@ class CalculateMetricStatsTask extends BaseTaskJob
             'count' => $values->count(),
             'mean' => $mean,
             'stddev' => $stddev,
+            'window_days' => $windowDays,
+        ]);
+    }
+
+    /**
+     * Null out computed stats on an existing row so stale bounds are not used for anomaly detection.
+     *
+     * @param  array<string, string>  $identifier
+     */
+    protected function clearMetricStatistics(array $identifier, int $windowDays): void
+    {
+        MetricStatistic::where($identifier)->update([
+            'event_count' => 0,
+            'first_event_at' => null,
+            'last_event_at' => null,
+            'min_value' => null,
+            'max_value' => null,
+            'mean_value' => null,
+            'stddev_value' => null,
+            'normal_lower_bound' => null,
+            'normal_upper_bound' => null,
+            'baseline_window_days' => $windowDays,
+            'last_calculated_at' => now(),
         ]);
     }
 

--- a/app/Jobs/TaskPipeline/Tasks/DetectAnomaliesTask.php
+++ b/app/Jobs/TaskPipeline/Tasks/DetectAnomaliesTask.php
@@ -61,6 +61,12 @@ class DetectAnomaliesTask extends BaseTaskJob
         // Determine anomaly type
         $type = $isAnomalyHigh ? 'anomaly_high' : 'anomaly_low';
 
+        // Skip if the user has actively suppressed this direction
+        $suppressionColumn = $type === 'anomaly_high' ? 'anomaly_high_suppressed_until' : 'anomaly_low_suppressed_until';
+        if ($metricStatistic->{$suppressionColumn} && now()->isBefore($metricStatistic->{$suppressionColumn})) {
+            return;
+        }
+
         // Check if we've already recorded this anomaly
         $existingAnomaly = MetricTrend::where('metric_statistic_id', $metricStatistic->id)
             ->where('type', $type)
@@ -85,7 +91,7 @@ class DetectAnomaliesTask extends BaseTaskJob
             'baseline_value' => $metricStatistic->mean_value,
             'current_value' => $value,
             'deviation' => $deviation,
-            'significance_score' => min($deviation / 2, 1.0), // Normalize to 0-1 scale
+            'significance_score' => tanh($deviation / 2),
             'metadata' => [
                 'event_id' => $this->model->id,
                 'normal_lower_bound' => $metricStatistic->normal_lower_bound,

--- a/app/Jobs/TaskPipeline/Tasks/DetectTrendsTask.php
+++ b/app/Jobs/TaskPipeline/Tasks/DetectTrendsTask.php
@@ -101,7 +101,7 @@ class DetectTrendsTask extends BaseTaskJob
                     'comparison_months' => $months,
                     'comparison_start' => $comparisonStart->toDateString(),
                     'comparison_end' => $comparisonEnd->toDateString(),
-                ]);
+                ], suggestBaselineReview: true);
                 break;
             }
         }
@@ -134,7 +134,7 @@ class DetectTrendsTask extends BaseTaskJob
                     'comparison_quarters' => $quarters,
                     'comparison_start' => $comparisonStart->toDateString(),
                     'comparison_end' => $comparisonEnd->toDateString(),
-                ]);
+                ], suggestBaselineReview: true);
                 break;
             }
         }
@@ -149,6 +149,7 @@ class DetectTrendsTask extends BaseTaskJob
         float $currentValue,
         float $deviation,
         array $metadata,
+        bool $suggestBaselineReview = false,
     ): void {
         $existing = MetricTrend::where('metric_statistic_id', $metric->id)
             ->where('type', $type)
@@ -172,6 +173,10 @@ class DetectTrendsTask extends BaseTaskJob
             'significance_score' => min($deviation / self::CHANGE_THRESHOLD, 1.0),
             'metadata' => $metadata,
         ]);
+
+        if ($suggestBaselineReview && $metric->baseline_reset_suggested_at === null) {
+            $metric->update(['baseline_reset_suggested_at' => now()]);
+        }
 
         Log::info('Detected metric trend via TaskPipeline', [
             'event_id' => $this->model->id,

--- a/app/Jobs/TaskPipeline/Tasks/DetectTrendsTask.php
+++ b/app/Jobs/TaskPipeline/Tasks/DetectTrendsTask.php
@@ -3,25 +3,203 @@
 namespace App\Jobs\TaskPipeline\Tasks;
 
 use App\Jobs\TaskPipeline\BaseTaskJob;
+use App\Models\Event;
+use App\Models\MetricStatistic;
+use App\Models\MetricTrend;
+use Illuminate\Support\Facades\Log;
 
 class DetectTrendsTask extends BaseTaskJob
 {
+    protected const CHANGE_THRESHOLD = 0.15; // 15% change
+
     /**
-     * Execute the trend detection task
-     *
-     * Note: This task is scheduled-only and runs via DispatchTrendDetectionTasksJob
-     * It is not triggered on event creation
+     * Execute trend detection for the event's metric combination
      */
     protected function execute(): void
     {
-        // Trend detection is a scheduled batch job that analyzes all metrics
-        // The actual implementation is in DetectMetricTrendsJob which processes
-        // all metric statistics globally.
-        //
-        // This task skeleton exists for consistency but the work is done
-        // by the scheduled job, not per-event.
+        if ($this->model->value === null || $this->model->value_unit === null) {
+            return;
+        }
 
-        // If we wanted per-event trend detection, we could implement it here,
-        // but for now the scheduled batch approach is more efficient.
+        $userId = $this->model->integration->user_id ?? null;
+        if (! $userId) {
+            return;
+        }
+
+        $metric = MetricStatistic::where('user_id', $userId)
+            ->where('service', $this->model->service)
+            ->where('action', $this->model->action)
+            ->where('value_unit', $this->model->value_unit)
+            ->first();
+
+        if (! $metric || ! $metric->hasValidStatistics()) {
+            return;
+        }
+
+        $this->detectWeeklyTrends($metric);
+        $this->detectMonthlyTrends($metric);
+        $this->detectQuarterlyTrends($metric);
+    }
+
+    protected function detectWeeklyTrends(MetricStatistic $metric): void
+    {
+        $currentWeekStart = now()->startOfWeek();
+        $currentWeekEnd = now()->endOfWeek();
+        $currentAvg = $this->getAverageForPeriod($metric, $currentWeekStart, $currentWeekEnd);
+
+        if ($currentAvg === null) {
+            return;
+        }
+
+        foreach ([4, 8, 12] as $weeks) {
+            $comparisonStart = $currentWeekStart->copy()->subWeeks($weeks);
+            $comparisonEnd = $currentWeekStart->copy()->subDay();
+            $comparisonAvg = $this->getAverageForPeriod($metric, $comparisonStart, $comparisonEnd);
+
+            if ($comparisonAvg === null || $comparisonAvg == 0) {
+                continue;
+            }
+
+            $percentChange = abs(($currentAvg - $comparisonAvg) / $comparisonAvg);
+
+            if ($percentChange >= self::CHANGE_THRESHOLD) {
+                $direction = $currentAvg > $comparisonAvg ? 'up' : 'down';
+                $this->createTrendIfNew($metric, "trend_{$direction}_weekly", $currentWeekStart, $currentWeekEnd, $comparisonAvg, $currentAvg, $percentChange, [
+                    'comparison_weeks' => $weeks,
+                    'comparison_start' => $comparisonStart->toDateString(),
+                    'comparison_end' => $comparisonEnd->toDateString(),
+                ]);
+                break;
+            }
+        }
+    }
+
+    protected function detectMonthlyTrends(MetricStatistic $metric): void
+    {
+        $currentMonthStart = now()->startOfMonth();
+        $currentMonthEnd = now()->endOfMonth();
+        $currentAvg = $this->getAverageForPeriod($metric, $currentMonthStart, $currentMonthEnd);
+
+        if ($currentAvg === null) {
+            return;
+        }
+
+        foreach ([3, 6, 12] as $months) {
+            $comparisonStart = $currentMonthStart->copy()->subMonths($months);
+            $comparisonEnd = $currentMonthStart->copy()->subDay();
+            $comparisonAvg = $this->getAverageForPeriod($metric, $comparisonStart, $comparisonEnd);
+
+            if ($comparisonAvg === null || $comparisonAvg == 0) {
+                continue;
+            }
+
+            $percentChange = abs(($currentAvg - $comparisonAvg) / $comparisonAvg);
+
+            if ($percentChange >= self::CHANGE_THRESHOLD) {
+                $direction = $currentAvg > $comparisonAvg ? 'up' : 'down';
+                $this->createTrendIfNew($metric, "trend_{$direction}_monthly", $currentMonthStart, $currentMonthEnd, $comparisonAvg, $currentAvg, $percentChange, [
+                    'comparison_months' => $months,
+                    'comparison_start' => $comparisonStart->toDateString(),
+                    'comparison_end' => $comparisonEnd->toDateString(),
+                ]);
+                break;
+            }
+        }
+    }
+
+    protected function detectQuarterlyTrends(MetricStatistic $metric): void
+    {
+        $currentQuarterStart = now()->startOfQuarter();
+        $currentQuarterEnd = now()->endOfQuarter();
+        $currentAvg = $this->getAverageForPeriod($metric, $currentQuarterStart, $currentQuarterEnd);
+
+        if ($currentAvg === null) {
+            return;
+        }
+
+        foreach ([2, 4] as $quarters) {
+            $comparisonStart = $currentQuarterStart->copy()->subQuarters($quarters);
+            $comparisonEnd = $currentQuarterStart->copy()->subDay();
+            $comparisonAvg = $this->getAverageForPeriod($metric, $comparisonStart, $comparisonEnd);
+
+            if ($comparisonAvg === null || $comparisonAvg == 0) {
+                continue;
+            }
+
+            $percentChange = abs(($currentAvg - $comparisonAvg) / $comparisonAvg);
+
+            if ($percentChange >= self::CHANGE_THRESHOLD) {
+                $direction = $currentAvg > $comparisonAvg ? 'up' : 'down';
+                $this->createTrendIfNew($metric, "trend_{$direction}_quarterly", $currentQuarterStart, $currentQuarterEnd, $comparisonAvg, $currentAvg, $percentChange, [
+                    'comparison_quarters' => $quarters,
+                    'comparison_start' => $comparisonStart->toDateString(),
+                    'comparison_end' => $comparisonEnd->toDateString(),
+                ]);
+                break;
+            }
+        }
+    }
+
+    protected function createTrendIfNew(
+        MetricStatistic $metric,
+        string $type,
+        $periodStart,
+        $periodEnd,
+        float $baselineValue,
+        float $currentValue,
+        float $deviation,
+        array $metadata,
+    ): void {
+        $existing = MetricTrend::where('metric_statistic_id', $metric->id)
+            ->where('type', $type)
+            ->whereNull('acknowledged_at')
+            ->where('start_date', '>=', $periodStart->toDateString())
+            ->exists();
+
+        if ($existing) {
+            return;
+        }
+
+        MetricTrend::create([
+            'metric_statistic_id' => $metric->id,
+            'type' => $type,
+            'detected_at' => now(),
+            'start_date' => $periodStart->toDateString(),
+            'end_date' => $periodEnd->toDateString(),
+            'baseline_value' => $baselineValue,
+            'current_value' => $currentValue,
+            'deviation' => $deviation,
+            'significance_score' => min($deviation / self::CHANGE_THRESHOLD, 1.0),
+            'metadata' => $metadata,
+        ]);
+
+        Log::info('Detected metric trend via TaskPipeline', [
+            'event_id' => $this->model->id,
+            'metric_id' => $metric->id,
+            'type' => $type,
+            'percent_change' => $deviation * 100,
+        ]);
+    }
+
+    protected function getAverageForPeriod(MetricStatistic $metric, $startDate, $endDate): ?float
+    {
+        $events = Event::whereHas('integration', function ($q) use ($metric) {
+            $q->where('user_id', $metric->user_id)->whereNull('deleted_at');
+        })
+            ->where('service', $metric->service)
+            ->where('action', $metric->action)
+            ->where('value_unit', $metric->value_unit)
+            ->whereNotNull('value')
+            ->whereNull('deleted_at')
+            ->whereBetween('time', [$startDate, $endDate])
+            ->get();
+
+        if ($events->isEmpty()) {
+            return null;
+        }
+
+        $values = $events->map(fn ($e) => $e->getFormattedValueAttribute())->filter();
+
+        return $values->isEmpty() ? null : $values->average();
     }
 }

--- a/app/Jobs/TaskPipeline/Tasks/FetchExtractContentTask.php
+++ b/app/Jobs/TaskPipeline/Tasks/FetchExtractContentTask.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace App\Jobs\TaskPipeline\Tasks;
+
+use App\Jobs\TaskPipeline\BaseTaskJob;
+use App\Jobs\TaskPipeline\ProcessTaskPipelineJob;
+use App\Models\Event;
+use Exception;
+use Illuminate\Support\Facades\Log;
+use OpenAI\Laravel\Facades\OpenAI;
+
+class FetchExtractContentTask extends BaseTaskJob
+{
+    protected function execute(): void
+    {
+        if (! $this->model instanceof Event) {
+            throw new Exception('Fetch extract task requires an Event model.');
+        }
+
+        $event = $this->model->loadMissing(['target', 'integration', 'blocks']);
+        $webpage = $event->target;
+
+        if (! $webpage) {
+            throw new Exception('Fetch event does not have a webpage target.');
+        }
+
+        $extracted = $this->buildExtractedPayload($event);
+        if (trim($extracted['text_content']) === '') {
+            throw new Exception('Fetch event has no raw content block text.');
+        }
+
+        try {
+            $articleText = $this->extractArticleText($extracted['title'], $extracted['text_content']);
+
+            $webpage->update(['content' => $articleText]);
+
+            ProcessTaskPipelineJob::dispatch(
+                model: $event->fresh(['target', 'integration', 'blocks']),
+                trigger: 'manual',
+                taskFilter: ['fetch_generate_summaries'],
+            );
+
+            Log::info('Fetch: Article text extracted via TaskPipeline', [
+                'event_id' => $event->id,
+                'webpage_id' => $webpage->id,
+                'word_count' => str_word_count($articleText),
+            ]);
+        } catch (Exception $e) {
+            $metadata = $webpage->metadata ?? [];
+            $metadata['last_extraction_error'] = $e->getMessage();
+            $metadata['last_extraction_error_at'] = now()->toIso8601String();
+            $webpage->update(['metadata' => $metadata]);
+
+            throw $e;
+        }
+    }
+
+    /**
+     * @return array{title: string, content: string, text_content: string, excerpt: string, author: ?string, image: ?string, direction: string}
+     */
+    private function buildExtractedPayload(Event $event): array
+    {
+        $webpage = $event->target;
+        $contentBlock = $event->blocks->firstWhere('block_type', 'fetch_content');
+        $blockMetadata = $contentBlock?->metadata ?? [];
+        $webpageMetadata = $webpage?->metadata ?? [];
+
+        return [
+            'title' => $webpage?->title ?: ($event->event_metadata['title'] ?? 'Untitled'),
+            'content' => (string) ($blockMetadata['html'] ?? $webpage?->content ?? ''),
+            'text_content' => (string) ($blockMetadata['text'] ?? ''),
+            'excerpt' => (string) ($blockMetadata['excerpt'] ?? $webpage?->content ?? ''),
+            'author' => $webpageMetadata['author'] ?? null,
+            'image' => $webpageMetadata['image_url'] ?? $webpage?->media_url,
+            'direction' => $webpageMetadata['direction'] ?? 'ltr',
+        ];
+    }
+
+    private function extractArticleText(string $title, string $content): string
+    {
+        $contentLength = strlen($content);
+        $maxContentLength = 150000;
+        $wasTruncated = $contentLength > $maxContentLength;
+        $contentToSend = mb_substr($content, 0, $maxContentLength);
+
+        if ($wasTruncated) {
+            Log::warning('Fetch: Content truncated for AI processing', [
+                'event_id' => $this->model->id,
+                'original_length' => $contentLength,
+                'truncated_to' => strlen($contentToSend),
+            ]);
+        }
+
+        $systemPrompt = <<<'PROMPT'
+You are an intelligent content extractor. Given an article title and raw content, extract and return the clean article text formatted in Markdown.
+
+**IMPORTANT**: Your output MUST be formatted in Markdown with appropriate formatting (headings, bold, italic, links, lists, quotes, code blocks, etc.) to enhance readability.
+
+Requirements:
+1. Remove navigation, ads, footers, cookie notices, and other non-article content
+2. Preserve the complete article text including all paragraphs
+3. Format the content using proper Markdown syntax:
+   - Use # ## ### for headings
+   - Use **bold** and *italic* for emphasis
+   - Use > for blockquotes
+   - Use - or * for unordered lists, 1. 2. 3. for ordered lists
+   - Use [text](url) for links
+   - Use `code` for inline code, ``` for code blocks
+4. Keep all important content intact
+5. Return only the clean article text as Markdown (not JSON)
+
+The output should be the full, clean article text in Markdown format that a reader would want to read.
+PROMPT;
+
+        $model = 'gpt-5-nano';
+        $messages = [
+            ['role' => 'system', 'content' => $systemPrompt],
+            [
+                'role' => 'user',
+                'content' => json_encode([
+                    'title' => $title,
+                    'content' => $contentToSend,
+                ]),
+            ],
+        ];
+        $aiSpan = start_ai_request_span($model, $messages, []);
+
+        $result = OpenAI::chat()->create([
+            'model' => $model,
+            'messages' => $messages,
+        ]);
+
+        $usage = $result->usage ? $result->usage->toArray() : [];
+        $finishReason = $result->choices[0]->finishReason ?? null;
+        finish_ai_request_span($aiSpan, $usage, $finishReason);
+
+        $articleText = trim($result->choices[0]->message->content);
+
+        if (empty($articleText)) {
+            throw new Exception('Empty article text returned from AI');
+        }
+
+        return $articleText;
+    }
+}

--- a/app/Jobs/TaskPipeline/Tasks/FetchGenerateSummariesTask.php
+++ b/app/Jobs/TaskPipeline/Tasks/FetchGenerateSummariesTask.php
@@ -1,0 +1,283 @@
+<?php
+
+namespace App\Jobs\TaskPipeline\Tasks;
+
+use App\Jobs\TaskPipeline\BaseTaskJob;
+use App\Models\Event;
+use Exception;
+use Illuminate\Support\Facades\Log;
+use OpenAI\Laravel\Facades\OpenAI;
+
+class FetchGenerateSummariesTask extends BaseTaskJob
+{
+    protected function execute(): void
+    {
+        if (! $this->model instanceof Event) {
+            throw new Exception('Fetch summary task requires an Event model.');
+        }
+
+        $event = $this->model->loadMissing(['target', 'integration', 'blocks']);
+        $webpage = $event->target?->fresh();
+        $articleText = $webpage?->content;
+
+        if (! $webpage) {
+            throw new Exception('Fetch event does not have a webpage target.');
+        }
+
+        if (! is_string($articleText) || trim($articleText) === '') {
+            throw new Exception('Fetch event has no extracted content to summarize.');
+        }
+
+        $extracted = $this->buildExtractedPayload($event);
+
+        try {
+            $summaries = $this->generateSummaries($extracted['title'], $articleText);
+
+            $this->createSummaryBlocks($event, $webpage, $extracted, $summaries);
+
+            if (! empty($summaries['emoji']) || ! empty($summaries['tags'])) {
+                $this->attachTags($event, $webpage, $summaries);
+            }
+
+            Log::info('Fetch: Summaries generated via TaskPipeline', [
+                'event_id' => $event->id,
+                'webpage_id' => $webpage->id,
+            ]);
+        } catch (Exception $e) {
+            $metadata = $webpage->metadata ?? [];
+            $metadata['last_summary_error'] = $e->getMessage();
+            $metadata['last_summary_error_at'] = now()->toIso8601String();
+            $webpage->update(['metadata' => $metadata]);
+
+            throw $e;
+        }
+    }
+
+    /**
+     * @return array{title: string, content: string, text_content: string, excerpt: string, author: ?string, image: ?string, direction: string}
+     */
+    private function buildExtractedPayload(Event $event): array
+    {
+        $webpage = $event->target;
+        $contentBlock = $event->blocks->firstWhere('block_type', 'fetch_content');
+        $blockMetadata = $contentBlock?->metadata ?? [];
+        $webpageMetadata = $webpage?->metadata ?? [];
+
+        return [
+            'title' => $webpage?->title ?: ($event->event_metadata['title'] ?? 'Untitled'),
+            'content' => (string) ($blockMetadata['html'] ?? $webpage?->content ?? ''),
+            'text_content' => (string) ($blockMetadata['text'] ?? ''),
+            'excerpt' => (string) ($blockMetadata['excerpt'] ?? $webpage?->content ?? ''),
+            'author' => $webpageMetadata['author'] ?? null,
+            'image' => $webpageMetadata['image_url'] ?? $webpage?->media_url,
+            'direction' => $webpageMetadata['direction'] ?? 'ltr',
+        ];
+    }
+
+    private function generateSummaries(string $title, string $articleText): array
+    {
+        $contentLength = strlen($articleText);
+        $maxContentLength = 150000;
+        $wasTruncated = $contentLength > $maxContentLength;
+        $contentToSend = mb_substr($articleText, 0, $maxContentLength);
+
+        if ($wasTruncated) {
+            Log::warning('Fetch: Article text truncated for summary generation', [
+                'event_id' => $this->model->id,
+                'original_length' => $contentLength,
+                'truncated_to' => strlen($contentToSend),
+            ]);
+        }
+
+        $systemPrompt = <<<'PROMPT'
+You are an intelligent content summarizer. Given an article title and clean article text, provide exactly 7 different outputs in JSON.
+
+**IMPORTANT**: All text outputs MUST be formatted in Markdown. Use appropriate formatting (bold, italic, links, lists) to enhance readability.
+
+Requirements:
+1. summary_tweet: 280 characters maximum, ultra-concise, engaging (Markdown formatted)
+2. summary_short: No more than 40 words, concise overview (Markdown formatted)
+3. summary_paragraph: No more than 150 words, detailed overview with key points (Markdown formatted)
+4. key_takeaways: Array of 3-5 strings, each a bullet point with key insights (can include bold, links)
+5. tldr: Single sentence (max 20 words), absolute minimum summary (Markdown formatted)
+6. emoji: Single emoji that best represents the article's theme or content
+7. tags: Array of 1-5 semantic tags with types. Only include tags that are clearly relevant and mentioned in the content:
+   - "topic-tag" for subjects/themes (e.g., "Machine Learning", "Climate Change")
+   - "person-tag" for people mentioned (e.g., "Elon Musk", "Jane Doe")
+   - "organisation-tag" for organizations (e.g., "NASA", "Microsoft")
+   - "place-tag" for locations (e.g., "New York", "Mars")
+
+Return ONLY valid JSON in this exact format:
+{
+  "summary_tweet": "**Markdown formatted** 280 char version here",
+  "summary_short": "Markdown formatted 40 word version here",
+  "summary_paragraph": "Markdown formatted 150 word version here with **bold** and *italic*",
+  "key_takeaways": ["**Bold point 1** with details", "Point 2 with [link](url)", "Point 3"],
+  "tldr": "Markdown formatted one sentence version here",
+  "emoji": "📰",
+  "tags": [
+    {"tag": "Artificial Intelligence", "tag_type": "topic-tag"},
+    {"tag": "Sam Altman", "tag_type": "person-tag"}
+  ]
+}
+PROMPT;
+
+        $model = 'gpt-5-nano';
+        $messages = [
+            ['role' => 'system', 'content' => $systemPrompt],
+            [
+                'role' => 'user',
+                'content' => json_encode([
+                    'title' => $title,
+                    'article_text' => $contentToSend,
+                ]),
+            ],
+        ];
+        $aiSpan = start_ai_request_span($model, $messages, []);
+
+        $result = OpenAI::chat()->create([
+            'model' => $model,
+            'messages' => $messages,
+            'response_format' => ['type' => 'json_object'],
+        ]);
+
+        $usage = $result->usage ? $result->usage->toArray() : [];
+        $finishReason = $result->choices[0]->finishReason ?? null;
+        finish_ai_request_span($aiSpan, $usage, $finishReason);
+
+        $summaries = json_decode($result->choices[0]->message->content, true);
+        if (! is_array($summaries)) {
+            throw new Exception('Summary response was not valid JSON');
+        }
+
+        $summaries = $this->normaliseSummaries($summaries);
+
+        foreach (['summary_tweet', 'summary_short', 'summary_paragraph', 'key_takeaways', 'tldr', 'emoji', 'tags'] as $key) {
+            if (! isset($summaries[$key])) {
+                throw new Exception("Missing required summary type: {$key}");
+            }
+        }
+
+        return $summaries;
+    }
+
+    private function normaliseSummaries(array $summaries): array
+    {
+        if (! isset($summaries['summary_tweet'])) {
+            $source = $summaries['summary_short'] ?? $summaries['tldr'] ?? null;
+
+            if (is_string($source) && $source !== '') {
+                $summaries['summary_tweet'] = mb_substr($source, 0, 280);
+
+                Log::warning('Fetch: Repaired missing summary_tweet from summary response', [
+                    'source_key' => isset($summaries['summary_short']) ? 'summary_short' : 'tldr',
+                ]);
+            }
+        }
+
+        return $summaries;
+    }
+
+    private function createSummaryBlocks(Event $event, $webpage, array $extracted, array $summaries): void
+    {
+        $webpageMetadata = $webpage->metadata ?? [];
+        $webpageMetadata['author'] = $extracted['author'];
+        $webpageMetadata['image_url'] = $extracted['image'];
+        $webpageMetadata['direction'] = $extracted['direction'];
+        $webpageMetadata['extracted_at'] = now()->toIso8601String();
+        $webpage->update(['metadata' => $webpageMetadata]);
+
+        $eventTime = $event->time;
+        $tweetContent = is_array($summaries['summary_tweet']) ? json_encode($summaries['summary_tweet']) : $summaries['summary_tweet'];
+
+        $event->createBlock([
+            'title' => 'Tweet Summary',
+            'block_type' => 'fetch_summary_tweet',
+            'time' => $eventTime,
+            'metadata' => [
+                'content' => $tweetContent,
+                'char_count' => strlen($tweetContent),
+                'generated_at' => now()->toIso8601String(),
+                'model' => 'gpt-5-nano',
+            ],
+        ]);
+
+        $event->createBlock([
+            'title' => 'Short Summary',
+            'block_type' => 'fetch_summary_short',
+            'time' => $eventTime,
+            'metadata' => [
+                'content' => $summaries['summary_short'],
+                'word_count' => str_word_count($summaries['summary_short']),
+                'generated_at' => now()->toIso8601String(),
+                'model' => 'gpt-5-nano',
+            ],
+        ]);
+
+        $event->createBlock([
+            'title' => 'Paragraph Summary',
+            'block_type' => 'fetch_summary_paragraph',
+            'time' => $eventTime,
+            'metadata' => [
+                'content' => $summaries['summary_paragraph'],
+                'word_count' => str_word_count($summaries['summary_paragraph']),
+                'generated_at' => now()->toIso8601String(),
+                'model' => 'gpt-5-nano',
+            ],
+        ]);
+
+        $event->createBlock([
+            'title' => 'Key Takeaways',
+            'block_type' => 'fetch_key_takeaways',
+            'time' => $eventTime,
+            'metadata' => [
+                'content' => $summaries['key_takeaways'],
+                'count' => count($summaries['key_takeaways']),
+                'generated_at' => now()->toIso8601String(),
+                'model' => 'gpt-5-nano',
+            ],
+        ]);
+
+        $event->createBlock([
+            'title' => 'TL;DR',
+            'block_type' => 'fetch_tldr',
+            'time' => $eventTime,
+            'metadata' => [
+                'content' => $summaries['tldr'],
+                'word_count' => str_word_count($summaries['tldr']),
+                'generated_at' => now()->toIso8601String(),
+                'model' => 'gpt-5-nano',
+            ],
+        ]);
+    }
+
+    private function attachTags(Event $event, $webpage, array $summaries): void
+    {
+        if (! empty($summaries['emoji'])) {
+            $webpage->attachTags([$summaries['emoji']], 'spark-emoji');
+            $event->detachTags($event->tagsWithType('spark-emoji'));
+            $event->attachTags([$summaries['emoji']], 'spark-emoji');
+        }
+
+        if (! empty($summaries['tags']) && is_array($summaries['tags'])) {
+            $tagsByType = [];
+            foreach ($summaries['tags'] as $tagData) {
+                if (isset($tagData['tag'], $tagData['tag_type'])) {
+                    $tagsByType[$tagData['tag_type']][] = $tagData['tag'];
+                }
+            }
+
+            foreach ($tagsByType as $type => $tags) {
+                $webpage->attachTags($tags, $type);
+                $event->detachTags($event->tagsWithType($type));
+                $event->attachTags($tags, $type);
+            }
+        }
+
+        $metadata = $webpage->metadata ?? [];
+        if (($metadata['fetch_mode'] ?? 'recurring') === 'once') {
+            $metadata['discovery_status'] = 'completed';
+            $webpage->update(['metadata' => $metadata]);
+        }
+    }
+}

--- a/app/Jobs/TaskPipeline/Tasks/GenerateEmbeddingTask.php
+++ b/app/Jobs/TaskPipeline/Tasks/GenerateEmbeddingTask.php
@@ -6,6 +6,7 @@ use App\Jobs\TaskPipeline\BaseTaskJob;
 use App\Models\Event;
 use App\Services\EmbeddingService;
 use Illuminate\Support\Facades\Log;
+use RuntimeException;
 
 class GenerateEmbeddingTask extends BaseTaskJob
 {
@@ -30,6 +31,10 @@ class GenerateEmbeddingTask extends BaseTaskJob
 
         // Generate embedding
         $embedding = $embeddingService->embed($searchableText);
+
+        if (EmbeddingService::isZeroVector($embedding)) {
+            throw new RuntimeException('Embedding provider returned a zero vector');
+        }
 
         // Get embedding metadata
         $embeddingMetadata = $embeddingService->getEmbeddingMetadata();

--- a/app/Jobs/TaskPipeline/Tasks/HevyAutoCoachTask.php
+++ b/app/Jobs/TaskPipeline/Tasks/HevyAutoCoachTask.php
@@ -27,7 +27,7 @@ class HevyAutoCoachTask extends BaseTaskJob
         $result = $effect->handle();
 
         if (! ($result['success'] ?? false)) {
-            throw new RuntimeException('HevyAutoCoachEffect failed: '.($result['message'] ?? 'unknown error'));
+            throw new RuntimeException('HevyAutoCoachEffect failed: ' . ($result['message'] ?? 'unknown error'));
         }
     }
 }

--- a/app/Jobs/TaskPipeline/Tasks/HevyAutoCoachTask.php
+++ b/app/Jobs/TaskPipeline/Tasks/HevyAutoCoachTask.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Jobs\TaskPipeline\Tasks;
+
+use App\Jobs\Effects\Hevy\HevyAutoCoachEffect;
+use App\Jobs\TaskPipeline\BaseTaskJob;
+use RuntimeException;
+
+class HevyAutoCoachTask extends BaseTaskJob
+{
+    /**
+     * Execute the Hevy auto-coach effect via the task pipeline
+     */
+    protected function execute(): void
+    {
+        $integration = $this->model->integration ?? null;
+
+        if (! $integration) {
+            throw new RuntimeException('No integration found for HevyAutoCoachTask');
+        }
+
+        $effect = new HevyAutoCoachEffect($integration, [
+            'task_key' => $this->task->key,
+            'triggered_by' => 'task_pipeline',
+        ]);
+
+        $result = $effect->handle();
+
+        if (! ($result['success'] ?? false)) {
+            throw new RuntimeException('HevyAutoCoachEffect failed: '.($result['message'] ?? 'unknown error'));
+        }
+    }
+}

--- a/app/Jobs/TaskPipeline/Tasks/NewsletterExtractContentTask.php
+++ b/app/Jobs/TaskPipeline/Tasks/NewsletterExtractContentTask.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace App\Jobs\TaskPipeline\Tasks;
+
+use App\Jobs\TaskPipeline\BaseTaskJob;
+use App\Jobs\TaskPipeline\ProcessTaskPipelineJob;
+use App\Models\Event;
+use Exception;
+use Illuminate\Support\Facades\Log;
+use OpenAI\Laravel\Facades\OpenAI;
+
+class NewsletterExtractContentTask extends BaseTaskJob
+{
+    protected function execute(): void
+    {
+        if (! $this->model instanceof Event) {
+            throw new Exception('Newsletter extract task requires an Event model.');
+        }
+
+        $event = $this->model->loadMissing(['target', 'integration']);
+        $publication = $event->target;
+        $rawContent = $event->event_metadata['raw_html'] ?? null;
+
+        if (! $publication) {
+            throw new Exception('Newsletter event does not have a publication target.');
+        }
+
+        if (! is_string($rawContent) || $rawContent === '') {
+            throw new Exception('Newsletter event has no raw_html metadata.');
+        }
+
+        Log::info('Newsletter: Extracting newsletter content via TaskPipeline', [
+            'integration_id' => $event->integration_id,
+            'event_id' => $event->id,
+            'publication_id' => $publication->id,
+        ]);
+
+        try {
+            $articleText = $this->extractArticleText(
+                $event->event_metadata['email_subject'] ?? 'No Subject',
+                $rawContent
+            );
+
+            $metadata = $publication->metadata ?? [];
+            $metadata['extracted_at'] = now()->toIso8601String();
+
+            $publication->update([
+                'content' => $articleText,
+                'metadata' => $metadata,
+            ]);
+
+            ProcessTaskPipelineJob::dispatch(
+                model: $event->fresh(['target', 'integration']),
+                trigger: 'manual',
+                taskFilter: ['newsletter_generate_summaries'],
+            );
+
+            Log::info('Newsletter: Article text extracted via TaskPipeline', [
+                'event_id' => $event->id,
+                'publication_id' => $publication->id,
+                'word_count' => str_word_count($articleText),
+            ]);
+        } catch (Exception $e) {
+            $metadata = $event->event_metadata ?? [];
+            $metadata['last_extraction_error'] = $e->getMessage();
+            $metadata['last_extraction_error_at'] = now()->toIso8601String();
+            $event->update(['event_metadata' => $metadata]);
+
+            throw $e;
+        }
+    }
+
+    private function extractArticleText(string $subject, string $content): string
+    {
+        $contentLength = mb_strlen($content);
+        $maxContentLength = 150000;
+        $wasTruncated = $contentLength > $maxContentLength;
+        $contentToSend = mb_substr($content, 0, $maxContentLength);
+
+        if ($wasTruncated) {
+            Log::warning('Newsletter: Content truncated for AI processing', [
+                'event_id' => $this->model->id,
+                'original_length' => $contentLength,
+                'truncated_to' => strlen($contentToSend),
+            ]);
+        }
+
+        $systemPrompt = <<<'PROMPT'
+You are an intelligent newsletter content extractor. Given a newsletter email HTML or text, extract and return the clean article text formatted in Markdown.
+
+**IMPORTANT**: Your output MUST be formatted in Markdown with appropriate formatting (headings, bold, italic, links, lists, quotes, code blocks, etc.) to enhance readability.
+
+Requirements:
+1. Remove email headers, footers, unsubscribe links, social media buttons, and other email-specific content
+2. Preserve the complete article/newsletter text including all paragraphs
+3. Format the content using proper Markdown syntax:
+   - Use # ## ### for headings
+   - Use **bold** and *italic* for emphasis
+   - Use > for blockquotes
+   - Use - or * for unordered lists, 1. 2. 3. for ordered lists
+   - Use [text](url) for links
+   - Use `code` for inline code, ``` for code blocks
+4. Keep all important content intact
+5. Return only the clean article text as Markdown (not JSON)
+
+The output should be the full, clean newsletter content in Markdown format that a reader would want to read.
+PROMPT;
+
+        $model = 'gpt-5-nano';
+        $messages = [
+            ['role' => 'system', 'content' => $systemPrompt],
+            [
+                'role' => 'user',
+                'content' => json_encode([
+                    'subject' => $subject,
+                    'content' => $contentToSend,
+                ]),
+            ],
+        ];
+        $aiSpan = start_ai_request_span($model, $messages, []);
+
+        $result = OpenAI::chat()->create([
+            'model' => $model,
+            'messages' => $messages,
+        ]);
+
+        $usage = $result->usage ? $result->usage->toArray() : [];
+        $finishReason = $result->choices[0]->finishReason ?? null;
+        finish_ai_request_span($aiSpan, $usage, $finishReason);
+
+        $articleText = trim($result->choices[0]->message->content);
+
+        if (empty($articleText)) {
+            throw new Exception('Empty article text returned from AI');
+        }
+
+        return $articleText;
+    }
+}

--- a/app/Jobs/TaskPipeline/Tasks/NewsletterGenerateSummariesTask.php
+++ b/app/Jobs/TaskPipeline/Tasks/NewsletterGenerateSummariesTask.php
@@ -1,0 +1,230 @@
+<?php
+
+namespace App\Jobs\TaskPipeline\Tasks;
+
+use App\Jobs\TaskPipeline\BaseTaskJob;
+use App\Models\Event;
+use Exception;
+use Illuminate\Support\Facades\Log;
+use OpenAI\Laravel\Facades\OpenAI;
+
+class NewsletterGenerateSummariesTask extends BaseTaskJob
+{
+    protected function execute(): void
+    {
+        if (! $this->model instanceof Event) {
+            throw new Exception('Newsletter summary task requires an Event model.');
+        }
+
+        $event = $this->model->loadMissing(['target', 'integration']);
+        $publication = $event->target?->fresh();
+        $articleText = $publication?->content;
+
+        if (! $publication) {
+            throw new Exception('Newsletter event does not have a publication target.');
+        }
+
+        if (! is_string($articleText) || trim($articleText) === '') {
+            throw new Exception('Newsletter event has no extracted content to summarize.');
+        }
+
+        try {
+            $summaries = $this->generateSummaries(
+                $event->event_metadata['email_subject'] ?? 'No Subject',
+                $articleText
+            );
+
+            $this->createSummaryBlocks($event, $summaries);
+
+            if (! empty($summaries['emoji']) || ! empty($summaries['tags'])) {
+                $this->attachTags($event, $publication, $summaries);
+            }
+
+            Log::info('Newsletter: Summaries generated via TaskPipeline', [
+                'event_id' => $event->id,
+                'publication_id' => $publication->id,
+            ]);
+        } catch (Exception $e) {
+            $metadata = $event->event_metadata ?? [];
+            $metadata['last_summary_error'] = $e->getMessage();
+            $metadata['last_summary_error_at'] = now()->toIso8601String();
+            $event->update(['event_metadata' => $metadata]);
+
+            throw $e;
+        }
+    }
+
+    private function generateSummaries(string $subject, string $articleText): array
+    {
+        $contentLength = strlen($articleText);
+        $maxContentLength = 150000;
+        $wasTruncated = $contentLength > $maxContentLength;
+        $contentToSend = mb_substr($articleText, 0, $maxContentLength);
+
+        if ($wasTruncated) {
+            Log::warning('Newsletter: Article text truncated for summary generation', [
+                'event_id' => $this->model->id,
+                'original_length' => $contentLength,
+                'truncated_to' => strlen($contentToSend),
+            ]);
+        }
+
+        $systemPrompt = <<<'PROMPT'
+You are an intelligent content summarizer. Given an article title and clean article text, provide exactly 7 different outputs in JSON.
+
+**IMPORTANT**: All text outputs MUST be formatted in Markdown. Use appropriate formatting (bold, italic, links, lists) to enhance readability.
+
+Requirements:
+1. summary_tweet: 280 characters maximum, ultra-concise, engaging (Markdown formatted)
+2. summary_short: No more than 40 words, concise overview (Markdown formatted)
+3. summary_paragraph: No more than 150 words, detailed overview with key points (Markdown formatted)
+4. key_takeaways: Array of 3-5 strings, each a bullet point with key insights (can include bold, links)
+5. tldr: Single sentence (max 20 words), absolute minimum summary (Markdown formatted)
+6. emoji: Single emoji that best represents the article's theme or content
+7. tags: Array of 1-5 semantic tags with types. Only include tags that are clearly relevant and mentioned in the content:
+   - "topic-tag" for subjects/themes (e.g., "Machine Learning", "Climate Change")
+   - "person-tag" for people mentioned (e.g., "Elon Musk", "Jane Doe")
+   - "organisation-tag" for organizations (e.g., "NASA", "Microsoft")
+   - "place-tag" for locations (e.g., "New York", "Mars")
+
+Return ONLY valid JSON in this exact format:
+{
+  "summary_tweet": "**Markdown formatted** 280 char version here",
+  "summary_short": "Markdown formatted 40 word version here",
+  "summary_paragraph": "Markdown formatted 150 word version here with **bold** and *italic*",
+  "key_takeaways": ["**Bold point 1** with details", "Point 2 with [link](url)", "Point 3"],
+  "tldr": "Markdown formatted one sentence version here",
+  "emoji": "📰",
+  "tags": [
+    {"tag": "Artificial Intelligence", "tag_type": "topic-tag"},
+    {"tag": "Sam Altman", "tag_type": "person-tag"}
+  ]
+}
+PROMPT;
+
+        $model = 'gpt-5-nano';
+        $messages = [
+            ['role' => 'system', 'content' => $systemPrompt],
+            [
+                'role' => 'user',
+                'content' => json_encode([
+                    'title' => $subject,
+                    'article_text' => $contentToSend,
+                ]),
+            ],
+        ];
+        $aiSpan = start_ai_request_span($model, $messages, []);
+
+        $result = OpenAI::chat()->create([
+            'model' => $model,
+            'messages' => $messages,
+            'response_format' => ['type' => 'json_object'],
+        ]);
+
+        $usage = $result->usage ? $result->usage->toArray() : [];
+        $finishReason = $result->choices[0]->finishReason ?? null;
+        finish_ai_request_span($aiSpan, $usage, $finishReason);
+
+        $summaries = json_decode($result->choices[0]->message->content, true);
+        if (! is_array($summaries)) {
+            throw new Exception('Summary response was not valid JSON');
+        }
+
+        foreach (['summary_tweet', 'summary_short', 'summary_paragraph', 'key_takeaways', 'tldr', 'emoji', 'tags'] as $key) {
+            if (! isset($summaries[$key])) {
+                throw new Exception("Missing required summary type: {$key}");
+            }
+        }
+
+        return $summaries;
+    }
+
+    private function createSummaryBlocks(Event $event, array $summaries): void
+    {
+        $eventTime = $event->time;
+
+        $event->createBlock([
+            'title' => 'Tweet Summary',
+            'block_type' => 'newsletter_summary_tweet',
+            'time' => $eventTime,
+            'metadata' => [
+                'content' => $summaries['summary_tweet'],
+                'char_count' => strlen($summaries['summary_tweet']),
+                'generated_at' => now()->toIso8601String(),
+                'model' => 'gpt-5-nano',
+            ],
+        ]);
+
+        $event->createBlock([
+            'title' => 'Short Summary',
+            'block_type' => 'newsletter_summary_short',
+            'time' => $eventTime,
+            'metadata' => [
+                'content' => $summaries['summary_short'],
+                'word_count' => str_word_count($summaries['summary_short']),
+                'generated_at' => now()->toIso8601String(),
+                'model' => 'gpt-5-nano',
+            ],
+        ]);
+
+        $event->createBlock([
+            'title' => 'Paragraph Summary',
+            'block_type' => 'newsletter_summary_paragraph',
+            'time' => $eventTime,
+            'metadata' => [
+                'content' => $summaries['summary_paragraph'],
+                'word_count' => str_word_count($summaries['summary_paragraph']),
+                'generated_at' => now()->toIso8601String(),
+                'model' => 'gpt-5-nano',
+            ],
+        ]);
+
+        $event->createBlock([
+            'title' => 'Key Takeaways',
+            'block_type' => 'newsletter_key_takeaways',
+            'time' => $eventTime,
+            'metadata' => [
+                'content' => $summaries['key_takeaways'],
+                'count' => count($summaries['key_takeaways']),
+                'generated_at' => now()->toIso8601String(),
+                'model' => 'gpt-5-nano',
+            ],
+        ]);
+
+        $event->createBlock([
+            'title' => 'TL;DR',
+            'block_type' => 'newsletter_tldr',
+            'time' => $eventTime,
+            'metadata' => [
+                'content' => $summaries['tldr'],
+                'word_count' => str_word_count($summaries['tldr']),
+                'generated_at' => now()->toIso8601String(),
+                'model' => 'gpt-5-nano',
+            ],
+        ]);
+    }
+
+    private function attachTags(Event $event, $publication, array $summaries): void
+    {
+        if (! empty($summaries['emoji'])) {
+            $publication->attachTags([$summaries['emoji']], 'spark-emoji');
+            $event->detachTags($event->tagsWithType('spark-emoji'));
+            $event->attachTags([$summaries['emoji']], 'spark-emoji');
+        }
+
+        if (! empty($summaries['tags']) && is_array($summaries['tags'])) {
+            $tagsByType = [];
+            foreach ($summaries['tags'] as $tagData) {
+                if (isset($tagData['tag'], $tagData['tag_type'])) {
+                    $tagsByType[$tagData['tag_type']][] = $tagData['tag'];
+                }
+            }
+
+            foreach ($tagsByType as $type => $tags) {
+                $publication->attachTags($tags, $type);
+                $event->detachTags($event->tagsWithType($type));
+                $event->attachTags($tags, $type);
+            }
+        }
+    }
+}

--- a/app/Livewire/IntegrationDetails.php
+++ b/app/Livewire/IntegrationDetails.php
@@ -8,6 +8,7 @@ use App\Models\Block;
 use App\Models\Event;
 use App\Models\EventObject;
 use App\Models\Integration;
+use App\Services\TaskPipeline\TaskExecutionStore;
 use Livewire\Component;
 use Mary\Traits\Toast;
 
@@ -247,9 +248,8 @@ class IntegrationDetails extends Component
     protected function shouldExpandTasksSection(): bool
     {
         // Expand if there are failed or pending tasks
-        // For Integration, task_executions are stored in configuration column
-        $configuration = $this->integration->configuration ?? [];
-        $executions = $configuration['task_executions'] ?? [];
+        $executions = app(TaskExecutionStore::class)
+            ->getTaskExecutions($this->integration);
 
         foreach ($executions as $execution) {
             $status = $execution['last_attempt']['status'] ?? null;

--- a/app/Livewire/MetricDetail.php
+++ b/app/Livewire/MetricDetail.php
@@ -2,7 +2,7 @@
 
 namespace App\Livewire;
 
-use App\Jobs\CalculateMetricStatisticsJob;
+use App\Jobs\Metrics\CalculateMetricStatisticsJob;
 use App\Models\Event;
 use App\Models\MetricStatistic;
 use App\Models\MetricTrend;

--- a/app/Mcp/Tools/GetBaselinesTool.php
+++ b/app/Mcp/Tools/GetBaselinesTool.php
@@ -99,7 +99,12 @@ class GetBaselinesTool extends Tool
                 'status' => 'insufficient_data',
                 'unit' => $statistic->value_unit,
                 'sample_days' => $statistic->event_count,
+                'window_days' => $statistic->baseline_window_days ?? MetricStatistic::DEFAULT_WINDOW_DAYS,
                 'display_name' => $statistic->getDisplayName(),
+                'baseline_review_suggested' => $statistic->baseline_reset_suggested_at !== null,
+                'baseline_review_suggested_since' => $statistic->baseline_reset_suggested_at?->toDateString(),
+                'anomaly_high_suppressed_until' => $statistic->anomaly_high_suppressed_until?->toDateString(),
+                'anomaly_low_suppressed_until' => $statistic->anomaly_low_suppressed_until?->toDateString(),
             ];
         }
 
@@ -113,7 +118,12 @@ class GetBaselinesTool extends Tool
             'normal_lower' => round($statistic->normal_lower_bound, 2),
             'normal_upper' => round($statistic->normal_upper_bound, 2),
             'sample_days' => $statistic->event_count,
+            'window_days' => $statistic->baseline_window_days ?? MetricStatistic::DEFAULT_WINDOW_DAYS,
             'display_name' => $statistic->getDisplayName(),
+            'baseline_review_suggested' => $statistic->baseline_reset_suggested_at !== null,
+            'baseline_review_suggested_since' => $statistic->baseline_reset_suggested_at?->toDateString(),
+            'anomaly_high_suppressed_until' => $statistic->anomaly_high_suppressed_until?->toDateString(),
+            'anomaly_low_suppressed_until' => $statistic->anomaly_low_suppressed_until?->toDateString(),
         ];
     }
 }

--- a/app/Models/MetricStatistic.php
+++ b/app/Models/MetricStatistic.php
@@ -12,6 +12,8 @@ class MetricStatistic extends Model
 {
     use HasFactory;
 
+    public const DEFAULT_WINDOW_DAYS = 90;
+
     public $incrementing = false;
 
     protected $keyType = 'string';
@@ -31,6 +33,10 @@ class MetricStatistic extends Model
         'normal_lower_bound',
         'normal_upper_bound',
         'last_calculated_at',
+        'baseline_window_days',
+        'baseline_reset_suggested_at',
+        'anomaly_high_suppressed_until',
+        'anomaly_low_suppressed_until',
     ];
 
     protected $casts = [
@@ -44,6 +50,10 @@ class MetricStatistic extends Model
         'normal_lower_bound' => 'decimal:6',
         'normal_upper_bound' => 'decimal:6',
         'last_calculated_at' => 'datetime',
+        'baseline_window_days' => 'integer',
+        'baseline_reset_suggested_at' => 'datetime',
+        'anomaly_high_suppressed_until' => 'datetime',
+        'anomaly_low_suppressed_until' => 'datetime',
         'created_at' => 'datetime',
         'updated_at' => 'datetime',
     ];

--- a/app/Models/MetricTrend.php
+++ b/app/Models/MetricTrend.php
@@ -123,6 +123,19 @@ class MetricTrend extends Model
     public function acknowledge(): void
     {
         $this->update(['acknowledged_at' => now()]);
+
+        // Clear the baseline review flag if no unacknowledged monthly/quarterly trends remain
+        $hasRemainingTrends = MetricTrend::where('metric_statistic_id', $this->metric_statistic_id)
+            ->whereIn('type', [
+                'trend_up_monthly', 'trend_down_monthly',
+                'trend_up_quarterly', 'trend_down_quarterly',
+            ])
+            ->whereNull('acknowledged_at')
+            ->exists();
+
+        if (! $hasRemainingTrends) {
+            $this->metricStatistic?->update(['baseline_reset_suggested_at' => null]);
+        }
     }
 
     /**

--- a/app/Models/TaskExecution.php
+++ b/app/Models/TaskExecution.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class TaskExecution extends Model
+{
+    use HasFactory, HasUuids;
+
+    protected $fillable = [
+        'user_id',
+        'entity_type',
+        'entity_id',
+        'task_key',
+        'task_name',
+        'status',
+        'attempts',
+        'triggered_by',
+        'started_at',
+        'completed_at',
+        'queue',
+        'queue_connection',
+        'job_id',
+        'error',
+        'waiting_for',
+        'blocked_by',
+        'changed_fields',
+        'history',
+        'last_success',
+    ];
+
+    protected $casts = [
+        'attempts' => 'integer',
+        'started_at' => 'datetime',
+        'completed_at' => 'datetime',
+        'changed_fields' => 'array',
+        'history' => 'array',
+        'last_success' => 'array',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function scopeForUser(Builder $query, string $userId): Builder
+    {
+        return $query->where('user_id', $userId);
+    }
+
+    public function scopeForEntity(Builder $query, string $entityType, string $entityId): Builder
+    {
+        return $query->where('entity_type', $entityType)->where('entity_id', $entityId);
+    }
+
+    public function scopeStatus(Builder $query, ?string $status): Builder
+    {
+        return $status ? $query->where('status', $status) : $query;
+    }
+}

--- a/app/Observers/BlockObserver.php
+++ b/app/Observers/BlockObserver.php
@@ -7,19 +7,40 @@ use App\Models\Block;
 
 class BlockObserver
 {
+    private const DERIVED_DATA_FIELDS = [
+        'event_id',
+        'block_type',
+        'time',
+        'title',
+        'metadata',
+        'url',
+        'value',
+        'value_multiplier',
+        'value_unit',
+    ];
+
     /**
      * Handle the Block "created" event.
      */
     public function created(Block $block): void
     {
+        if (! config('app.enable_task_pipeline', true)) {
+            return;
+        }
+
         // Embedding generation is now handled by TaskPipeline
         // See GenerateEmbeddingTask in app/Jobs/TaskPipeline/Tasks/
 
         // If this is a summary/details block, trigger parent event's task pipeline
         // This ensures events get re-embedded when AI summaries are added
         if ($this->isSummaryOrDetailsBlock($block) && $block->event) {
-            ProcessTaskPipelineJob::dispatch($block->event, 'updated', ['generate_embedding'], force: true)
-                ->onQueue('tasks');
+            ProcessTaskPipelineJob::dispatch(
+                model: $block->event,
+                trigger: 'updated',
+                taskFilter: ['generate_embedding'],
+                force: true,
+                changedFields: ['blocks.created'],
+            )->onQueue('tasks');
         }
     }
 
@@ -28,15 +49,32 @@ class BlockObserver
      */
     public function updated(Block $block): void
     {
-        // Embedding regeneration is now handled by TaskPipeline
-        // See GenerateEmbeddingTask in app/Jobs/TaskPipeline/Tasks/
+        if (! config('app.enable_task_pipeline', true)) {
+            return;
+        }
+
+        $changedFields = $this->changedDerivedDataFields($block);
+
+        if ($changedFields === []) {
+            return;
+        }
+
+        ProcessTaskPipelineJob::dispatch(
+            model: $block,
+            trigger: 'updated',
+            force: true,
+            changedFields: $changedFields,
+        )->onQueue('tasks');
 
         // If this is a summary/details block and relevant fields changed, trigger parent event's task pipeline
-        if ($block->wasChanged(['title', 'metadata', 'url', 'value', 'value_unit'])) {
-            if ($this->isSummaryOrDetailsBlock($block) && $block->event) {
-                ProcessTaskPipelineJob::dispatch($block->event, 'updated', ['generate_embedding'], force: true)
-                    ->onQueue('tasks');
-            }
+        if (($this->isSummaryOrDetailsBlock($block) || $this->wasSummaryOrDetailsBlock($block)) && $block->event) {
+            ProcessTaskPipelineJob::dispatch(
+                model: $block->event,
+                trigger: 'updated',
+                taskFilter: ['generate_embedding'],
+                force: true,
+                changedFields: array_map(fn (string $field) => "blocks.{$field}", $changedFields),
+            )->onQueue('tasks');
         }
     }
 
@@ -45,12 +83,33 @@ class BlockObserver
      */
     private function isSummaryOrDetailsBlock(Block $block): bool
     {
-        if (empty($block->block_type)) {
+        return $this->isSummaryOrDetailsBlockType($block->block_type);
+    }
+
+    private function wasSummaryOrDetailsBlock(Block $block): bool
+    {
+        return $this->isSummaryOrDetailsBlockType($block->getOriginal('block_type'));
+    }
+
+    private function isSummaryOrDetailsBlockType(?string $blockType): bool
+    {
+        if (empty($blockType)) {
             return false;
         }
 
-        $blockType = strtolower($block->block_type);
+        $blockType = strtolower($blockType);
 
         return str_contains($blockType, 'summary') || str_contains($blockType, 'details');
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function changedDerivedDataFields(Block $block): array
+    {
+        return array_values(array_filter(
+            self::DERIVED_DATA_FIELDS,
+            fn (string $field) => $block->wasChanged($field),
+        ));
     }
 }

--- a/app/Observers/EventObjectObserver.php
+++ b/app/Observers/EventObjectObserver.php
@@ -2,10 +2,20 @@
 
 namespace App\Observers;
 
+use App\Jobs\TaskPipeline\ProcessTaskPipelineJob;
 use App\Models\EventObject;
 
 class EventObjectObserver
 {
+    private const DERIVED_DATA_FIELDS = [
+        'time',
+        'concept',
+        'type',
+        'title',
+        'content',
+        'url',
+    ];
+
     /**
      * Handle the EventObject "created" event.
      */
@@ -20,7 +30,32 @@ class EventObjectObserver
      */
     public function updated(EventObject $object): void
     {
-        // Embedding regeneration on updates is now handled by TaskPipeline
-        // See GenerateEmbeddingTask in app/Jobs/TaskPipeline/Tasks/
+        if (! config('app.enable_task_pipeline', true)) {
+            return;
+        }
+
+        $changedFields = $this->changedDerivedDataFields($object);
+
+        if ($changedFields === []) {
+            return;
+        }
+
+        ProcessTaskPipelineJob::dispatch(
+            model: $object,
+            trigger: 'updated',
+            force: true,
+            changedFields: $changedFields,
+        )->onQueue('tasks');
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function changedDerivedDataFields(EventObject $object): array
+    {
+        return array_values(array_filter(
+            self::DERIVED_DATA_FIELDS,
+            fn (string $field) => $object->wasChanged($field),
+        ));
     }
 }

--- a/app/Observers/EventObserver.php
+++ b/app/Observers/EventObserver.php
@@ -2,10 +2,23 @@
 
 namespace App\Observers;
 
+use App\Jobs\TaskPipeline\ProcessTaskPipelineJob;
 use App\Models\Event;
 
 class EventObserver
 {
+    private const DERIVED_DATA_FIELDS = [
+        'time',
+        'service',
+        'domain',
+        'action',
+        'value',
+        'value_multiplier',
+        'value_unit',
+        'actor_id',
+        'target_id',
+    ];
+
     /**
      * Handle the Event "created" event.
      */
@@ -20,7 +33,32 @@ class EventObserver
      */
     public function updated(Event $event): void
     {
-        // Embedding regeneration on updates is now handled by TaskPipeline
-        // See GenerateEmbeddingTask in app/Jobs/TaskPipeline/Tasks/
+        if (! config('app.enable_task_pipeline', true)) {
+            return;
+        }
+
+        $changedFields = $this->changedDerivedDataFields($event);
+
+        if ($changedFields === []) {
+            return;
+        }
+
+        ProcessTaskPipelineJob::dispatch(
+            model: $event,
+            trigger: 'updated',
+            force: true,
+            changedFields: $changedFields,
+        )->onQueue('tasks');
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private function changedDerivedDataFields(Event $event): array
+    {
+        return array_values(array_filter(
+            self::DERIVED_DATA_FIELDS,
+            fn (string $field) => $event->wasChanged($field),
+        ));
     }
 }

--- a/app/Providers/TaskPipelineServiceProvider.php
+++ b/app/Providers/TaskPipelineServiceProvider.php
@@ -282,8 +282,8 @@ class TaskPipelineServiceProvider extends ServiceProvider
             }
 
             // Convert file path to class name
-            $relativePath = str_replace($integrationPath.'/', '', $file->getPathname());
-            $className = 'App\\Integrations\\'.str_replace(
+            $relativePath = str_replace($integrationPath . '/', '', $file->getPathname());
+            $className = 'App\\Integrations\\' . str_replace(
                 ['/', '.php'],
                 ['\\', ''],
                 $relativePath

--- a/app/Providers/TaskPipelineServiceProvider.php
+++ b/app/Providers/TaskPipelineServiceProvider.php
@@ -38,6 +38,11 @@ class TaskPipelineServiceProvider extends ServiceProvider
     {
         $this->registerCoreTasks();
         $this->registerPluginTasks();
+
+        // Fail fast if any task declares a dependency that was never registered.
+        // This runs on every boot so misconfigured deps are caught immediately
+        // rather than surfacing as silent no-ops or runtime exceptions.
+        TaskRegistry::validateDependencies();
     }
 
     /**
@@ -277,8 +282,8 @@ class TaskPipelineServiceProvider extends ServiceProvider
             }
 
             // Convert file path to class name
-            $relativePath = str_replace($integrationPath . '/', '', $file->getPathname());
-            $className = 'App\\Integrations\\' . str_replace(
+            $relativePath = str_replace($integrationPath.'/', '', $file->getPathname());
+            $className = 'App\\Integrations\\'.str_replace(
                 ['/', '.php'],
                 ['\\', ''],
                 $relativePath

--- a/app/Services/DaySummaryService.php
+++ b/app/Services/DaySummaryService.php
@@ -559,7 +559,7 @@ class DaySummaryService
                 if ($summary) {
                     $content = $summary->getContent();
                     $bookmark['summary'] = mb_strlen($content, 'UTF-8') > 300
-                        ? mb_substr($content, 0, 300, 'UTF-8').'...'
+                        ? mb_substr($content, 0, 300, 'UTF-8') . '...'
                         : $content;
                 }
 

--- a/app/Services/DaySummaryService.php
+++ b/app/Services/DaySummaryService.php
@@ -692,16 +692,6 @@ class DaySummaryService
             ->with('metricStatistic')
             ->get();
 
-        // Also respect suppress_until
-        $trends = $trends->filter(function ($trend) {
-            $suppressUntil = $trend->metadata['suppress_until'] ?? null;
-            if ($suppressUntil && Carbon::parse($suppressUntil)->isFuture()) {
-                return false;
-            }
-
-            return true;
-        });
-
         return $trends->map(function ($trend) {
             $stat = $trend->metricStatistic;
 

--- a/app/Services/DaySummaryService.php
+++ b/app/Services/DaySummaryService.php
@@ -559,7 +559,7 @@ class DaySummaryService
                 if ($summary) {
                     $content = $summary->getContent();
                     $bookmark['summary'] = mb_strlen($content, 'UTF-8') > 300
-                        ? mb_substr($content, 0, 300, 'UTF-8') . '...'
+                        ? mb_substr($content, 0, 300, 'UTF-8').'...'
                         : $content;
                 }
 
@@ -691,6 +691,17 @@ class DaySummaryService
             ->whereDate('detected_at', $date)
             ->with('metricStatistic')
             ->get();
+
+        $trends = $trends->filter(function ($trend) {
+            $stat = $trend->metricStatistic;
+            if (! $stat) {
+                return true;
+            }
+
+            $suppressionColumn = $trend->type === 'anomaly_high' ? 'anomaly_high_suppressed_until' : 'anomaly_low_suppressed_until';
+
+            return ! ($stat->{$suppressionColumn} && now()->isBefore($stat->{$suppressionColumn}));
+        });
 
         return $trends->map(function ($trend) {
             $stat = $trend->metricStatistic;

--- a/app/Services/EmbeddingService.php
+++ b/app/Services/EmbeddingService.php
@@ -87,6 +87,24 @@ class EmbeddingService
     }
 
     /**
+     * Check whether an embedding vector contains only zeros.
+     */
+    public static function isZeroVector(array $embedding): bool
+    {
+        if ($embedding === []) {
+            return false;
+        }
+
+        foreach ($embedding as $value) {
+            if ((float) $value != 0.0) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
      * Get metadata about the embedding configuration
      */
     public function getEmbeddingMetadata(): array
@@ -110,8 +128,7 @@ class EmbeddingService
     public function embed(string $text, bool $useCache = true): array
     {
         if (empty(trim($text))) {
-            // Return zero vector for empty text
-            return array_fill(0, $this->dimensions, 0.0);
+            throw new Exception('Cannot generate embedding for empty text');
         }
 
         // Use cache to avoid redundant API calls for the same text
@@ -120,17 +137,27 @@ class EmbeddingService
             $cached = Cache::get($cacheKey);
 
             if ($cached !== null) {
-                return $cached;
+                try {
+                    return $this->validateEmbedding($cached);
+                } catch (Exception) {
+                    Cache::forget($cacheKey);
+                }
             }
         }
 
         $embeddings = $this->embedBatch([$text]);
 
-        if ($useCache && ! empty($embeddings)) {
-            Cache::put('embedding:' . md5($text), $embeddings[0], now()->addDays(30));
+        if (! isset($embeddings[0])) {
+            throw new Exception('OpenAI API returned no embedding data');
         }
 
-        return $embeddings[0] ?? array_fill(0, $this->dimensions, 0.0);
+        $embedding = $this->validateEmbedding($embeddings[0]);
+
+        if ($useCache) {
+            Cache::put('embedding:' . md5($text), $embedding, now()->addDays(30));
+        }
+
+        return $embedding;
     }
 
     /**
@@ -147,16 +174,14 @@ class EmbeddingService
             return [];
         }
 
-        // Filter out empty strings
-        $nonEmptyTexts = array_filter($texts, fn ($text) => ! empty(trim($text)));
-
-        if (empty($nonEmptyTexts)) {
-            // Return zero vectors for all texts
-            return array_fill(0, count($texts), array_fill(0, $this->dimensions, 0.0));
+        foreach ($texts as $index => $text) {
+            if (empty(trim($text))) {
+                throw new Exception("Cannot generate embedding for empty text at index {$index}");
+            }
         }
 
         // Truncate texts to avoid token limits (8191 tokens for text-embedding-3-small)
-        $truncatedTexts = array_map(fn ($text) => $this->truncateText($text), $nonEmptyTexts);
+        $truncatedTexts = array_map(fn ($text) => $this->truncateText($text), $texts);
 
         try {
             $headers = [
@@ -191,21 +216,51 @@ class EmbeddingService
                 throw new Exception('Invalid response from OpenAI API');
             }
 
-            // Extract embeddings from response
-            $embeddings = array_map(function ($item) {
-                return $item['embedding'] ?? array_fill(0, $this->dimensions, 0.0);
-            }, $data['data']);
+            if (count($data['data']) !== count($texts)) {
+                throw new Exception('OpenAI API returned an unexpected number of embeddings');
+            }
 
-            return $embeddings;
+            return array_map(function ($item, $index) {
+                if (! isset($item['embedding']) || ! is_array($item['embedding'])) {
+                    throw new Exception("OpenAI API response missing embedding at index {$index}");
+                }
+
+                return $this->validateEmbedding($item['embedding']);
+            }, $data['data'], array_keys($data['data']));
         } catch (Exception $e) {
             Log::error('Failed to generate embeddings', [
                 'error' => $e->getMessage(),
                 'texts_count' => count($texts),
             ]);
 
-            // Return zero vectors as fallback
-            return array_fill(0, count($texts), array_fill(0, $this->dimensions, 0.0));
+            throw $e;
         }
+    }
+
+    /**
+     * Validate a provider/cached embedding before it can be stored or reused.
+     */
+    private function validateEmbedding(array $embedding): array
+    {
+        if (count($embedding) !== $this->dimensions) {
+            throw new Exception("Embedding vector has invalid dimensions: expected {$this->dimensions}, got " . count($embedding));
+        }
+
+        $normalized = [];
+
+        foreach ($embedding as $index => $value) {
+            if (! is_numeric($value)) {
+                throw new Exception("Embedding vector contains a non-numeric value at index {$index}");
+            }
+
+            $normalized[] = (float) $value;
+        }
+
+        if (self::isZeroVector($normalized)) {
+            throw new Exception('Embedding provider returned a zero vector');
+        }
+
+        return $normalized;
     }
 
     /**

--- a/app/Services/Knowledge/KnowledgeReprocessingService.php
+++ b/app/Services/Knowledge/KnowledgeReprocessingService.php
@@ -2,11 +2,8 @@
 
 namespace App\Services\Knowledge;
 
-use App\Jobs\Data\Fetch\ExtractContentJob;
-use App\Jobs\Data\Fetch\GenerateSummariesJob;
-use App\Jobs\Data\Newsletter\ExtractNewsletterContentJob;
-use App\Jobs\Data\Newsletter\GenerateNewsletterSummariesJob;
 use App\Jobs\Fetch\FetchSingleUrl;
+use App\Jobs\TaskPipeline\ProcessTaskPipelineJob;
 use App\Models\Event;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
@@ -138,24 +135,16 @@ class KnowledgeReprocessingService
             return;
         }
 
-        $extracted = $this->buildFetchExtractedPayload($event);
-
-        if ($mode === self::MODE_AUTO && ! empty($extracted['text_content'])) {
-            ExtractContentJob::dispatch($event->integration, $event, $webpage, $extracted);
-
-            return;
-        }
-
-        if (empty($webpage->content)) {
+        if ($mode === self::MODE_SUMMARY_ONLY && empty($webpage->content)) {
             throw new InvalidArgumentException('Fetch webpage has no extracted content to summarize.');
         }
 
-        GenerateSummariesJob::dispatch(
-            $event->integration,
-            $event,
-            $webpage,
-            $extracted,
-            $webpage->content,
+        ProcessTaskPipelineJob::dispatch(
+            model: $event,
+            trigger: 'manual',
+            taskFilter: $mode === self::MODE_AUTO
+                ? ['fetch_extract_content', 'fetch_generate_summaries']
+                : ['fetch_generate_summaries'],
         );
     }
 
@@ -171,45 +160,17 @@ class KnowledgeReprocessingService
             throw new InvalidArgumentException('Newsletter event does not have a publication target.');
         }
 
-        $rawHtml = $event->event_metadata['raw_html'] ?? null;
-
-        if ($mode === self::MODE_AUTO && is_string($rawHtml) && $rawHtml !== '') {
-            ExtractNewsletterContentJob::dispatch($event->integration, $event, $publication, $rawHtml);
-
-            return;
-        }
-
-        if (empty($publication->content)) {
+        if ($mode === self::MODE_SUMMARY_ONLY && empty($publication->content)) {
             throw new InvalidArgumentException('Newsletter event has no extracted content to summarize.');
         }
 
-        GenerateNewsletterSummariesJob::dispatch(
-            $event->integration,
-            $event,
-            $publication,
-            $publication->content,
+        ProcessTaskPipelineJob::dispatch(
+            model: $event,
+            trigger: 'manual',
+            taskFilter: $mode === self::MODE_AUTO
+                ? ['newsletter_extract_content', 'newsletter_generate_summaries']
+                : ['newsletter_generate_summaries'],
         );
-    }
-
-    /**
-     * @return array{title: string, content: string, text_content: string, excerpt: string, author: ?string, image: ?string, direction: string}
-     */
-    private function buildFetchExtractedPayload(Event $event): array
-    {
-        $webpage = $event->target;
-        $contentBlock = $event->blocks->firstWhere('block_type', 'fetch_content');
-        $blockMetadata = $contentBlock?->metadata ?? [];
-        $webpageMetadata = $webpage?->metadata ?? [];
-
-        return [
-            'title' => $webpage?->title ?: ($event->event_metadata['title'] ?? 'Untitled'),
-            'content' => (string) ($blockMetadata['html'] ?? $webpage?->content ?? ''),
-            'text_content' => (string) ($blockMetadata['text'] ?? ''),
-            'excerpt' => (string) ($blockMetadata['excerpt'] ?? $webpage?->content ?? ''),
-            'author' => $webpageMetadata['author'] ?? null,
-            'image' => $webpageMetadata['image_url'] ?? $webpage?->media_url,
-            'direction' => $webpageMetadata['direction'] ?? 'ltr',
-        ];
     }
 
     private function whereUsableTldrBlock(Builder $query, string $blockType): void

--- a/app/Services/Mobile/AnomalyAcknowledgement.php
+++ b/app/Services/Mobile/AnomalyAcknowledgement.php
@@ -4,6 +4,7 @@ namespace App\Services\Mobile;
 
 use App\Models\MetricTrend;
 use App\Models\User;
+use Carbon\Carbon;
 
 /**
  * Acknowledges a single MetricTrend anomaly on behalf of a user. Used both by
@@ -40,6 +41,38 @@ class AnomalyAcknowledgement
 
         $anomaly->save();
 
+        $this->propagateSuppression($anomaly, $metadata);
+
         return true;
+    }
+
+    /**
+     * When suppress_until is provided, write it to the directional suppression
+     * column on MetricStatistic so detection jobs can skip record creation.
+     */
+    private function propagateSuppression(MetricTrend $anomaly, array $metadata): void
+    {
+        $suppressUntil = $metadata['suppress_until'] ?? null;
+
+        if (! $suppressUntil || ! in_array($anomaly->type, ['anomaly_high', 'anomaly_low'], true)) {
+            return;
+        }
+
+        $statistic = $anomaly->metricStatistic;
+        if (! $statistic) {
+            return;
+        }
+
+        $suppressDate = Carbon::parse($suppressUntil)->endOfDay();
+
+        $column = $anomaly->type === 'anomaly_high'
+            ? 'anomaly_high_suppressed_until'
+            : 'anomaly_low_suppressed_until';
+
+        // Take the later of any existing suppression and the new one.
+        $existing = $statistic->{$column};
+        if ($existing === null || $suppressDate->isAfter($existing)) {
+            $statistic->update([$column => $suppressDate]);
+        }
     }
 }

--- a/app/Services/TaskPipeline/Exceptions/UnresolvableDependencyException.php
+++ b/app/Services/TaskPipeline/Exceptions/UnresolvableDependencyException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Services\TaskPipeline\Exceptions;
+
+use Exception;
+
+class UnresolvableDependencyException extends Exception
+{
+    //
+}

--- a/app/Services/TaskPipeline/TaskExecutionStore.php
+++ b/app/Services/TaskPipeline/TaskExecutionStore.php
@@ -1,0 +1,290 @@
+<?php
+
+namespace App\Services\TaskPipeline;
+
+use App\Models\Block;
+use App\Models\Event;
+use App\Models\EventObject;
+use App\Models\Integration;
+use App\Models\TaskExecution;
+use Carbon\CarbonInterface;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Schema;
+use InvalidArgumentException;
+
+class TaskExecutionStore
+{
+    /**
+     * @return array<string, array{last_attempt?: array<string, mixed>, last_success?: array<string, mixed>}>
+     */
+    public function getTaskExecutions(Model $model): array
+    {
+        $legacy = $this->getLegacyTaskExecutions($model);
+
+        if (! $model->exists || ! Schema::hasTable('task_executions')) {
+            return $legacy;
+        }
+
+        $rows = TaskExecution::query()
+            ->forEntity($this->entityType($model), (string) $model->getKey())
+            ->get();
+
+        if ($rows->isEmpty()) {
+            return $legacy;
+        }
+
+        $fromTable = $rows
+            ->mapWithKeys(fn (TaskExecution $execution) => [
+                $execution->task_key => $this->legacyShapeFromRow($execution),
+            ])
+            ->all();
+
+        return array_replace($legacy, $fromTable);
+    }
+
+    public function getLegacyTaskExecutions(Model $model): array
+    {
+        $field = $this->metadataField($model);
+        $metadata = $model->$field ?? [];
+
+        return is_array($metadata) ? ($metadata['task_executions'] ?? []) : [];
+    }
+
+    public function setTaskExecutions(Model $model, array $executions, bool $force = true): void
+    {
+        foreach ($executions as $taskKey => $execution) {
+            if (! is_string($taskKey) || ! is_array($execution)) {
+                continue;
+            }
+
+            $lastAttempt = $execution['last_attempt'] ?? null;
+            if (! is_array($lastAttempt) || empty($lastAttempt['status'])) {
+                continue;
+            }
+
+            $this->upsertFromLegacy($model, $taskKey, $execution, $force);
+        }
+
+        $this->mirrorLegacyTaskExecutions($model, $executions);
+    }
+
+    public function recordStatus(
+        Model $model,
+        TaskDefinition $task,
+        string $status,
+        array $data = [],
+        ?object $jobContext = null,
+        bool $mergeLastAttempt = true,
+    ): array {
+        $executions = $this->getTaskExecutions($model);
+
+        $executionData = array_merge($data, [
+            'status' => $status,
+        ], $this->queueContext($task, $jobContext));
+
+        $lastAttempt = $mergeLastAttempt
+            ? array_merge($executions[$task->key]['last_attempt'] ?? [], $executionData)
+            : $executionData;
+
+        $executions[$task->key]['last_attempt'] = $lastAttempt;
+
+        if ($status === 'success') {
+            $executions[$task->key]['last_success'] = $lastAttempt;
+        }
+
+        $this->upsertFromLegacy($model, $task->key, $executions[$task->key], true, $task, $this->isTerminalStatus($status));
+        $this->mirrorLegacyTaskExecutions($model, $executions);
+
+        return $executions[$task->key];
+    }
+
+    public function upsertFromLegacy(
+        Model $model,
+        string $taskKey,
+        array $legacyExecution,
+        bool $force = false,
+        ?TaskDefinition $task = null,
+        bool $appendHistory = false,
+    ): ?TaskExecution {
+        if (! $model->exists || ! Schema::hasTable('task_executions')) {
+            return null;
+        }
+
+        $lastAttempt = $legacyExecution['last_attempt'] ?? null;
+        if (! is_array($lastAttempt) || empty($lastAttempt['status'])) {
+            return null;
+        }
+
+        $execution = TaskExecution::firstOrNew([
+            'entity_type' => $this->entityType($model),
+            'entity_id' => (string) $model->getKey(),
+            'task_key' => $taskKey,
+        ]);
+
+        if ($execution->exists && ! $force) {
+            return $execution;
+        }
+
+        $lastSuccess = $legacyExecution['last_success'] ?? null;
+        $history = $execution->history ?? [];
+        if ($appendHistory) {
+            $history[] = $this->historySnapshot($taskKey, $lastAttempt);
+        }
+
+        $execution->fill([
+            'user_id' => $this->resolveUserId($model),
+            'task_name' => $task?->name ?? TaskRegistry::getTask($taskKey)?->name ?? $taskKey,
+            'status' => (string) $lastAttempt['status'],
+            'attempts' => (int) ($lastAttempt['attempts'] ?? $execution->attempts ?? 0),
+            'triggered_by' => $lastAttempt['triggered_by'] ?? null,
+            'started_at' => $this->dateOrNull($lastAttempt['started_at'] ?? null),
+            'completed_at' => $this->dateOrNull($lastAttempt['completed_at'] ?? null),
+            'queue' => $lastAttempt['queue'] ?? $task?->queue,
+            'queue_connection' => $lastAttempt['queue_connection'] ?? null,
+            'job_id' => $lastAttempt['job_id'] ?? null,
+            'error' => $lastAttempt['error'] ?? null,
+            'waiting_for' => $lastAttempt['waiting_for'] ?? null,
+            'blocked_by' => $lastAttempt['blocked_by'] ?? null,
+            'changed_fields' => $lastAttempt['changed_fields'] ?? null,
+            'history' => $history,
+            'last_success' => is_array($lastSuccess) ? $lastSuccess : null,
+        ]);
+
+        $execution->save();
+
+        return $execution;
+    }
+
+    public function mirrorLegacyTaskExecutions(Model $model, array $executions): void
+    {
+        $field = $this->metadataField($model);
+        $metadata = $model->$field ?? [];
+        $metadata = is_array($metadata) ? $metadata : [];
+        $metadata['task_executions'] = $executions;
+
+        if (! $model->exists) {
+            $model->$field = $metadata;
+
+            return;
+        }
+
+        $model->withoutEvents(function () use ($model, $field, $metadata): void {
+            $model->newQueryWithoutScopes()
+                ->whereKey($model->getKey())
+                ->update([$field => $metadata]);
+        });
+
+        $model->$field = $metadata;
+        $model->syncOriginalAttribute($field);
+    }
+
+    public function metadataField(Model $model): string
+    {
+        return match (true) {
+            $model instanceof Event => 'event_metadata',
+            $model instanceof Integration => 'configuration',
+            $model instanceof Block, $model instanceof EventObject => 'metadata',
+            default => throw new InvalidArgumentException('Unsupported task execution model: ' . get_class($model)),
+        };
+    }
+
+    public function entityType(Model $model): string
+    {
+        return match (true) {
+            $model instanceof Event => 'event',
+            $model instanceof Block => 'block',
+            $model instanceof EventObject => 'object',
+            $model instanceof Integration => 'integration',
+            default => throw new InvalidArgumentException('Unsupported task execution model: ' . get_class($model)),
+        };
+    }
+
+    public function resolveUserId(Model $model): ?string
+    {
+        if ($model instanceof Integration || $model instanceof EventObject) {
+            return $model->user_id;
+        }
+
+        if ($model instanceof Event) {
+            return $model->integration?->user_id;
+        }
+
+        if ($model instanceof Block) {
+            return $model->event?->integration?->user_id;
+        }
+
+        return null;
+    }
+
+    protected function legacyShapeFromRow(TaskExecution $execution): array
+    {
+        $lastAttempt = array_filter([
+            'status' => $execution->status,
+            'attempts' => $execution->attempts,
+            'triggered_by' => $execution->triggered_by,
+            'started_at' => $execution->started_at?->toIso8601String(),
+            'completed_at' => $execution->completed_at?->toIso8601String(),
+            'queue' => $execution->queue,
+            'queue_connection' => $execution->queue_connection,
+            'job_id' => $execution->job_id,
+            'error' => $execution->error,
+            'waiting_for' => $execution->waiting_for,
+            'blocked_by' => $execution->blocked_by,
+            'changed_fields' => $execution->changed_fields,
+        ], fn (mixed $value) => $value !== null);
+
+        $shape = ['last_attempt' => $lastAttempt];
+
+        if (is_array($execution->last_success)) {
+            $shape['last_success'] = $execution->last_success;
+        }
+
+        return $shape;
+    }
+
+    protected function queueContext(TaskDefinition $task, ?object $jobContext): array
+    {
+        $context = ['queue' => $task->queue];
+
+        if (! $jobContext || ! property_exists($jobContext, 'job') || ! $jobContext->job) {
+            return $context;
+        }
+
+        $job = $jobContext->job;
+        $context['job_id'] = method_exists($job, 'getJobId') ? $job->getJobId() : null;
+        $context['queue_connection'] = method_exists($job, 'getConnectionName') ? $job->getConnectionName() : null;
+        $context['queue'] = method_exists($job, 'getQueue') ? ($job->getQueue() ?? $task->queue) : $task->queue;
+
+        return array_filter($context, fn (mixed $value) => $value !== null);
+    }
+
+    protected function historySnapshot(string $taskKey, array $lastAttempt): array
+    {
+        return [
+            'task_key' => $taskKey,
+            'status' => $lastAttempt['status'] ?? null,
+            'attempts' => $lastAttempt['attempts'] ?? null,
+            'started_at' => $lastAttempt['started_at'] ?? null,
+            'completed_at' => $lastAttempt['completed_at'] ?? now()->toIso8601String(),
+            'triggered_by' => $lastAttempt['triggered_by'] ?? null,
+            'error' => Arr::get($lastAttempt, 'error'),
+            'waiting_for' => Arr::get($lastAttempt, 'waiting_for'),
+            'blocked_by' => Arr::get($lastAttempt, 'blocked_by'),
+        ];
+    }
+
+    protected function isTerminalStatus(string $status): bool
+    {
+        return in_array($status, ['success', 'failed', 'blocked', 'not_applicable'], true);
+    }
+
+    protected function dateOrNull(mixed $value): mixed
+    {
+        if ($value instanceof CarbonInterface) {
+            return $value;
+        }
+
+        return $value ?: null;
+    }
+}

--- a/app/Services/TaskPipeline/TaskRegistry.php
+++ b/app/Services/TaskPipeline/TaskRegistry.php
@@ -82,7 +82,7 @@ class TaskRegistry
             if ($resolved->isEmpty() && $remaining->isNotEmpty()) {
                 // Circular dependency detected
                 throw new CircularDependencyException(
-                    'Circular dependency detected in tasks: '.$remaining->pluck('key')->join(', ')
+                    'Circular dependency detected in tasks: ' . $remaining->pluck('key')->join(', ')
                 );
             }
 
@@ -116,7 +116,7 @@ class TaskRegistry
 
         if (! empty($errors)) {
             throw new UnresolvableDependencyException(
-                "Task dependency validation failed:\n".implode("\n", $errors)
+                "Task dependency validation failed:\n" . implode("\n", $errors)
             );
         }
     }

--- a/app/Services/TaskPipeline/TaskRegistry.php
+++ b/app/Services/TaskPipeline/TaskRegistry.php
@@ -3,6 +3,7 @@
 namespace App\Services\TaskPipeline;
 
 use App\Services\TaskPipeline\Exceptions\CircularDependencyException;
+use App\Services\TaskPipeline\Exceptions\UnresolvableDependencyException;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
 
@@ -67,19 +68,21 @@ class TaskRegistry
     {
         $ordered = collect();
         $remaining = $tasks->keyBy('key');
+        // Keys present in the input batch — deps NOT in this set are externally satisfied
+        $inputKeys = $remaining->keys()->all();
 
         while ($remaining->isNotEmpty()) {
             // Find tasks whose dependencies are all satisfied
-            $resolved = $remaining->filter(function ($task) use ($ordered) {
-                // All dependencies already in ordered list?
+            $resolved = $remaining->filter(function ($task) use ($ordered, $inputKeys) {
+                // A dependency is satisfied if it's already ordered OR it's not in this batch
                 return collect($task->dependencies)
-                    ->every(fn ($dep) => $ordered->has($dep));
+                    ->every(fn ($dep) => $ordered->has($dep) || ! in_array($dep, $inputKeys, true));
             });
 
             if ($resolved->isEmpty() && $remaining->isNotEmpty()) {
                 // Circular dependency detected
                 throw new CircularDependencyException(
-                    'Circular dependency detected in tasks: ' . $remaining->pluck('key')->join(', ')
+                    'Circular dependency detected in tasks: '.$remaining->pluck('key')->join(', ')
                 );
             }
 
@@ -88,6 +91,34 @@ class TaskRegistry
         }
 
         return $ordered;
+    }
+
+    /**
+     * Validate that all declared dependencies exist in the registry.
+     *
+     * Call once after all tasks have been registered (e.g. end of ServiceProvider::boot).
+     * Throws UnresolvableDependencyException listing every missing dep, so one boot-time
+     * failure surfaces all misconfigured tasks at once rather than failing silently at runtime.
+     *
+     * @throws UnresolvableDependencyException
+     */
+    public static function validateDependencies(): void
+    {
+        $errors = [];
+
+        foreach (static::$tasks as $task) {
+            foreach ($task->dependencies as $dep) {
+                if (! isset(static::$tasks[$dep])) {
+                    $errors[] = "Task '{$task->key}' declares dependency '{$dep}' which is not registered.";
+                }
+            }
+        }
+
+        if (! empty($errors)) {
+            throw new UnresolvableDependencyException(
+                "Task dependency validation failed:\n".implode("\n", $errors)
+            );
+        }
     }
 
     /**

--- a/app/Services/TaskPipeline/TaskRegistry.php
+++ b/app/Services/TaskPipeline/TaskRegistry.php
@@ -60,6 +60,20 @@ class TaskRegistry
     }
 
     /**
+     * Get the keys for tasks that directly depend on the given task.
+     *
+     * @return array<int, string>
+     */
+    public static function getDependentTaskKeys(string $taskKey): array
+    {
+        return collect(static::$tasks)
+            ->filter(fn (TaskDefinition $task) => in_array($taskKey, $task->dependencies, true))
+            ->keys()
+            ->values()
+            ->all();
+    }
+
+    /**
      * Resolve the execution order based on task dependencies
      *
      * @throws CircularDependencyException

--- a/config/app.php
+++ b/config/app.php
@@ -123,10 +123,33 @@ return [
         'store' => env('APP_MAINTENANCE_STORE', 'database'),
     ],
 
-    // Whitelist of allowed artisan task commands for Task plugin execution (comma-separated in env)
+    /*
+     * Whitelist of job classes that RunIntegrationTask may dispatch.
+     *
+     * Validation is ALWAYS enforced — this list is the source of truth.
+     * Add new classes here when creating new Outline/Task presets, or extend
+     * via the ALLOWED_TASK_JOBS env var (comma-separated FQCNs) for runtime overrides.
+     *
+     * Known usages:
+     *   OutlinePlugin 'pin_today' preset     → PinTodayDayNote
+     *   OutlinePlugin 'generate_year' preset → GenerateDayNotes
+     */
+    'allowed_task_jobs' => array_merge(
+        [
+            'App\\Jobs\\Outline\\PinTodayDayNote',
+            'App\\Jobs\\Outline\\GenerateDayNotes',
+        ],
+        env('ALLOWED_TASK_JOBS') ? explode(',', env('ALLOWED_TASK_JOBS')) : []
+    ),
+
+    /*
+     * Whitelist of Artisan commands that RunIntegrationTask may invoke.
+     *
+     * null = no restriction (allow any command). Set ALLOWED_TASK_COMMANDS to a
+     * comma-separated list to lock this down for production hardening.
+     * Example: ALLOWED_TASK_COMMANDS=queue:prune-batches,horizon:snapshot
+     */
     'allowed_task_commands' => env('ALLOWED_TASK_COMMANDS') ? explode(',', env('ALLOWED_TASK_COMMANDS')) : null,
-    // Whitelist of allowed job classes for Task plugin execution (comma-separated FQCNs)
-    'allowed_task_jobs' => env('ALLOWED_TASK_JOBS') ? explode(',', env('ALLOWED_TASK_JOBS')) : null,
 
     // Enable/disable TaskPipeline job dispatch (disabled in testing by default to improve performance)
     'enable_task_pipeline' => env('ENABLE_TASK_PIPELINE', true),

--- a/database/factories/MetricStatisticFactory.php
+++ b/database/factories/MetricStatisticFactory.php
@@ -36,6 +36,10 @@ class MetricStatisticFactory extends Factory
             'normal_lower_bound' => $mean - (2 * $stddev),
             'normal_upper_bound' => $mean + (2 * $stddev),
             'last_calculated_at' => now(),
+            'baseline_window_days' => MetricStatistic::DEFAULT_WINDOW_DAYS,
+            'baseline_reset_suggested_at' => null,
+            'anomaly_high_suppressed_until' => null,
+            'anomaly_low_suppressed_until' => null,
         ];
     }
 }

--- a/database/factories/TaskExecutionFactory.php
+++ b/database/factories/TaskExecutionFactory.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Event;
+use App\Models\TaskExecution;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class TaskExecutionFactory extends Factory
+{
+    protected $model = TaskExecution::class;
+
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'entity_type' => 'event',
+            'entity_id' => Event::factory(),
+            'task_key' => $this->faker->slug(2),
+            'task_name' => $this->faker->words(3, true),
+            'status' => $this->faker->randomElement(['pending', 'running', 'success', 'failed']),
+            'attempts' => 1,
+            'triggered_by' => 'created',
+            'started_at' => now(),
+            'completed_at' => null,
+            'queue' => 'tasks',
+            'queue_connection' => null,
+            'job_id' => null,
+            'error' => null,
+            'waiting_for' => null,
+            'blocked_by' => null,
+            'changed_fields' => null,
+            'history' => [],
+            'last_success' => null,
+        ];
+    }
+}

--- a/database/migrations/2026_05_23_000001_create_task_executions_table.php
+++ b/database/migrations/2026_05_23_000001_create_task_executions_table.php
@@ -1,0 +1,47 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('task_executions', function (Blueprint $table) {
+            $table->uuid('id')->primary()->default(DB::raw('gen_random_uuid()'));
+            $table->foreignUuid('user_id')->nullable()->constrained()->nullOnDelete();
+            $table->string('entity_type', 32);
+            $table->uuid('entity_id');
+            $table->string('task_key');
+            $table->string('task_name')->nullable();
+            $table->string('status', 32);
+            $table->unsignedInteger('attempts')->default(0);
+            $table->string('triggered_by')->nullable();
+            $table->timestampTz('started_at')->nullable();
+            $table->timestampTz('completed_at')->nullable();
+            $table->string('queue')->nullable();
+            $table->string('queue_connection')->nullable();
+            $table->string('job_id')->nullable();
+            $table->text('error')->nullable();
+            $table->string('waiting_for')->nullable();
+            $table->string('blocked_by')->nullable();
+            $table->jsonb('changed_fields')->nullable();
+            $table->jsonb('history')->nullable();
+            $table->jsonb('last_success')->nullable();
+            $table->timestampsTz();
+
+            $table->unique(['entity_type', 'entity_id', 'task_key']);
+            $table->index(['user_id', 'status', 'updated_at']);
+            $table->index(['user_id', 'task_key', 'status']);
+            $table->index(['entity_type', 'entity_id']);
+            $table->index('job_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('task_executions');
+    }
+};

--- a/database/migrations/2026_05_25_081338_add_baseline_window_days_to_metric_statistics.php
+++ b/database/migrations/2026_05_25_081338_add_baseline_window_days_to_metric_statistics.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('metric_statistics', function (Blueprint $table) {
+            $table->integer('baseline_window_days')->nullable()->default(90)->after('last_calculated_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('metric_statistics', function (Blueprint $table) {
+            $table->dropColumn('baseline_window_days');
+        });
+    }
+};

--- a/database/migrations/2026_05_25_143301_add_baseline_reset_suggested_at_to_metric_statistics.php
+++ b/database/migrations/2026_05_25_143301_add_baseline_reset_suggested_at_to_metric_statistics.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('metric_statistics', function (Blueprint $table) {
+            $table->timestampTz('baseline_reset_suggested_at')->nullable()->after('baseline_window_days');
+        });
+
+        // Backfill: set flag on any existing metric_statistic that already has
+        // unacknowledged monthly or quarterly trend records.
+        $prefix = DB::getTablePrefix();
+        $ms = $prefix . 'metric_statistics';
+        $mt = $prefix . 'metric_trends';
+
+        DB::statement(<<<SQL
+            UPDATE {$ms} ms
+            SET baseline_reset_suggested_at = (
+                SELECT MIN(mt.detected_at)
+                FROM {$mt} mt
+                WHERE mt.metric_statistic_id = ms.id
+                  AND mt.type IN (
+                      'trend_up_monthly', 'trend_down_monthly',
+                      'trend_up_quarterly', 'trend_down_quarterly'
+                  )
+                  AND mt.acknowledged_at IS NULL
+            )
+            WHERE EXISTS (
+                SELECT 1 FROM {$mt} mt
+                WHERE mt.metric_statistic_id = ms.id
+                  AND mt.type IN (
+                      'trend_up_monthly', 'trend_down_monthly',
+                      'trend_up_quarterly', 'trend_down_quarterly'
+                  )
+                  AND mt.acknowledged_at IS NULL
+            )
+        SQL);
+    }
+
+    public function down(): void
+    {
+        Schema::table('metric_statistics', function (Blueprint $table) {
+            $table->dropColumn('baseline_reset_suggested_at');
+        });
+    }
+};

--- a/database/migrations/2026_05_25_153229_recalculate_metric_trend_significance_scores.php
+++ b/database/migrations/2026_05_25_153229_recalculate_metric_trend_significance_scores.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::table('metric_trends')
+            ->whereIn('type', ['anomaly_high', 'anomaly_low'])
+            ->whereNotNull('deviation')
+            ->update([
+                'significance_score' => DB::raw('tanh(deviation::double precision / 2)'),
+            ]);
+    }
+
+    public function down(): void
+    {
+        DB::table('metric_trends')
+            ->whereIn('type', ['anomaly_high', 'anomaly_low'])
+            ->whereNotNull('deviation')
+            ->update([
+                'significance_score' => DB::raw('LEAST(deviation::double precision / 2, 1.0)'),
+            ]);
+    }
+};

--- a/database/migrations/2026_05_25_191659_add_directional_suppression_to_metric_statistics.php
+++ b/database/migrations/2026_05_25_191659_add_directional_suppression_to_metric_statistics.php
@@ -1,0 +1,23 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('metric_statistics', function (Blueprint $table) {
+            $table->timestampTz('anomaly_high_suppressed_until')->nullable()->after('baseline_reset_suggested_at');
+            $table->timestampTz('anomaly_low_suppressed_until')->nullable()->after('anomaly_high_suppressed_until');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('metric_statistics', function (Blueprint $table) {
+            $table->dropColumn(['anomaly_high_suppressed_until', 'anomaly_low_suppressed_until']);
+        });
+    }
+};

--- a/docs/Architecture/TASK_PIPELINE.md
+++ b/docs/Architecture/TASK_PIPELINE.md
@@ -55,14 +55,16 @@ Event/Object/Block Created/Updated
 4. **BaseTaskJob** - Abstract base class for task implementations
 5. **InteractsWithTaskMetadata** - Trait for metadata field handling
 
-### Metadata Storage
+### Execution Storage
 
-Task executions are tracked in model metadata fields:
+Task executions are tracked in the `task_executions` table and mirrored to model metadata during the transition:
 
 - **Event**: Uses `event_metadata['task_executions']`
 - **Block**: Uses `metadata['task_executions']`
 - **EventObject**: Uses `metadata['task_executions']`
-- **Integration**: Uses `metadata['task_executions']`
+- **Integration**: Uses `configuration['task_executions']`
+
+The table is the source of truth for current state with one row per `entity_type`, `entity_id`, and `task_key`. `TaskExecutionStore` reads table rows first and falls back to legacy metadata for records that have not been backfilled yet.
 
 Structure:
 
@@ -157,6 +159,21 @@ php artisan task-pipeline:populate-initial-state --model=event
 
 # Limit for testing
 php artisan task-pipeline:populate-initial-state --limit=100
+```
+
+### Backfill Table-Backed Executions
+
+Backfill legacy metadata into `task_executions` using Redis migration workers:
+
+```bash
+# Count in-process only
+php artisan task-pipeline:migrate-executions --model=event --dry-run
+
+# Dispatch batched Redis migration jobs
+php artisan task-pipeline:migrate-executions --batch-size=500
+
+# Overwrite existing task_executions rows while rerunning
+php artisan task-pipeline:migrate-executions --force
 ```
 
 ### Re-run a Task

--- a/docs/Architecture/TASK_PIPELINE.md
+++ b/docs/Architecture/TASK_PIPELINE.md
@@ -539,6 +539,10 @@ public $tries = 3;               // 3 attempts
 public $backoff = [30, 120, 300]; // 30s, 2m, 5m
 ```
 
+Task jobs update metadata to `failed` and re-throw exceptions, so Laravel's queue worker can apply the retry policy. A failed task attempt is visible in the model's `task_executions` metadata with the exception message in `last_attempt.error`; only completed runs write `last_success`.
+
+`generate_embedding` has an additional provider-request retry inside `EmbeddingService`: the OpenAI embeddings HTTP request uses `retry(3, 1000)` after a 30 second timeout. If the provider still fails, returns malformed data, or returns an all-zero vector, the exception is allowed to fail the task. Zero vectors are not stored as successful embeddings.
+
 Override in your task:
 
 ```php

--- a/docs/Architecture/TASK_PIPELINE.md
+++ b/docs/Architecture/TASK_PIPELINE.md
@@ -111,7 +111,7 @@ A task definition specifies:
 
 ### Task Lifecycle
 
-1. **Registration** - Task registered in TaskPipelineServiceProvider
+1. **Registration** - Task registered in TaskPipelineServiceProvider; boot-time validation checks all declared deps exist
 2. **Trigger** - Event/model created/updated or scheduled
 3. **Dispatch** - ProcessTaskPipelineJob finds applicable tasks
 4. **Execution** - Tasks run in dependency order
@@ -129,8 +129,9 @@ dependencies: ['calculate_metric_stats', 'generate_embedding']
 The system ensures:
 
 - Dependencies run first
-- Circular dependencies are detected
+- Circular dependencies are detected and thrown at runtime (`CircularDependencyException`)
 - Order is deterministic
+- All declared dependencies are validated at boot time (`UnresolvableDependencyException` if a dep key is never registered)
 
 ## Getting Started
 
@@ -498,14 +499,35 @@ Horizon configuration (already set up):
 Configured in `routes/console.php`:
 
 ```php
-// Daily: Trend detection
+// Daily: Trend detection (dispatches DetectTrendsTask for recent events)
 Schedule::job(new DispatchTrendDetectionTasksJob)->daily();
 
-// Daily: Retrospective anomaly detection
+// Daily: Retrospective anomaly detection (re-processes yesterday's events)
 Schedule::job(new DispatchRetrospectiveAnomalyTasksJob)->daily();
 ```
 
-**Note:** Metric statistics calculation now runs automatically in the task pipeline on event creation and update, so no scheduled job is needed.
+**Note:** Metric statistics calculation runs automatically in the task pipeline on event creation and update — no scheduled job is needed. The old `CalculateMetricStatisticsJob`, `DetectMetricTrendsJob`, and `DetectRetrospectiveMetricAnomaliesJob` batch jobs remain available for manual dispatch via the UI but are no longer scheduled.
+
+### RunIntegrationTask Job Whitelist
+
+`RunIntegrationTask` (used by the `task` and `outline` integration plugins) can dispatch arbitrary job classes. The allowed list is **always enforced** — add new classes to `config/app.php` or extend via the `ALLOWED_TASK_JOBS` env var.
+
+```php
+// config/app.php
+'allowed_task_jobs' => array_merge(
+    [
+        'App\\Jobs\\Outline\\PinTodayDayNote',   // Outline 'pin_today' preset
+        'App\\Jobs\\Outline\\GenerateDayNotes',   // Outline 'generate_year' preset
+    ],
+    env('ALLOWED_TASK_JOBS') ? explode(',', env('ALLOWED_TASK_JOBS')) : []
+),
+```
+
+Artisan commands (`task_mode: artisan`) are unrestricted by default. Set `ALLOWED_TASK_COMMANDS` (comma-separated) to restrict them:
+
+```
+ALLOWED_TASK_COMMANDS=queue:prune-batches,horizon:snapshot
+```
 
 ### Task Retry Configuration
 
@@ -679,43 +701,6 @@ $this->model->withoutEvents(function() use ($data) {
 - Track queue depth in Horizon
 - Review task execution rates in admin UI
 - Set up alerts for high failure rates
-
-## Migration Guide
-
-### From Old System
-
-If migrating from scattered observers/listeners:
-
-1. **Identify existing tasks:**
-    - Search for Observer files
-    - Check AppServiceProvider boot listeners
-    - Review scheduled jobs
-
-2. **Create task jobs:**
-    - Move logic to task job classes
-    - Extend BaseTaskJob
-    - Keep existing functionality intact
-
-3. **Register tasks:**
-    - Add to TaskPipelineServiceProvider
-    - Define conditions and dependencies
-
-4. **Populate initial state:**
-
-    ```bash
-    php artisan task-pipeline:populate-initial-state --dry-run
-    php artisan task-pipeline:populate-initial-state
-    ```
-
-5. **Test in parallel:**
-    - Run both systems temporarily
-    - Compare results
-    - Verify execution tracking
-
-6. **Cutover:**
-    - Remove old observers
-    - Clean up listeners
-    - Monitor for issues
 
 ## Support
 

--- a/docs/Guides/aws-ses-receipt-setup.md
+++ b/docs/Guides/aws-ses-receipt-setup.md
@@ -169,7 +169,7 @@ Go to: https://console.aws.amazon.com/sns/v3/home?region=eu-west-1#/topics
 ### 3.3 Note the Topic ARN
 
 ```
-arn:aws:sns:eu-west-1:123456789012:receipt-emails-topic
+
 ```
 
 Save this for your `.env` file (`AWS_SNS_RECEIPT_TOPIC_ARN`).

--- a/resources/views/livewire/admin/task-pipeline-overview.blade.php
+++ b/resources/views/livewire/admin/task-pipeline-overview.blade.php
@@ -1,9 +1,8 @@
 <?php
 
 use App\Services\TaskPipeline\TaskRegistry;
+use App\Models\TaskExecution;
 use App\Models\Event;
-use App\Models\Block;
-use App\Models\EventObject;
 use Livewire\Volt\Component;
 
 new class extends Component {
@@ -37,64 +36,55 @@ new class extends Component {
 
     protected function getRecentFailures(): array
     {
-        $failures = [];
-        $since = now()->subDay();
-
-        // Check Events
-        foreach (Event::where('updated_at', '>=', $since)->get() as $event) {
-            $executions = $event->event_metadata['task_executions'] ?? [];
-            foreach ($executions as $taskKey => $execution) {
-                if (($execution['last_attempt']['status'] ?? null) === 'failed') {
-                    $failures[] = [
-                        'id' => $event->id . '-' . $taskKey,
-                        'task_name' => TaskRegistry::getTask($taskKey)?->name ?? $taskKey,
-                        'model_type' => 'Event',
-                        'model_id' => $event->id,
-                        'model_url' => route('events.show', $event), // Adjust route as needed
-                        'error' => $execution['last_attempt']['error'] ?? 'Unknown error',
-                        'failed_at' => $execution['last_attempt']['completed_at'] ?? null,
-                    ];
-                }
-            }
-        }
-
-        return collect($failures)->sortByDesc('failed_at')->take(10)->values()->toArray();
+        return TaskExecution::query()
+            ->where('status', 'failed')
+            ->where('updated_at', '>=', now()->subDay())
+            ->latest('updated_at')
+            ->take(10)
+            ->get()
+            ->map(fn(TaskExecution $execution) => [
+                'id' => $execution->id,
+                'task_name' => $execution->task_name ?? TaskRegistry::getTask($execution->task_key)?->name ?? $execution->task_key,
+                'model_type' => ucfirst($execution->entity_type),
+                'model_id' => $execution->entity_id,
+                'model_url' => $execution->entity_type === 'event' ? route('events.show', $execution->entity_id) : '#',
+                'error' => $execution->error ?? 'Unknown error',
+                'failed_at' => $execution->completed_at?->toIso8601String(),
+            ])
+            ->values()
+            ->toArray();
     }
 
     protected function getTaskStatistics(): array
     {
-        $pending = 0;
-        $failed = 0;
-        $success = 0;
         $since = now()->subDay();
 
-        // Count from Events
-        foreach (Event::where('updated_at', '>=', $since)->get() as $event) {
-            $executions = $event->event_metadata['task_executions'] ?? [];
-            foreach ($executions as $execution) {
-                $status = $execution['last_attempt']['status'] ?? null;
-                match($status) {
-                    'pending', 'running' => $pending++,
-                    'failed' => $failed++,
-                    'success' => $success++,
-                    default => null,
-                };
-            }
-        }
+        $counts = TaskExecution::query()
+            ->where('updated_at', '>=', $since)
+            ->selectRaw('status, count(*) as aggregate')
+            ->groupBy('status')
+            ->pluck('aggregate', 'status');
 
-        return [$pending, $failed, $success];
+        return [
+            (int) ($counts['pending'] ?? 0) + (int) ($counts['running'] ?? 0),
+            (int) ($counts['failed'] ?? 0),
+            (int) ($counts['success'] ?? 0),
+        ];
     }
 
     public function retryFailure(string $failureId): void
     {
-        [$modelId, $taskKey] = explode('-', $failureId, 2);
+        $execution = TaskExecution::find($failureId);
+        if (! $execution || $execution->entity_type !== 'event') {
+            return;
+        }
 
-        $event = Event::find($modelId);
+        $event = Event::find($execution->entity_id);
         if ($event) {
             App\Jobs\TaskPipeline\ProcessTaskPipelineJob::dispatch(
                 model: $event,
                 trigger: 'manual',
-                taskFilter: [$taskKey],
+                taskFilter: [$execution->task_key],
                 force: true,
             )->onQueue('tasks');
 

--- a/resources/views/livewire/blocks/show.blade.php
+++ b/resources/views/livewire/blocks/show.blade.php
@@ -334,8 +334,8 @@ new class extends Component
     protected function shouldExpandTasksSection(): bool
     {
         // Expand if there are failed or pending tasks
-        $metadata = $this->block->metadata ?? [];
-        $executions = $metadata['task_executions'] ?? [];
+        $executions = app(\App\Services\TaskPipeline\TaskExecutionStore::class)
+            ->getTaskExecutions($this->block);
 
         foreach ($executions as $execution) {
             $status = $execution['last_attempt']['status'] ?? null;
@@ -811,8 +811,7 @@ new class extends Component
                 <div class="pb-4 border-b border-base-200">
                     @if ($drawerContentLoaded && $tasksLoaded)
                         @php
-                            $metadata = $block->metadata ?? [];
-                            $executions = $metadata['task_executions'] ?? [];
+                            $executions = app(\App\Services\TaskPipeline\TaskExecutionStore::class)->getTaskExecutions($block);
                             $failedCount = collect($executions)->filter(fn($e) => ($e['last_attempt']['status'] ?? null) === 'failed')->count();
                             $pendingCount = collect($executions)->filter(fn($e) => in_array($e['last_attempt']['status'] ?? null, ['pending', 'running']))->count();
                             $executedCount = collect($executions)->filter(fn($e) => in_array($e['last_attempt']['status'] ?? null, ['success', 'failed', 'running', 'pending']))->count();

--- a/resources/views/livewire/events/show.blade.php
+++ b/resources/views/livewire/events/show.blade.php
@@ -789,8 +789,8 @@ new class extends Component
     protected function shouldExpandTasksSection(): bool
     {
         // Expand if there are failed or pending tasks
-        $metadata = $this->event->event_metadata ?? [];
-        $executions = $metadata['task_executions'] ?? [];
+        $executions = app(\App\Services\TaskPipeline\TaskExecutionStore::class)
+            ->getTaskExecutions($this->event);
 
         foreach ($executions as $execution) {
             $status = $execution['last_attempt']['status'] ?? null;
@@ -1510,8 +1510,7 @@ new class extends Component
                     <!-- Tasks -->
                     @if ($drawerContentLoaded && $tasksLoaded)
                         @php
-                            $metadata = $event->event_metadata ?? [];
-                            $executions = $metadata['task_executions'] ?? [];
+                            $executions = app(\App\Services\TaskPipeline\TaskExecutionStore::class)->getTaskExecutions($event);
                             $failedCount = collect($executions)->filter(fn($e) => ($e['last_attempt']['status'] ?? null) === 'failed')->count();
                             $pendingCount = collect($executions)->filter(fn($e) => in_array($e['last_attempt']['status'] ?? null, ['pending', 'running']))->count();
                             $executedCount = collect($executions)->filter(fn($e) => in_array($e['last_attempt']['status'] ?? null, ['success', 'failed', 'running', 'pending']))->count();

--- a/resources/views/livewire/integration-details.blade.php
+++ b/resources/views/livewire/integration-details.blade.php
@@ -364,8 +364,7 @@
                 <div class="pb-4 border-b border-base-200" wire:init="loadTasks">
                     @if ($tasksLoaded)
                         @php
-                            $configuration = $integration->configuration ?? [];
-                            $executions = $configuration['task_executions'] ?? [];
+                            $executions = app(\App\Services\TaskPipeline\TaskExecutionStore::class)->getTaskExecutions($integration);
                             $failedCount = collect($executions)->filter(fn($e) => ($e['last_attempt']['status'] ?? null) === 'failed')->count();
                             $pendingCount = collect($executions)->filter(fn($e) => in_array($e['last_attempt']['status'] ?? null, ['pending', 'running']))->count();
                             $executedCount = collect($executions)->filter(fn($e) => in_array($e['last_attempt']['status'] ?? null, ['success', 'failed', 'running', 'pending']))->count();

--- a/resources/views/livewire/objects/show.blade.php
+++ b/resources/views/livewire/objects/show.blade.php
@@ -702,8 +702,8 @@ new class extends Component
     protected function shouldExpandTasksSection(): bool
     {
         // Expand if there are failed or pending tasks
-        $metadata = $this->object->metadata ?? [];
-        $executions = $metadata['task_executions'] ?? [];
+        $executions = app(\App\Services\TaskPipeline\TaskExecutionStore::class)
+            ->getTaskExecutions($this->object);
 
         foreach ($executions as $execution) {
             $status = $execution['last_attempt']['status'] ?? null;
@@ -1380,8 +1380,7 @@ new class extends Component
                     <!-- Tasks -->
                     @if ($drawerContentLoaded && $tasksLoaded)
                         @php
-                            $metadata = $object->metadata ?? [];
-                            $executions = $metadata['task_executions'] ?? [];
+                            $executions = app(\App\Services\TaskPipeline\TaskExecutionStore::class)->getTaskExecutions($object);
                             $failedCount = collect($executions)->filter(fn($e) => ($e['last_attempt']['status'] ?? null) === 'failed')->count();
                             $pendingCount = collect($executions)->filter(fn($e) => in_array($e['last_attempt']['status'] ?? null, ['pending', 'running']))->count();
                             $executedCount = collect($executions)->filter(fn($e) => in_array($e['last_attempt']['status'] ?? null, ['success', 'failed', 'running', 'pending']))->count();

--- a/resources/views/livewire/task-execution-section.blade.php
+++ b/resources/views/livewire/task-execution-section.blade.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Services\TaskPipeline\TaskRegistry;
+use App\Services\TaskPipeline\TaskExecutionStore;
 use Livewire\Volt\Component;
 use Illuminate\Database\Eloquent\Model;
 use App\Jobs\TaskPipeline\ProcessTaskPipelineJob;
@@ -73,15 +74,7 @@ new class extends Component {
 
     protected function getTaskExecutions(): array
     {
-        // Determine which field to use based on model type
-        $field = match (get_class($this->model)) {
-            \App\Models\Event::class => 'event_metadata',
-            \App\Models\Integration::class => 'configuration',
-            default => 'metadata', // EventObject, Block
-        };
-
-        $metadata = $this->model->$field ?? [];
-        return $metadata['task_executions'] ?? [];
+        return app(TaskExecutionStore::class)->getTaskExecutions($this->model->refresh());
     }
 }; ?>
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Api\FlintQuestionsController;
 use App\Http\Controllers\Api\IntegrationApiController;
 use App\Http\Controllers\Api\SearchApiController;
 use App\Http\Controllers\Api\SemanticSearchController;
+use App\Http\Controllers\Api\TaskExecutionController;
 use App\Http\Controllers\Auth\OAuthController;
 use App\Http\Controllers\EventApiController;
 use Illuminate\Http\Request;
@@ -99,6 +100,10 @@ Route::middleware('sentry.api.logging')->group(function () {
 
         // Flint Questions API
         Route::post('flint/questions/{block}/answer', [FlintQuestionsController::class, 'answer'])->name('api.flint.questions.answer');
+
+        // Task Executions API
+        Route::get('task-executions', [TaskExecutionController::class, 'index'])->name('api.task-executions.index');
+        Route::get('task-executions/{taskExecution}', [TaskExecutionController::class, 'show'])->name('api.task-executions.show');
 
         // Clear card stream cache
         Route::post('clear-card-cache', function (Request $request) {

--- a/routes/console.php
+++ b/routes/console.php
@@ -7,9 +7,8 @@ use App\Jobs\Flint\RunPatternDetectionJob;
 use App\Jobs\Flint\RunPreDigestRefreshJob;
 use App\Jobs\Flint\SendDigestNotificationJob;
 use App\Jobs\Knowledge\ProcessMissingKnowledgeSummariesJob;
-use App\Jobs\Metrics\CalculateMetricStatisticsJob;
-use App\Jobs\Metrics\DetectMetricTrendsJob;
-use App\Jobs\Metrics\DetectRetrospectiveMetricAnomaliesJob;
+use App\Jobs\TaskPipeline\DispatchRetrospectiveAnomalyTasksJob;
+use App\Jobs\TaskPipeline\DispatchTrendDetectionTasksJob;
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Foundation\Inspiring;
@@ -30,22 +29,15 @@ Schedule::job(new CheckIntegrationUpdates)
     ->onOneServer()
     ->sentryMonitor();
 
-// Calculate metric statistics hourly
-Schedule::job(new CalculateMetricStatisticsJob)
-    ->hourly()
-    ->withoutOverlapping()
-    ->onOneServer()
-    ->sentryMonitor();
-
-// Detect metric trends daily
-Schedule::job(new DetectMetricTrendsJob)
+// Detect metric trends daily via task pipeline
+Schedule::job(new DispatchTrendDetectionTasksJob)
     ->daily()
     ->withoutOverlapping()
     ->onOneServer()
     ->sentryMonitor();
 
-// Detect retrospective metric anomalies daily
-Schedule::job(new DetectRetrospectiveMetricAnomaliesJob)
+// Detect retrospective metric anomalies daily via task pipeline
+Schedule::job(new DispatchRetrospectiveAnomalyTasksJob)
     ->daily()
     ->withoutOverlapping()
     ->onOneServer()

--- a/routes/console.php
+++ b/routes/console.php
@@ -6,7 +6,6 @@ use App\Jobs\Fetch\RefreshExpiringCookies;
 use App\Jobs\Flint\RunPatternDetectionJob;
 use App\Jobs\Flint\RunPreDigestRefreshJob;
 use App\Jobs\Flint\SendDigestNotificationJob;
-use App\Jobs\Knowledge\ProcessMissingKnowledgeSummariesJob;
 use App\Jobs\TaskPipeline\DispatchRetrospectiveAnomalyTasksJob;
 use App\Jobs\TaskPipeline\DispatchTrendDetectionTasksJob;
 use App\Models\User;
@@ -62,13 +61,6 @@ Schedule::job(new CheckCookieExpiryJob)
 // Refresh expiring cookies daily at 2am
 Schedule::job(new RefreshExpiringCookies)
     ->dailyAt('02:00')
-    ->onOneServer()
-    ->withoutOverlapping()
-    ->sentryMonitor();
-
-// Repair Fetch/Newsletter knowledge events that never received AI summary blocks.
-Schedule::job(new ProcessMissingKnowledgeSummariesJob(limit: 100))
-    ->everySixHours()
     ->onOneServer()
     ->withoutOverlapping()
     ->sentryMonitor();

--- a/tests/Feature/Api/V1/Mobile/KnowledgeReprocessingControllerTest.php
+++ b/tests/Feature/Api/V1/Mobile/KnowledgeReprocessingControllerTest.php
@@ -2,9 +2,8 @@
 
 namespace Tests\Feature\Api\V1\Mobile;
 
-use App\Jobs\Data\Fetch\GenerateSummariesJob;
-use App\Jobs\Data\Newsletter\ExtractNewsletterContentJob;
 use App\Jobs\Fetch\FetchSingleUrl;
+use App\Jobs\TaskPipeline\ProcessTaskPipelineJob;
 use App\Models\Block;
 use App\Models\Event;
 use App\Models\EventObject;
@@ -99,8 +98,9 @@ class KnowledgeReprocessingControllerTest extends TestCase
             'mode' => 'summary_only',
         ])->assertAccepted();
 
-        Queue::assertPushed(GenerateSummariesJob::class, fn (GenerateSummariesJob $job) => $job->event->is($event)
-            && $job->articleText === 'Existing extracted markdown.');
+        Queue::assertPushed(ProcessTaskPipelineJob::class, fn (ProcessTaskPipelineJob $job) => $job->model->is($event)
+            && $job->trigger === 'manual'
+            && $job->taskFilter === ['fetch_generate_summaries']);
     }
 
     #[Test]
@@ -114,18 +114,24 @@ class KnowledgeReprocessingControllerTest extends TestCase
             ->assertAccepted()
             ->assertJsonPath('service', 'newsletter');
 
-        Queue::assertPushed(ExtractNewsletterContentJob::class, fn (ExtractNewsletterContentJob $job) => $job->event->is($event)
-            && $job->rawContent === '<main>Newsletter body</main>');
+        Queue::assertPushed(ProcessTaskPipelineJob::class, fn (ProcessTaskPipelineJob $job) => $job->model->is($event)
+            && $job->trigger === 'manual'
+            && $job->taskFilter === ['newsletter_extract_content', 'newsletter_generate_summaries']);
     }
 
     #[Test]
-    public function newsletter_reprocess_requires_content_when_raw_html_is_missing(): void
+    public function newsletter_auto_queues_pipeline_when_raw_html_and_content_are_missing(): void
     {
         $event = $this->createNewsletterEvent(rawHtml: null, publicationContent: null);
+        Queue::fake();
         Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
 
         $this->postJson("/api/v1/mobile/knowledge/events/{$event->id}/reprocess")
-            ->assertStatus(422);
+            ->assertAccepted();
+
+        Queue::assertPushed(ProcessTaskPipelineJob::class, fn (ProcessTaskPipelineJob $job) => $job->model->is($event)
+            && $job->trigger === 'manual'
+            && $job->taskFilter === ['newsletter_extract_content', 'newsletter_generate_summaries']);
     }
 
     #[Test]

--- a/tests/Feature/Integrations/Oyster/ProcessOysterEmailJobTest.php
+++ b/tests/Feature/Integrations/Oyster/ProcessOysterEmailJobTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Integrations\Oyster;
 
+use App\Integrations\Oyster\OysterTransportModeDetector;
 use App\Jobs\Data\Oyster\LinkOysterJourneyEventsJob;
 use App\Jobs\Data\Oyster\ProcessOysterEmailJob;
 use App\Models\Event;
@@ -12,6 +13,7 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Queue;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class ProcessOysterEmailJobTest extends TestCase
@@ -53,7 +55,7 @@ class ProcessOysterEmailJobTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_be_instantiated()
     {
         $job = new ProcessOysterEmailJob(
@@ -64,7 +66,7 @@ class ProcessOysterEmailJobTest extends TestCase
         $this->assertInstanceOf(ProcessOysterEmailJob::class, $job);
     }
 
-    /** @test */
+    #[Test]
     public function it_has_correct_timeout()
     {
         $job = new ProcessOysterEmailJob(
@@ -75,7 +77,7 @@ class ProcessOysterEmailJobTest extends TestCase
         $this->assertEquals(300, $job->timeout);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_unique_id_based_on_integration_and_content()
     {
         $s3Key = 'oyster/test-email-123.eml';
@@ -87,7 +89,7 @@ class ProcessOysterEmailJobTest extends TestCase
         $this->assertStringContainsString($this->integration->id, $uniqueId);
     }
 
-    /** @test */
+    #[Test]
     public function it_processes_csv_and_creates_events()
     {
         Queue::fake([LinkOysterJourneyEventsJob::class]);
@@ -158,7 +160,7 @@ CSV;
         Queue::assertPushed(LinkOysterJourneyEventsJob::class);
     }
 
-    /** @test */
+    #[Test]
     public function it_processes_top_up_entries()
     {
         Queue::fake([LinkOysterJourneyEventsJob::class]);
@@ -183,7 +185,7 @@ CSV;
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function it_creates_correct_transport_mode_metadata()
     {
         Queue::fake([LinkOysterJourneyEventsJob::class]);
@@ -217,9 +219,69 @@ CSV;
 
         $this->assertNotNull($tramEvent);
         $this->assertEquals('Tram', $tramEvent->event_metadata['transport_mode_display']);
+
+        // Check tags are attached
+        $this->assertTrue($nationalRailEvent->hasTag('national_rail'));
+        $this->assertEquals('transport_mode', $nationalRailEvent->tagsWithType('transport_mode')->first()->type);
+        $this->assertTrue($tramEvent->hasTag('tram'));
     }
 
-    /** @test */
+    #[Test]
+    public function it_attaches_transport_mode_tags_to_both_touched_in_and_touched_out()
+    {
+        Queue::fake([LinkOysterJourneyEventsJob::class]);
+
+        $csvContent = <<<'CSV'
+
+Date,Start Time,End Time,Journey/Action,Charge,Credit,Balance,Note
+28-Nov-2025,17:47,18:14,"Victoria (platforms 9-19) [National Rail] to East Croydon [National Rail]",2.80,,8.41,""
+CSV;
+
+        $email = $this->createMockEmail($csvContent);
+
+        $job = new ProcessOysterEmailJob($this->integration, null, $email);
+        $job->handle();
+
+        $touchedIn = Event::where('integration_id', $this->integration->id)
+            ->where('action', 'touched_in_at')
+            ->first();
+
+        $touchedOut = Event::where('integration_id', $this->integration->id)
+            ->where('action', 'touched_out_at')
+            ->first();
+
+        $this->assertNotNull($touchedIn);
+        $this->assertNotNull($touchedOut);
+        $this->assertTrue($touchedIn->hasTag(OysterTransportModeDetector::MODE_NATIONAL_RAIL));
+        $this->assertTrue($touchedOut->hasTag(OysterTransportModeDetector::MODE_NATIONAL_RAIL));
+    }
+
+    #[Test]
+    public function it_does_not_attach_tag_for_unknown_transport_mode()
+    {
+        Queue::fake([LinkOysterJourneyEventsJob::class]);
+
+        // A journey that would resolve to unknown mode (no mode annotation, no "to" pattern)
+        $csvContent = <<<'CSV'
+
+Date,Start Time,End Time,Journey/Action,Charge,Credit,Balance,Note
+28-Nov-2025,17:47,,"Unknown journey type",.00,,8.41,""
+CSV;
+
+        $email = $this->createMockEmail($csvContent);
+
+        $job = new ProcessOysterEmailJob($this->integration, null, $email);
+        $job->handle();
+
+        $events = Event::where('integration_id', $this->integration->id)
+            ->where('action', 'touched_in_at')
+            ->get();
+
+        // Unrecognizable journey formats produce no events (no origin detected), so no tags either
+        $this->assertEmpty($events);
+    }
+
+    #[Test]
     public function it_is_idempotent_and_does_not_duplicate_events()
     {
         Queue::fake([LinkOysterJourneyEventsJob::class]);
@@ -247,7 +309,7 @@ CSV;
         $this->assertCount(1, $events);
     }
 
-    /** @test */
+    #[Test]
     public function it_reuses_existing_station_objects()
     {
         Queue::fake([LinkOysterJourneyEventsJob::class]);

--- a/tests/Feature/Mcp/GetDaySummaryToolTest.php
+++ b/tests/Feature/Mcp/GetDaySummaryToolTest.php
@@ -452,6 +452,7 @@ class GetDaySummaryToolTest extends TestCase
             'action' => 'had_sleep_score',
             'value_unit' => 'percent',
             'mean_value' => 80,
+            'anomaly_low_suppressed_until' => Carbon::tomorrow()->endOfDay(),
         ]);
 
         MetricTrend::factory()->create([
@@ -462,7 +463,6 @@ class GetDaySummaryToolTest extends TestCase
             'baseline_value' => 80,
             'deviation' => 0.3125,
             'acknowledged_at' => null,
-            'metadata' => ['suppress_until' => Carbon::tomorrow()->toDateString()],
         ]);
 
         $service = app(DaySummaryService::class);

--- a/tests/Feature/MetricTrackingTest.php
+++ b/tests/Feature/MetricTrackingTest.php
@@ -4,8 +4,11 @@ namespace Tests\Feature;
 
 use App\Jobs\Metrics\CalculateMetricStatisticsJob;
 use App\Jobs\Metrics\DetectMetricAnomaliesJob;
+use App\Jobs\Metrics\DetectMetricTrendsJob;
 use App\Jobs\TaskPipeline\ProcessTaskPipelineJob;
+use App\Jobs\TaskPipeline\Tasks\CalculateMetricStatsTask;
 use App\Jobs\TaskPipeline\Tasks\DetectAnomaliesTask;
+use App\Mcp\Tools\GetBaselinesTool;
 use App\Models\Event;
 use App\Models\EventObject;
 use App\Models\Integration;
@@ -13,6 +16,8 @@ use App\Models\IntegrationGroup;
 use App\Models\MetricStatistic;
 use App\Models\MetricTrend;
 use App\Models\User;
+use App\Services\Mobile\AnomalyAcknowledgement;
+use App\Services\TaskPipeline\TaskRegistry;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Queue;
@@ -60,9 +65,29 @@ class MetricTrackingTest extends TestCase
             return $job->model->id === $event->id && $job->trigger === 'created';
         });
 
-        // Process the pipeline manually to verify it dispatches the anomaly detection task
+        // Phase 1: initial pipeline — dispatches CalculateMetricStatsTask;
+        // DetectAnomaliesTask is held waiting because its dependency hasn't completed yet.
         $pipelineJob = new ProcessTaskPipelineJob($event, 'created');
         $pipelineJob->handle();
+
+        Queue::assertPushed(CalculateMetricStatsTask::class, function ($job) use ($event) {
+            return $job->model->id === $event->id;
+        });
+
+        // Phase 2: simulate CalculateMetricStatsTask completing — marks the task succeeded
+        // and dispatches a secondary pipeline for dependent tasks.
+        $statsTaskDef = TaskRegistry::getTask('calculate_metric_stats');
+        $statsJob = new CalculateMetricStatsTask($event->fresh(), $statsTaskDef);
+        $statsJob->handle();
+
+        // Phase 3: run the secondary pipeline — dependency is now satisfied,
+        // so DetectAnomaliesTask is dispatched.
+        $dependentPipelineJob = new ProcessTaskPipelineJob(
+            $event->fresh(),
+            'manual',
+            TaskRegistry::getDependentTaskKeys('calculate_metric_stats')
+        );
+        $dependentPipelineJob->handle();
 
         // Verify DetectAnomaliesTask was dispatched by the pipeline
         Queue::assertPushed(DetectAnomaliesTask::class, function ($job) use ($event) {
@@ -130,6 +155,157 @@ class MetricTrackingTest extends TestCase
         $this->assertEqualsWithDelta($expectedStddev, (float) $metric->stddev_value, 0.0001);
         $this->assertEqualsWithDelta($mean - 2 * $expectedStddev, (float) $metric->normal_lower_bound, 0.0001);
         $this->assertEqualsWithDelta($mean + 2 * $expectedStddev, (float) $metric->normal_upper_bound, 0.0001);
+    }
+
+    #[Test]
+    public function both_calculation_paths_produce_identical_statistics_with_zero_values(): void
+    {
+        $user = User::factory()->create();
+        $group = IntegrationGroup::factory()->create(['user_id' => $user->id]);
+        $integration = Integration::factory()->create([
+            'user_id' => $user->id,
+            'integration_group_id' => $group->id,
+        ]);
+        $actor = EventObject::factory()->create(['user_id' => $user->id]);
+        $target = EventObject::factory()->create(['user_id' => $user->id]);
+
+        // 10 zero-value events (days 31–40 ago) + 30 non-zero events (days 1–30 ago).
+        // Both paths should exclude the zeros and agree on the non-zero statistics.
+        for ($i = 0; $i < 10; $i++) {
+            Event::create([
+                'source_id' => 'zero-' . $i,
+                'time' => now()->subDays(40 - $i),
+                'integration_id' => $integration->id,
+                'actor_id' => $actor->id,
+                'target_id' => $target->id,
+                'service' => 'oura',
+                'domain' => 'health',
+                'action' => 'had_readiness_score',
+                'value' => 0,
+                'value_multiplier' => 1,
+                'value_unit' => 'percent',
+            ]);
+        }
+
+        $lastEvent = null;
+        for ($i = 0; $i < 30; $i++) {
+            $lastEvent = Event::create([
+                'source_id' => 'nonzero-' . $i,
+                'time' => now()->subDays(30 - $i),
+                'integration_id' => $integration->id,
+                'actor_id' => $actor->id,
+                'target_id' => $target->id,
+                'service' => 'oura',
+                'domain' => 'health',
+                'action' => 'had_readiness_score',
+                'value' => 70 + ($i % 20), // Values 70–89
+                'value_multiplier' => 1,
+                'value_unit' => 'percent',
+            ]);
+        }
+
+        // Run the task-pipeline path on the most recent event.
+        $statsTaskDef = TaskRegistry::getTask('calculate_metric_stats');
+        $statsJob = new CalculateMetricStatsTask($lastEvent->fresh(), $statsTaskDef);
+        $statsJob->handle();
+
+        $taskStat = MetricStatistic::where('user_id', $user->id)->first();
+        $this->assertNotNull($taskStat, 'Task pipeline should produce a MetricStatistic');
+        $this->assertEquals(30, $taskStat->event_count, 'Zero events must be excluded from the count');
+
+        // Capture task-pipeline values.
+        $taskMean = (float) $taskStat->mean_value;
+        $taskStddev = (float) $taskStat->stddev_value;
+        $taskMin = (float) $taskStat->min_value;
+        $taskMax = (float) $taskStat->max_value;
+        $taskLower = (float) $taskStat->normal_lower_bound;
+        $taskUpper = (float) $taskStat->normal_upper_bound;
+
+        // Delete the row so the batch job writes a fresh one.
+        $taskStat->delete();
+
+        // Run the batch job path.
+        (new CalculateMetricStatisticsJob)->handle();
+
+        $batchStat = MetricStatistic::where('user_id', $user->id)->first();
+        $this->assertNotNull($batchStat, 'Batch job should produce a MetricStatistic');
+        $this->assertEquals(30, $batchStat->event_count, 'Zero events must be excluded from the count');
+
+        $delta = 0.0001;
+        $this->assertEqualsWithDelta($taskMean, (float) $batchStat->mean_value, $delta);
+        $this->assertEqualsWithDelta($taskStddev, (float) $batchStat->stddev_value, $delta);
+        $this->assertEqualsWithDelta($taskMin, (float) $batchStat->min_value, $delta);
+        $this->assertEqualsWithDelta($taskMax, (float) $batchStat->max_value, $delta);
+        $this->assertEqualsWithDelta($taskLower, (float) $batchStat->normal_lower_bound, $delta);
+        $this->assertEqualsWithDelta($taskUpper, (float) $batchStat->normal_upper_bound, $delta);
+    }
+
+    #[Test]
+    public function financial_metrics_include_zeros_in_both_calculation_paths(): void
+    {
+        $user = User::factory()->create();
+        $group = IntegrationGroup::factory()->create(['user_id' => $user->id]);
+        $integration = Integration::factory()->create([
+            'user_id' => $user->id,
+            'integration_group_id' => $group->id,
+        ]);
+        $actor = EventObject::factory()->create(['user_id' => $user->id]);
+        $target = EventObject::factory()->create(['user_id' => $user->id]);
+
+        // 10 zero-value events (days 31–40 ago) + 30 non-zero events (days 1–30 ago).
+        // For money domain, zeros are legitimate and must be included.
+        for ($i = 0; $i < 10; $i++) {
+            Event::create([
+                'source_id' => 'fin-zero-' . $i,
+                'time' => now()->subDays(40 - $i),
+                'integration_id' => $integration->id,
+                'actor_id' => $actor->id,
+                'target_id' => $target->id,
+                'service' => 'monzo',
+                'domain' => 'money',
+                'action' => 'transaction',
+                'value' => 0,
+                'value_multiplier' => 1,
+                'value_unit' => 'gbp',
+            ]);
+        }
+
+        $lastEvent = null;
+        for ($i = 0; $i < 30; $i++) {
+            $lastEvent = Event::create([
+                'source_id' => 'fin-nonzero-' . $i,
+                'time' => now()->subDays(30 - $i),
+                'integration_id' => $integration->id,
+                'actor_id' => $actor->id,
+                'target_id' => $target->id,
+                'service' => 'monzo',
+                'domain' => 'money',
+                'action' => 'transaction',
+                'value' => 100,
+                'value_multiplier' => 1,
+                'value_unit' => 'gbp',
+            ]);
+        }
+
+        // Run the task-pipeline path.
+        $statsTaskDef = TaskRegistry::getTask('calculate_metric_stats');
+        $statsJob = new CalculateMetricStatsTask($lastEvent->fresh(), $statsTaskDef);
+        $statsJob->handle();
+
+        $taskStat = MetricStatistic::where('user_id', $user->id)->first();
+        $this->assertNotNull($taskStat);
+        $this->assertEquals(40, $taskStat->event_count, 'All 40 events including zeros must be counted for money domain');
+
+        $taskMean = (float) $taskStat->mean_value;
+        $taskStat->delete();
+
+        // Run the batch job path.
+        (new CalculateMetricStatisticsJob)->handle();
+
+        $batchStat = MetricStatistic::where('user_id', $user->id)->first();
+        $this->assertNotNull($batchStat);
+        $this->assertEquals(40, $batchStat->event_count, 'All 40 events including zeros must be counted for money domain');
+        $this->assertEqualsWithDelta($taskMean, (float) $batchStat->mean_value, 0.0001);
     }
 
     #[Test]
@@ -281,6 +457,118 @@ class MetricTrackingTest extends TestCase
             'service' => 'oura',
             'action' => 'had_readiness_score',
         ]);
+    }
+
+    #[Test]
+    public function calculate_metric_statistics_job_excludes_events_outside_rolling_window(): void
+    {
+        $user = User::factory()->create();
+        $group = IntegrationGroup::factory()->create(['user_id' => $user->id]);
+        $integration = Integration::factory()->create([
+            'user_id' => $user->id,
+            'integration_group_id' => $group->id,
+        ]);
+        $actor = EventObject::factory()->create(['user_id' => $user->id]);
+        $target = EventObject::factory()->create(['user_id' => $user->id]);
+
+        // 20 old events outside the 90-day window with value = 100
+        for ($i = 0; $i < 20; $i++) {
+            Event::create([
+                'source_id' => 'old-' . $i,
+                'time' => now()->subDays(200 - $i),
+                'integration_id' => $integration->id,
+                'actor_id' => $actor->id,
+                'target_id' => $target->id,
+                'service' => 'oura',
+                'domain' => 'health',
+                'action' => 'had_readiness_score',
+                'value' => 100,
+                'value_multiplier' => 1,
+                'value_unit' => 'percent',
+            ]);
+        }
+
+        // 20 recent events inside the 90-day window with value = 70, spanning ~76 days
+        for ($i = 0; $i < 20; $i++) {
+            Event::create([
+                'source_id' => 'new-' . $i,
+                'time' => now()->subDays(85 - ($i * 4)),
+                'integration_id' => $integration->id,
+                'actor_id' => $actor->id,
+                'target_id' => $target->id,
+                'service' => 'oura',
+                'domain' => 'health',
+                'action' => 'had_readiness_score',
+                'value' => 70,
+                'value_multiplier' => 1,
+                'value_unit' => 'percent',
+            ]);
+        }
+
+        (new CalculateMetricStatisticsJob)->handle();
+
+        $metric = MetricStatistic::where('user_id', $user->id)->first();
+        $this->assertNotNull($metric);
+
+        // Mean should be 70 (only window events), not ~85 (all-time mean)
+        $this->assertEqualsWithDelta(70.0, (float) $metric->mean_value, 0.0001);
+        $this->assertEquals(20, $metric->event_count);
+        $this->assertEquals(MetricStatistic::DEFAULT_WINDOW_DAYS, $metric->baseline_window_days);
+    }
+
+    #[Test]
+    public function calculate_metric_statistics_job_nulls_out_stale_stats_when_window_has_insufficient_data(): void
+    {
+        $user = User::factory()->create();
+        $group = IntegrationGroup::factory()->create(['user_id' => $user->id]);
+        $integration = Integration::factory()->create([
+            'user_id' => $user->id,
+            'integration_group_id' => $group->id,
+        ]);
+        $actor = EventObject::factory()->create(['user_id' => $user->id]);
+        $target = EventObject::factory()->create(['user_id' => $user->id]);
+
+        // Existing stale MetricStatistic with valid all-time stats
+        $metric = MetricStatistic::factory()->create([
+            'user_id' => $user->id,
+            'service' => 'oura',
+            'action' => 'had_readiness_score',
+            'value_unit' => 'percent',
+            'mean_value' => 80,
+            'stddev_value' => 5,
+            'normal_lower_bound' => 70,
+            'normal_upper_bound' => 90,
+            'event_count' => 40,
+            'last_calculated_at' => null, // force recalculation
+        ]);
+
+        // All events are outside the rolling window
+        for ($i = 0; $i < 40; $i++) {
+            Event::create([
+                'source_id' => 'stale-' . $i,
+                'time' => now()->subDays(200 - $i),
+                'integration_id' => $integration->id,
+                'actor_id' => $actor->id,
+                'target_id' => $target->id,
+                'service' => 'oura',
+                'domain' => 'health',
+                'action' => 'had_readiness_score',
+                'value' => 80,
+                'value_multiplier' => 1,
+                'value_unit' => 'percent',
+            ]);
+        }
+
+        (new CalculateMetricStatisticsJob)->handle();
+
+        $metric->refresh();
+
+        // Stats must be nulled out so anomaly detection cannot use stale bounds
+        $this->assertNull($metric->mean_value);
+        $this->assertNull($metric->stddev_value);
+        $this->assertNull($metric->normal_lower_bound);
+        $this->assertNull($metric->normal_upper_bound);
+        $this->assertFalse($metric->hasValidStatistics());
     }
 
     #[Test]
@@ -504,5 +792,539 @@ class MetricTrackingTest extends TestCase
 
         // No anomaly should be created due to user override
         $this->assertEquals(0, MetricTrend::where('metric_statistic_id', $metric->id)->count());
+    }
+
+    // -------------------------------------------------------------------------
+    // Baseline review flag (CRX-652)
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function monthly_trend_sets_baseline_reset_suggested_at(): void
+    {
+        $user = User::factory()->create();
+        $group = IntegrationGroup::factory()->create(['user_id' => $user->id]);
+        $integration = Integration::factory()->create([
+            'user_id' => $user->id,
+            'integration_group_id' => $group->id,
+        ]);
+        $actor = EventObject::factory()->create(['user_id' => $user->id]);
+        $target = EventObject::factory()->create(['user_id' => $user->id]);
+
+        $metric = MetricStatistic::factory()->create([
+            'user_id' => $user->id,
+            'service' => 'oura',
+            'action' => 'had_readiness_score',
+            'value_unit' => 'percent',
+            'baseline_reset_suggested_at' => null,
+        ]);
+
+        // 5 events in the comparison period (3 months back) with value 70
+        $comparisonStart = now()->startOfMonth()->subMonths(3);
+        for ($i = 0; $i < 5; $i++) {
+            Event::create([
+                'source_id' => 'monthly-comp-' . $i,
+                'time' => $comparisonStart->copy()->addDays($i),
+                'integration_id' => $integration->id,
+                'actor_id' => $actor->id,
+                'target_id' => $target->id,
+                'service' => 'oura',
+                'domain' => 'health',
+                'action' => 'had_readiness_score',
+                'value' => 70,
+                'value_multiplier' => 1,
+                'value_unit' => 'percent',
+            ]);
+        }
+
+        // 5 events in the current month with value 90 (~29% higher — exceeds 15% threshold)
+        $currentMonthStart = now()->startOfMonth();
+        for ($i = 0; $i < 5; $i++) {
+            Event::create([
+                'source_id' => 'monthly-curr-' . $i,
+                'time' => $currentMonthStart->copy()->addDays($i),
+                'integration_id' => $integration->id,
+                'actor_id' => $actor->id,
+                'target_id' => $target->id,
+                'service' => 'oura',
+                'domain' => 'health',
+                'action' => 'had_readiness_score',
+                'value' => 90,
+                'value_multiplier' => 1,
+                'value_unit' => 'percent',
+            ]);
+        }
+
+        $this->assertNull($metric->baseline_reset_suggested_at);
+
+        (new DetectMetricTrendsJob)->handle();
+
+        $metric->refresh();
+        $this->assertNotNull($metric->baseline_reset_suggested_at);
+    }
+
+    #[Test]
+    public function quarterly_trend_sets_baseline_reset_suggested_at(): void
+    {
+        $user = User::factory()->create();
+        $group = IntegrationGroup::factory()->create(['user_id' => $user->id]);
+        $integration = Integration::factory()->create([
+            'user_id' => $user->id,
+            'integration_group_id' => $group->id,
+        ]);
+        $actor = EventObject::factory()->create(['user_id' => $user->id]);
+        $target = EventObject::factory()->create(['user_id' => $user->id]);
+
+        $metric = MetricStatistic::factory()->create([
+            'user_id' => $user->id,
+            'service' => 'oura',
+            'action' => 'had_readiness_score',
+            'value_unit' => 'percent',
+            'baseline_reset_suggested_at' => null,
+        ]);
+
+        // 5 events 2 quarters back with value 70
+        $comparisonStart = now()->startOfQuarter()->subQuarters(2);
+        for ($i = 0; $i < 5; $i++) {
+            Event::create([
+                'source_id' => 'quarterly-comp-' . $i,
+                'time' => $comparisonStart->copy()->addDays($i),
+                'integration_id' => $integration->id,
+                'actor_id' => $actor->id,
+                'target_id' => $target->id,
+                'service' => 'oura',
+                'domain' => 'health',
+                'action' => 'had_readiness_score',
+                'value' => 70,
+                'value_multiplier' => 1,
+                'value_unit' => 'percent',
+            ]);
+        }
+
+        // 5 events in the current quarter with value 90 (~29% higher)
+        $currentQuarterStart = now()->startOfQuarter();
+        for ($i = 0; $i < 5; $i++) {
+            Event::create([
+                'source_id' => 'quarterly-curr-' . $i,
+                'time' => $currentQuarterStart->copy()->addDays($i),
+                'integration_id' => $integration->id,
+                'actor_id' => $actor->id,
+                'target_id' => $target->id,
+                'service' => 'oura',
+                'domain' => 'health',
+                'action' => 'had_readiness_score',
+                'value' => 90,
+                'value_multiplier' => 1,
+                'value_unit' => 'percent',
+            ]);
+        }
+
+        $this->assertNull($metric->baseline_reset_suggested_at);
+
+        (new DetectMetricTrendsJob)->handle();
+
+        $metric->refresh();
+        $this->assertNotNull($metric->baseline_reset_suggested_at);
+    }
+
+    #[Test]
+    public function acknowledging_last_sustained_trend_clears_baseline_reset_flag(): void
+    {
+        $metric = MetricStatistic::factory()->create([
+            'baseline_reset_suggested_at' => now()->subDay(),
+        ]);
+
+        $trend = MetricTrend::factory()->create([
+            'metric_statistic_id' => $metric->id,
+            'type' => 'trend_up_monthly',
+            'acknowledged_at' => null,
+        ]);
+
+        $trend->acknowledge();
+
+        $metric->refresh();
+        $this->assertNull($metric->baseline_reset_suggested_at);
+    }
+
+    #[Test]
+    public function acknowledging_one_trend_does_not_clear_flag_while_others_remain(): void
+    {
+        $metric = MetricStatistic::factory()->create([
+            'baseline_reset_suggested_at' => now()->subDay(),
+        ]);
+
+        $monthlyTrend = MetricTrend::factory()->create([
+            'metric_statistic_id' => $metric->id,
+            'type' => 'trend_up_monthly',
+            'acknowledged_at' => null,
+        ]);
+
+        MetricTrend::factory()->create([
+            'metric_statistic_id' => $metric->id,
+            'type' => 'trend_up_quarterly',
+            'acknowledged_at' => null,
+        ]);
+
+        $monthlyTrend->acknowledge();
+
+        $metric->refresh();
+        $this->assertNotNull($metric->baseline_reset_suggested_at);
+    }
+
+    #[Test]
+    public function get_baselines_tool_includes_baseline_review_fields(): void
+    {
+        $metric = MetricStatistic::factory()->create([
+            'baseline_reset_suggested_at' => now()->subDays(3),
+        ]);
+
+        $tool = new class extends GetBaselinesTool
+        {
+            public function publicFormatBaseline(MetricStatistic $statistic): array
+            {
+                return $this->formatBaseline($statistic);
+            }
+        };
+
+        // Flag is set
+        $result = $tool->publicFormatBaseline($metric);
+        $this->assertTrue($result['baseline_review_suggested']);
+        $this->assertEquals(now()->subDays(3)->toDateString(), $result['baseline_review_suggested_since']);
+
+        // Flag is cleared
+        $metric->update(['baseline_reset_suggested_at' => null]);
+        $result = $tool->publicFormatBaseline($metric->fresh());
+        $this->assertFalse($result['baseline_review_suggested']);
+        $this->assertNull($result['baseline_review_suggested_since']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Significance scoring (CRX-654)
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function significance_score_increases_monotonically_with_z_score_distance(): void
+    {
+        $user = User::factory()->create();
+        $group = IntegrationGroup::factory()->create(['user_id' => $user->id]);
+        $integration = Integration::factory()->create([
+            'user_id' => $user->id,
+            'integration_group_id' => $group->id,
+        ]);
+        $actor = EventObject::factory()->create(['user_id' => $user->id]);
+        $target = EventObject::factory()->create(['user_id' => $user->id]);
+
+        // Baseline: mean=100, stddev=10. Bounds are set tighter than 2σ so that
+        // test events at exactly 2σ, 3σ, 5σ above the mean are all flagged.
+        $metric = MetricStatistic::factory()->create([
+            'user_id' => $user->id,
+            'service' => 'oura',
+            'action' => 'had_readiness_score',
+            'value_unit' => 'percent',
+            'mean_value' => 100,
+            'stddev_value' => 10,
+            'normal_lower_bound' => 80,
+            'normal_upper_bound' => 119,
+            'event_count' => 50,
+        ]);
+
+        // Events at 2σ, 3σ, and 5σ above the mean. With upper_bound=119, a value
+        // of exactly 120 (2σ) is strictly anomalous (120 > 119).
+        $sigmas = [2, 3, 5];
+        $scores = [];
+
+        foreach ($sigmas as $sigma) {
+            $value = 100 + ($sigma * 10); // mean + n * stddev
+
+            $event = Event::create([
+                'source_id' => "sig-{$sigma}",
+                'time' => now(),
+                'integration_id' => $integration->id,
+                'actor_id' => $actor->id,
+                'target_id' => $target->id,
+                'service' => 'oura',
+                'domain' => 'health',
+                'action' => 'had_readiness_score',
+                'value' => $value,
+                'value_multiplier' => 1,
+                'value_unit' => 'percent',
+            ]);
+
+            $job = new DetectMetricAnomaliesJob($event);
+            $job->handle();
+
+            $trend = MetricTrend::where('metric_statistic_id', $metric->id)
+                ->whereJsonContains('metadata->event_id', $event->id)
+                ->first();
+
+            $this->assertNotNull($trend, "Expected anomaly at {$sigma}σ");
+            $scores[$sigma] = (float) $trend->significance_score;
+        }
+
+        // Scores must strictly increase with z-score distance.
+        $this->assertGreaterThan($scores[2], $scores[3], '3σ must score higher than 2σ');
+        $this->assertGreaterThan($scores[3], $scores[5], '5σ must score higher than 3σ');
+
+        // A 2σ and a 5σ outlier must be meaningfully different (not both capped at 1.0).
+        $this->assertGreaterThan(0.05, $scores[5] - $scores[2], '2σ and 5σ scores must differ by more than 0.05');
+
+        // All scores must be in (0, 1) — the asymptotic tanh formula never reaches 1.0.
+        foreach ($scores as $sigma => $score) {
+            $this->assertGreaterThan(0, $score, "{$sigma}σ score must be > 0");
+            $this->assertLessThan(1, $score, "{$sigma}σ score must be < 1 (tanh never reaches 1.0)");
+        }
+    }
+
+    #[Test]
+    public function active_high_suppression_prevents_anomaly_high_creation(): void
+    {
+        [
+            'user' => $user,
+            'metric' => $metric,
+            'integration' => $integration,
+            'actor' => $actor,
+            'target' => $target,
+        ] = $this->makeSuppressionFixtures();
+
+        $metric->update(['anomaly_high_suppressed_until' => now()->addDays(7)]);
+
+        $event = Event::create([
+            'source_id' => 'supp-high-1',
+            'time' => now(),
+            'integration_id' => $integration->id,
+            'actor_id' => $actor->id,
+            'service' => 'oura',
+            'domain' => 'health',
+            'action' => 'had_readiness_score',
+            'value' => 95, // above upper bound of 85
+            'value_multiplier' => 1,
+            'value_unit' => 'percent',
+            'target_id' => $target->id,
+        ]);
+
+        (new DetectMetricAnomaliesJob($event))->handle();
+
+        $this->assertEquals(0, MetricTrend::where('metric_statistic_id', $metric->id)->count());
+    }
+
+    #[Test]
+    public function active_low_suppression_prevents_anomaly_low_creation(): void
+    {
+        [
+            'user' => $user,
+            'metric' => $metric,
+            'integration' => $integration,
+            'actor' => $actor,
+            'target' => $target,
+        ] = $this->makeSuppressionFixtures();
+
+        $metric->update(['anomaly_low_suppressed_until' => now()->addDays(7)]);
+
+        $event = Event::create([
+            'source_id' => 'supp-low-1',
+            'time' => now(),
+            'integration_id' => $integration->id,
+            'actor_id' => $actor->id,
+            'service' => 'oura',
+            'domain' => 'health',
+            'action' => 'had_readiness_score',
+            'value' => 50, // below lower bound of 65
+            'value_multiplier' => 1,
+            'value_unit' => 'percent',
+            'target_id' => $target->id,
+        ]);
+
+        (new DetectMetricAnomaliesJob($event))->handle();
+
+        $this->assertEquals(0, MetricTrend::where('metric_statistic_id', $metric->id)->count());
+    }
+
+    #[Test]
+    public function high_suppression_does_not_prevent_anomaly_low_creation(): void
+    {
+        [
+            'user' => $user,
+            'metric' => $metric,
+            'integration' => $integration,
+            'actor' => $actor,
+            'target' => $target,
+        ] = $this->makeSuppressionFixtures();
+
+        // Only suppress highs — lows should still fire.
+        $metric->update(['anomaly_high_suppressed_until' => now()->addDays(7)]);
+
+        $event = Event::create([
+            'source_id' => 'supp-direc-1',
+            'time' => now(),
+            'integration_id' => $integration->id,
+            'actor_id' => $actor->id,
+            'service' => 'oura',
+            'domain' => 'health',
+            'action' => 'had_readiness_score',
+            'value' => 50, // below lower bound → anomaly_low
+            'value_multiplier' => 1,
+            'value_unit' => 'percent',
+            'target_id' => $target->id,
+        ]);
+
+        (new DetectMetricAnomaliesJob($event))->handle();
+
+        $this->assertDatabaseHas('metric_trends', [
+            'metric_statistic_id' => $metric->id,
+            'type' => 'anomaly_low',
+        ]);
+    }
+
+    #[Test]
+    public function low_suppression_does_not_prevent_anomaly_high_creation(): void
+    {
+        [
+            'user' => $user,
+            'metric' => $metric,
+            'integration' => $integration,
+            'actor' => $actor,
+            'target' => $target,
+        ] = $this->makeSuppressionFixtures();
+
+        // Only suppress lows — highs should still fire.
+        $metric->update(['anomaly_low_suppressed_until' => now()->addDays(7)]);
+
+        $event = Event::create([
+            'source_id' => 'supp-direc-2',
+            'time' => now(),
+            'integration_id' => $integration->id,
+            'actor_id' => $actor->id,
+            'service' => 'oura',
+            'domain' => 'health',
+            'action' => 'had_readiness_score',
+            'value' => 95, // above upper bound → anomaly_high
+            'value_multiplier' => 1,
+            'value_unit' => 'percent',
+            'target_id' => $target->id,
+        ]);
+
+        (new DetectMetricAnomaliesJob($event))->handle();
+
+        $this->assertDatabaseHas('metric_trends', [
+            'metric_statistic_id' => $metric->id,
+            'type' => 'anomaly_high',
+        ]);
+    }
+
+    #[Test]
+    public function expired_suppression_allows_anomaly_creation(): void
+    {
+        [
+            'user' => $user,
+            'metric' => $metric,
+            'integration' => $integration,
+            'actor' => $actor,
+            'target' => $target,
+        ] = $this->makeSuppressionFixtures();
+
+        $metric->update(['anomaly_high_suppressed_until' => now()->subDay()]);
+
+        $event = Event::create([
+            'source_id' => 'supp-expired-1',
+            'time' => now(),
+            'integration_id' => $integration->id,
+            'actor_id' => $actor->id,
+            'service' => 'oura',
+            'domain' => 'health',
+            'action' => 'had_readiness_score',
+            'value' => 95,
+            'value_multiplier' => 1,
+            'value_unit' => 'percent',
+            'target_id' => $target->id,
+        ]);
+
+        (new DetectMetricAnomaliesJob($event))->handle();
+
+        $this->assertDatabaseHas('metric_trends', [
+            'metric_statistic_id' => $metric->id,
+            'type' => 'anomaly_high',
+        ]);
+    }
+
+    #[Test]
+    public function acknowledging_anomaly_high_with_suppress_until_sets_directional_column(): void
+    {
+        $user = User::factory()->create();
+        $metric = MetricStatistic::factory()->create([
+            'user_id' => $user->id,
+            'anomaly_high_suppressed_until' => null,
+            'anomaly_low_suppressed_until' => null,
+        ]);
+
+        $anomaly = MetricTrend::factory()->create([
+            'metric_statistic_id' => $metric->id,
+            'type' => 'anomaly_high',
+            'acknowledged_at' => null,
+        ]);
+
+        $service = app(AnomalyAcknowledgement::class);
+        $service->acknowledge($user, (string) $anomaly->id, [
+            'suppress_until' => now()->addDays(14)->toDateString(),
+        ]);
+
+        $metric->refresh();
+        $this->assertNotNull($metric->anomaly_high_suppressed_until);
+        $this->assertNull($metric->anomaly_low_suppressed_until);
+        $this->assertTrue($metric->anomaly_high_suppressed_until->isFuture());
+    }
+
+    #[Test]
+    public function acknowledging_anomaly_low_with_suppress_until_sets_directional_column(): void
+    {
+        $user = User::factory()->create();
+        $metric = MetricStatistic::factory()->create([
+            'user_id' => $user->id,
+            'anomaly_high_suppressed_until' => null,
+            'anomaly_low_suppressed_until' => null,
+        ]);
+
+        $anomaly = MetricTrend::factory()->create([
+            'metric_statistic_id' => $metric->id,
+            'type' => 'anomaly_low',
+            'acknowledged_at' => null,
+        ]);
+
+        $service = app(AnomalyAcknowledgement::class);
+        $service->acknowledge($user, (string) $anomaly->id, [
+            'suppress_until' => now()->addDays(14)->toDateString(),
+        ]);
+
+        $metric->refresh();
+        $this->assertNotNull($metric->anomaly_low_suppressed_until);
+        $this->assertNull($metric->anomaly_high_suppressed_until);
+        $this->assertTrue($metric->anomaly_low_suppressed_until->isFuture());
+    }
+
+    // -------------------------------------------------------------------------
+    // Directional suppression (CRX-655)
+    // -------------------------------------------------------------------------
+
+    private function makeSuppressionFixtures(string $service = 'oura', string $action = 'had_readiness_score', string $unit = 'percent'): array
+    {
+        $user = User::factory()->create();
+        $metric = MetricStatistic::factory()->create([
+            'user_id' => $user->id,
+            'service' => $service,
+            'action' => $action,
+            'value_unit' => $unit,
+            'mean_value' => 75,
+            'stddev_value' => 5,
+            'normal_lower_bound' => 65,
+            'normal_upper_bound' => 85,
+            'event_count' => 50,
+        ]);
+        $group = IntegrationGroup::factory()->create(['user_id' => $user->id]);
+        $integration = Integration::factory()->create([
+            'user_id' => $user->id,
+            'integration_group_id' => $group->id,
+        ]);
+        $actor = EventObject::factory()->create(['user_id' => $user->id]);
+        $target = EventObject::factory()->create(['user_id' => $user->id]);
+
+        return ['user' => $user, 'metric' => $metric, 'integration' => $integration, 'actor' => $actor, 'target' => $target];
     }
 }

--- a/tests/Feature/TaskPipeline/CommandsTest.php
+++ b/tests/Feature/TaskPipeline/CommandsTest.php
@@ -7,6 +7,7 @@ use App\Models\Event;
 use App\Services\TaskPipeline\TaskDefinition;
 use App\Services\TaskPipeline\TaskRegistry;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class CommandsTest extends TestCase
@@ -19,9 +20,7 @@ class CommandsTest extends TestCase
         TaskRegistry::clear();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function list_tasks_command_displays_registered_tasks(): void
     {
         TaskRegistry::register(new TaskDefinition(
@@ -38,9 +37,7 @@ class CommandsTest extends TestCase
             ->assertExitCode(0);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function list_tasks_command_with_json_output(): void
     {
         TaskRegistry::register(new TaskDefinition(
@@ -56,9 +53,7 @@ class CommandsTest extends TestCase
             ->assertExitCode(0);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function list_tasks_command_filters_by_model_type(): void
     {
         TaskRegistry::register(new TaskDefinition(
@@ -83,9 +78,7 @@ class CommandsTest extends TestCase
             ->assertExitCode(0);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function rerun_command_validates_model_type(): void
     {
         $this->artisan('task-pipeline:rerun test_task invalid_model abc-123')
@@ -93,9 +86,7 @@ class CommandsTest extends TestCase
             ->assertExitCode(1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function bulk_rerun_command_validates_model_type(): void
     {
         $this->artisan('task-pipeline:bulk-rerun test_task invalid_model')
@@ -103,9 +94,7 @@ class CommandsTest extends TestCase
             ->assertExitCode(1);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function bulk_rerun_command_dry_run_mode(): void
     {
         // Create a test event so the command has something to find

--- a/tests/Feature/TaskPipeline/DetectTrendsTaskTest.php
+++ b/tests/Feature/TaskPipeline/DetectTrendsTaskTest.php
@@ -1,0 +1,179 @@
+<?php
+
+namespace Tests\Feature\TaskPipeline;
+
+use App\Jobs\TaskPipeline\Tasks\DetectTrendsTask;
+use App\Models\Event;
+use App\Models\Integration;
+use App\Models\MetricStatistic;
+use App\Models\MetricTrend;
+use App\Services\TaskPipeline\TaskDefinition;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class DetectTrendsTaskTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function makeTask(): TaskDefinition
+    {
+        return new TaskDefinition(
+            key: 'detect_trends',
+            name: 'Detect Trends',
+            description: 'Detect metric trends',
+            jobClass: DetectTrendsTask::class,
+            appliesTo: ['event'],
+        );
+    }
+
+    #[Test]
+    public function does_nothing_when_event_has_no_value(): void
+    {
+        $integration = Integration::factory()->create();
+        $event = Event::factory()->create([
+            'integration_id' => $integration->id,
+            'value' => null,
+            'value_unit' => null,
+        ]);
+
+        $job = new DetectTrendsTask($event, $this->makeTask());
+        $job->handle();
+
+        $this->assertDatabaseCount('metric_trends', 0);
+    }
+
+    #[Test]
+    public function does_nothing_when_no_metric_statistic_exists(): void
+    {
+        $integration = Integration::factory()->create();
+        $event = Event::factory()->create([
+            'integration_id' => $integration->id,
+            'service' => 'oura',
+            'action' => 'had_readiness_score',
+            'value' => 80,
+            'value_multiplier' => 1,
+            'value_unit' => 'percent',
+        ]);
+
+        $job = new DetectTrendsTask($event, $this->makeTask());
+        $job->handle();
+
+        $this->assertDatabaseCount('metric_trends', 0);
+    }
+
+    #[Test]
+    public function creates_weekly_trend_when_significant_change_detected(): void
+    {
+        $integration = Integration::factory()->create();
+
+        $metric = MetricStatistic::factory()->create([
+            'user_id' => $integration->user_id,
+            'service' => 'oura',
+            'action' => 'had_readiness_score',
+            'value_unit' => 'percent',
+            'mean_value' => 70.0,
+            'stddev_value' => 5.0,
+            'normal_lower_bound' => 60.0,
+            'normal_upper_bound' => 80.0,
+        ]);
+
+        // Create historical events (4+ weeks ago) with low values
+        for ($i = 5; $i <= 8; $i++) {
+            Event::factory()->create([
+                'integration_id' => $integration->id,
+                'service' => 'oura',
+                'action' => 'had_readiness_score',
+                'value_unit' => 'percent',
+                'value' => 60,
+                'value_multiplier' => 1,
+                'time' => now()->subWeeks($i),
+            ]);
+        }
+
+        // Create current week events with significantly higher values
+        for ($i = 1; $i <= 3; $i++) {
+            Event::factory()->create([
+                'integration_id' => $integration->id,
+                'service' => 'oura',
+                'action' => 'had_readiness_score',
+                'value_unit' => 'percent',
+                'value' => 85,
+                'value_multiplier' => 1,
+                'time' => now()->startOfWeek()->addDays($i),
+            ]);
+        }
+
+        $triggerEvent = Event::factory()->create([
+            'integration_id' => $integration->id,
+            'service' => 'oura',
+            'action' => 'had_readiness_score',
+            'value_unit' => 'percent',
+            'value' => 85,
+            'value_multiplier' => 1,
+            'time' => now(),
+        ]);
+
+        $job = new DetectTrendsTask($triggerEvent, $this->makeTask());
+        $job->handle();
+
+        $this->assertDatabaseHas('metric_trends', [
+            'metric_statistic_id' => $metric->id,
+            'type' => 'trend_up_weekly',
+        ]);
+    }
+
+    #[Test]
+    public function does_not_create_duplicate_unacknowledged_trend(): void
+    {
+        $integration = Integration::factory()->create();
+
+        $metric = MetricStatistic::factory()->create([
+            'user_id' => $integration->user_id,
+            'service' => 'oura',
+            'action' => 'had_readiness_score',
+            'value_unit' => 'percent',
+            'mean_value' => 70.0,
+            'stddev_value' => 5.0,
+            'normal_lower_bound' => 60.0,
+            'normal_upper_bound' => 80.0,
+        ]);
+
+        // Pre-existing unacknowledged trend for this week
+        MetricTrend::factory()->create([
+            'metric_statistic_id' => $metric->id,
+            'type' => 'trend_up_weekly',
+            'acknowledged_at' => null,
+            'start_date' => now()->startOfWeek()->toDateString(),
+        ]);
+
+        // Create historical + current week data to trigger the same trend
+        for ($i = 5; $i <= 8; $i++) {
+            Event::factory()->create([
+                'integration_id' => $integration->id,
+                'service' => 'oura',
+                'action' => 'had_readiness_score',
+                'value_unit' => 'percent',
+                'value' => 60,
+                'value_multiplier' => 1,
+                'time' => now()->subWeeks($i),
+            ]);
+        }
+
+        $triggerEvent = Event::factory()->create([
+            'integration_id' => $integration->id,
+            'service' => 'oura',
+            'action' => 'had_readiness_score',
+            'value_unit' => 'percent',
+            'value' => 85,
+            'value_multiplier' => 1,
+            'time' => now()->startOfWeek()->addDay(),
+        ]);
+
+        $job = new DetectTrendsTask($triggerEvent, $this->makeTask());
+        $job->handle();
+
+        // Weekly trend count unchanged — no duplicate created for the same period
+        $this->assertEquals(1, MetricTrend::where('type', 'trend_up_weekly')->count());
+    }
+}

--- a/tests/Feature/TaskPipeline/DetectTrendsTaskTest.php
+++ b/tests/Feature/TaskPipeline/DetectTrendsTaskTest.php
@@ -16,17 +16,6 @@ class DetectTrendsTaskTest extends TestCase
 {
     use RefreshDatabase;
 
-    protected function makeTask(): TaskDefinition
-    {
-        return new TaskDefinition(
-            key: 'detect_trends',
-            name: 'Detect Trends',
-            description: 'Detect metric trends',
-            jobClass: DetectTrendsTask::class,
-            appliesTo: ['event'],
-        );
-    }
-
     #[Test]
     public function does_nothing_when_event_has_no_value(): void
     {
@@ -175,5 +164,16 @@ class DetectTrendsTaskTest extends TestCase
 
         // Weekly trend count unchanged — no duplicate created for the same period
         $this->assertEquals(1, MetricTrend::where('type', 'trend_up_weekly')->count());
+    }
+
+    protected function makeTask(): TaskDefinition
+    {
+        return new TaskDefinition(
+            key: 'detect_trends',
+            name: 'Detect Trends',
+            description: 'Detect metric trends',
+            jobClass: DetectTrendsTask::class,
+            appliesTo: ['event'],
+        );
     }
 }

--- a/tests/Feature/TaskPipeline/DispatchRetrospectiveAnomalyTasksJobTest.php
+++ b/tests/Feature/TaskPipeline/DispatchRetrospectiveAnomalyTasksJobTest.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace Tests\Feature\TaskPipeline;
+
+use App\Jobs\TaskPipeline\DispatchRetrospectiveAnomalyTasksJob;
+use App\Jobs\TaskPipeline\ProcessTaskPipelineJob;
+use App\Models\Event;
+use App\Models\Integration;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class DispatchRetrospectiveAnomalyTasksJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function skips_events_with_successful_anomaly_detection_in_event_metadata(): void
+    {
+        Queue::fake();
+
+        $integration = Integration::factory()->create();
+
+        // Event yesterday, value+unit set, already successfully processed
+        Event::factory()->create([
+            'integration_id' => $integration->id,
+            'time' => now()->subDay()->midDay(),
+            'value' => 100,
+            'value_unit' => 'kcal',
+            'event_metadata' => [
+                'task_executions' => [
+                    'detect_anomalies' => [
+                        'last_attempt' => ['status' => 'success'],
+                    ],
+                ],
+            ],
+        ]);
+
+        (new DispatchRetrospectiveAnomalyTasksJob)->handle();
+
+        Queue::assertNotPushed(ProcessTaskPipelineJob::class);
+    }
+
+    #[Test]
+    public function dispatches_for_events_without_successful_anomaly_detection(): void
+    {
+        Queue::fake();
+
+        $integration = Integration::factory()->create();
+
+        // Event yesterday, value+unit set, no task execution recorded
+        Event::factory()->create([
+            'integration_id' => $integration->id,
+            'time' => now()->subDay()->midDay(),
+            'value' => 100,
+            'value_unit' => 'kcal',
+            'event_metadata' => [],
+        ]);
+
+        (new DispatchRetrospectiveAnomalyTasksJob)->handle();
+
+        Queue::assertPushed(ProcessTaskPipelineJob::class);
+    }
+
+    #[Test]
+    public function does_not_dispatch_for_events_outside_yesterday(): void
+    {
+        Queue::fake();
+
+        $integration = Integration::factory()->create();
+
+        // Event from two days ago (outside yesterday window)
+        Event::factory()->create([
+            'integration_id' => $integration->id,
+            'time' => now()->subDays(2)->midDay(),
+            'value' => 100,
+            'value_unit' => 'kcal',
+            'event_metadata' => [],
+        ]);
+
+        (new DispatchRetrospectiveAnomalyTasksJob)->handle();
+
+        Queue::assertNotPushed(ProcessTaskPipelineJob::class);
+    }
+}

--- a/tests/Feature/TaskPipeline/FetchExtractContentTaskTest.php
+++ b/tests/Feature/TaskPipeline/FetchExtractContentTaskTest.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace Tests\Feature\TaskPipeline;
+
+use App\Integrations\Fetch\FetchPlugin;
+use App\Jobs\TaskPipeline\ProcessTaskPipelineJob;
+use App\Jobs\TaskPipeline\Tasks\FetchExtractContentTask;
+use App\Models\Block;
+use App\Models\Event;
+use App\Models\EventObject;
+use App\Models\Integration;
+use App\Services\TaskPipeline\TaskDefinition;
+use Exception;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use OpenAI\Laravel\Facades\OpenAI;
+use OpenAI\Resources\Chat;
+use OpenAI\Responses\Chat\CreateResponse;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class FetchExtractContentTaskTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_extracts_fetch_content_and_marks_success(): void
+    {
+        Queue::fake([ProcessTaskPipelineJob::class]);
+        $fake = OpenAI::fake([$this->openAiResponse('# Clean Article')]);
+
+        [$event, $webpage] = $this->fetchEvent(webpageContent: null, blockText: 'Raw article text');
+
+        (new FetchExtractContentTask($event, $this->task()))->handle();
+
+        $this->assertSame('# Clean Article', $webpage->refresh()->content);
+        $this->assertSame('success', $event->refresh()->event_metadata['task_executions']['fetch_extract_content']['last_attempt']['status']);
+        Queue::assertPushed(ProcessTaskPipelineJob::class);
+        $fake->assertSent(Chat::class, 1);
+    }
+
+    #[Test]
+    public function should_run_guard_skips_when_webpage_content_already_exists(): void
+    {
+        [$event] = $this->fetchEvent(webpageContent: 'Already extracted', blockText: 'Raw article text');
+
+        $definition = collect(FetchPlugin::getTaskDefinitions())
+            ->firstWhere('key', 'fetch_extract_content');
+
+        $this->assertFalse($definition->isApplicableTo($event));
+    }
+
+    #[Test]
+    public function it_marks_failed_when_fetch_content_block_is_missing_text(): void
+    {
+        [$event] = $this->fetchEvent(webpageContent: null, blockText: '');
+
+        $this->expectException(Exception::class);
+
+        try {
+            (new FetchExtractContentTask($event, $this->task()))->handle();
+        } finally {
+            $this->assertSame('failed', $event->refresh()->event_metadata['task_executions']['fetch_extract_content']['last_attempt']['status']);
+        }
+    }
+
+    private function fetchEvent(?string $webpageContent, string $blockText): array
+    {
+        Queue::fake([ProcessTaskPipelineJob::class]);
+        $integration = Integration::factory()->create(['service' => 'fetch']);
+        $webpage = EventObject::factory()->create([
+            'user_id' => $integration->user_id,
+            'concept' => 'webpage',
+            'type' => 'fetch_webpage',
+            'title' => 'Article Title',
+            'content' => $webpageContent,
+            'metadata' => ['author' => 'Author', 'direction' => 'ltr'],
+        ]);
+
+        $event = Event::factory()->create([
+            'integration_id' => $integration->id,
+            'target_id' => $webpage->id,
+            'service' => 'fetch',
+            'domain' => 'knowledge',
+            'action' => 'fetched',
+        ]);
+
+        Block::factory()->create([
+            'event_id' => $event->id,
+            'block_type' => 'fetch_content',
+            'title' => 'Raw Content',
+            'metadata' => [
+                'html' => '<article>Raw article text</article>',
+                'text' => $blockText,
+                'excerpt' => 'Excerpt',
+            ],
+        ]);
+
+        return [$event->fresh(['blocks', 'target']), $webpage];
+    }
+
+    private function task(): TaskDefinition
+    {
+        return new TaskDefinition(
+            key: 'fetch_extract_content',
+            name: 'Fetch: Extract Content',
+            description: 'Extract clean Markdown from fetched article HTML using AI',
+            jobClass: FetchExtractContentTask::class,
+            appliesTo: ['event'],
+        );
+    }
+
+    private function openAiResponse(string $content): CreateResponse
+    {
+        return CreateResponse::fake([
+            'choices' => [
+                [
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => $content,
+                    ],
+                ],
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/TaskPipeline/FetchGenerateSummariesTaskTest.php
+++ b/tests/Feature/TaskPipeline/FetchGenerateSummariesTaskTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Tests\Feature\TaskPipeline;
+
+use App\Integrations\Fetch\FetchPlugin;
+use App\Jobs\TaskPipeline\ProcessTaskPipelineJob;
+use App\Jobs\TaskPipeline\Tasks\FetchGenerateSummariesTask;
+use App\Models\Block;
+use App\Models\Event;
+use App\Models\EventObject;
+use App\Models\Integration;
+use App\Services\TaskPipeline\TaskDefinition;
+use Exception;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use OpenAI\Laravel\Facades\OpenAI;
+use OpenAI\Resources\Chat;
+use OpenAI\Responses\Chat\CreateResponse;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class FetchGenerateSummariesTaskTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_generates_fetch_summary_blocks_and_marks_success(): void
+    {
+        $fake = OpenAI::fake([$this->openAiResponse(json_encode($this->summaryPayload()))]);
+
+        [$event, $webpage] = $this->fetchEvent(content: 'Clean article text');
+
+        (new FetchGenerateSummariesTask($event, $this->task()))->handle();
+
+        $this->assertSame(5, $event->blocks()->whereIn('block_type', [
+            'fetch_summary_tweet',
+            'fetch_summary_short',
+            'fetch_summary_paragraph',
+            'fetch_key_takeaways',
+            'fetch_tldr',
+        ])->count());
+        $this->assertNotEmpty($webpage->refresh()->metadata['extracted_at']);
+        $this->assertSame('success', $event->refresh()->event_metadata['task_executions']['fetch_generate_summaries']['last_attempt']['status']);
+        $fake->assertSent(Chat::class, 1);
+    }
+
+    #[Test]
+    public function should_run_guard_skips_when_tldr_already_exists(): void
+    {
+        [$event] = $this->fetchEvent(content: 'Clean article text');
+        Block::factory()->create([
+            'event_id' => $event->id,
+            'block_type' => 'fetch_tldr',
+            'title' => 'TL;DR',
+            'metadata' => ['content' => 'Already summarized'],
+        ]);
+
+        $definition = collect(FetchPlugin::getTaskDefinitions())
+            ->firstWhere('key', 'fetch_generate_summaries');
+
+        $this->assertFalse($definition->isApplicableTo($event));
+    }
+
+    #[Test]
+    public function it_marks_failed_when_content_is_missing(): void
+    {
+        [$event] = $this->fetchEvent(content: null);
+
+        $this->expectException(Exception::class);
+
+        try {
+            (new FetchGenerateSummariesTask($event, $this->task()))->handle();
+        } finally {
+            $this->assertSame('failed', $event->refresh()->event_metadata['task_executions']['fetch_generate_summaries']['last_attempt']['status']);
+        }
+    }
+
+    private function fetchEvent(?string $content): array
+    {
+        Queue::fake([ProcessTaskPipelineJob::class]);
+        $integration = Integration::factory()->create(['service' => 'fetch']);
+        $webpage = EventObject::factory()->create([
+            'user_id' => $integration->user_id,
+            'concept' => 'webpage',
+            'type' => 'fetch_webpage',
+            'title' => 'Article Title',
+            'content' => $content,
+            'metadata' => ['author' => 'Author', 'direction' => 'ltr'],
+        ]);
+
+        $event = Event::factory()->create([
+            'integration_id' => $integration->id,
+            'target_id' => $webpage->id,
+            'service' => 'fetch',
+            'domain' => 'knowledge',
+            'action' => 'fetched',
+        ]);
+
+        Block::factory()->create([
+            'event_id' => $event->id,
+            'block_type' => 'fetch_content',
+            'title' => 'Raw Content',
+            'metadata' => [
+                'html' => '<article>Raw article text</article>',
+                'text' => 'Raw article text',
+                'excerpt' => 'Excerpt',
+            ],
+        ]);
+
+        return [$event->fresh(['blocks', 'target']), $webpage];
+    }
+
+    private function task(): TaskDefinition
+    {
+        return new TaskDefinition(
+            key: 'fetch_generate_summaries',
+            name: 'Fetch: Generate Summaries',
+            description: 'Generate AI summary blocks and tags for a fetched article',
+            jobClass: FetchGenerateSummariesTask::class,
+            appliesTo: ['event'],
+        );
+    }
+
+    private function summaryPayload(): array
+    {
+        return [
+            'summary_tweet' => 'Tweet',
+            'summary_short' => 'Short summary',
+            'summary_paragraph' => 'Paragraph summary',
+            'key_takeaways' => ['One', 'Two', 'Three'],
+            'tldr' => 'TLDR',
+            'emoji' => '',
+            'tags' => [],
+        ];
+    }
+
+    private function openAiResponse(string $content): CreateResponse
+    {
+        return CreateResponse::fake([
+            'choices' => [
+                [
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => $content,
+                    ],
+                ],
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/TaskPipeline/GenerateEmbeddingTaskTest.php
+++ b/tests/Feature/TaskPipeline/GenerateEmbeddingTaskTest.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace Tests\Feature\TaskPipeline;
+
+use App\Jobs\TaskPipeline\Tasks\GenerateEmbeddingTask;
+use App\Models\Event;
+use App\Services\EmbeddingService;
+use App\Services\TaskPipeline\TaskDefinition;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Mockery;
+use RuntimeException;
+use Tests\TestCase;
+
+class GenerateEmbeddingTaskTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @test
+     */
+    public function stores_successful_embedding_and_marks_task_successful(): void
+    {
+        $event = Event::factory()->create([
+            'action' => 'paid',
+            'domain' => 'money',
+            'service' => 'monzo',
+        ]);
+
+        $embedding = $this->validEmbedding();
+        $embeddingService = Mockery::mock(EmbeddingService::class);
+        $embeddingService->shouldReceive('embed')->once()->andReturn($embedding);
+        $embeddingService->shouldReceive('getEmbeddingMetadata')->once()->andReturn([
+            'embedding_model' => 'text-embedding-3-small',
+            'embedding_dimensions' => 1536,
+            'embedding_generated_at' => now()->toIso8601String(),
+        ]);
+        $this->instance(EmbeddingService::class, $embeddingService);
+
+        (new GenerateEmbeddingTask($event, $this->taskDefinition()))->handle();
+
+        $event->refresh();
+
+        $this->assertNotNull($event->embeddings);
+        $this->assertSame('text-embedding-3-small', $event->event_metadata['embedding_model']);
+        $this->assertSame('success', $event->event_metadata['task_executions']['generate_embedding']['last_attempt']['status']);
+        $this->assertSame('success', $event->event_metadata['task_executions']['generate_embedding']['last_success']['status']);
+    }
+
+    /**
+     * @test
+     */
+    public function provider_failure_marks_task_failed_and_does_not_store_embedding(): void
+    {
+        $event = Event::factory()->create();
+
+        $embeddingService = Mockery::mock(EmbeddingService::class);
+        $embeddingService->shouldReceive('embed')->once()->andThrow(new RuntimeException('provider unavailable'));
+        $embeddingService->shouldReceive('getEmbeddingMetadata')->never();
+        $this->instance(EmbeddingService::class, $embeddingService);
+
+        try {
+            (new GenerateEmbeddingTask($event, $this->taskDefinition()))->handle();
+            $this->fail('Expected embedding task to fail.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame('provider unavailable', $exception->getMessage());
+        }
+
+        $event->refresh();
+
+        $this->assertNull($event->embeddings);
+        $this->assertSame('failed', $event->event_metadata['task_executions']['generate_embedding']['last_attempt']['status']);
+        $this->assertSame('provider unavailable', $event->event_metadata['task_executions']['generate_embedding']['last_attempt']['error']);
+        $this->assertArrayNotHasKey('last_success', $event->event_metadata['task_executions']['generate_embedding']);
+    }
+
+    /**
+     * @test
+     */
+    public function zero_vector_marks_task_failed_and_does_not_store_embedding(): void
+    {
+        $event = Event::factory()->create();
+
+        $embeddingService = Mockery::mock(EmbeddingService::class);
+        $embeddingService->shouldReceive('embed')->once()->andReturn(array_fill(0, 1536, 0.0));
+        $embeddingService->shouldReceive('getEmbeddingMetadata')->never();
+        $this->instance(EmbeddingService::class, $embeddingService);
+
+        try {
+            (new GenerateEmbeddingTask($event, $this->taskDefinition()))->handle();
+            $this->fail('Expected embedding task to reject zero vector.');
+        } catch (RuntimeException $exception) {
+            $this->assertSame('Embedding provider returned a zero vector', $exception->getMessage());
+        }
+
+        $event->refresh();
+
+        $this->assertNull($event->embeddings);
+        $this->assertSame('failed', $event->event_metadata['task_executions']['generate_embedding']['last_attempt']['status']);
+        $this->assertSame(
+            'Embedding provider returned a zero vector',
+            $event->event_metadata['task_executions']['generate_embedding']['last_attempt']['error']
+        );
+        $this->assertArrayNotHasKey('last_success', $event->event_metadata['task_executions']['generate_embedding']);
+    }
+
+    private function taskDefinition(): TaskDefinition
+    {
+        return new TaskDefinition(
+            key: 'generate_embedding',
+            name: 'Generate Embedding',
+            description: 'Generate AI embedding for semantic search',
+            jobClass: GenerateEmbeddingTask::class,
+            appliesTo: ['event'],
+        );
+    }
+
+    private function validEmbedding(): array
+    {
+        $embedding = array_fill(0, 1536, 0.0);
+        $embedding[0] = 0.25;
+
+        return $embedding;
+    }
+}

--- a/tests/Feature/TaskPipeline/GenerateEmbeddingTaskTest.php
+++ b/tests/Feature/TaskPipeline/GenerateEmbeddingTaskTest.php
@@ -8,6 +8,7 @@ use App\Services\EmbeddingService;
 use App\Services\TaskPipeline\TaskDefinition;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Mockery;
+use PHPUnit\Framework\Attributes\Test;
 use RuntimeException;
 use Tests\TestCase;
 
@@ -15,9 +16,7 @@ class GenerateEmbeddingTaskTest extends TestCase
 {
     use RefreshDatabase;
 
-    /**
-     * @test
-     */
+    #[Test]
     public function stores_successful_embedding_and_marks_task_successful(): void
     {
         $event = Event::factory()->create([
@@ -46,9 +45,7 @@ class GenerateEmbeddingTaskTest extends TestCase
         $this->assertSame('success', $event->event_metadata['task_executions']['generate_embedding']['last_success']['status']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function provider_failure_marks_task_failed_and_does_not_store_embedding(): void
     {
         $event = Event::factory()->create();
@@ -73,9 +70,7 @@ class GenerateEmbeddingTaskTest extends TestCase
         $this->assertArrayNotHasKey('last_success', $event->event_metadata['task_executions']['generate_embedding']);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function zero_vector_marks_task_failed_and_does_not_store_embedding(): void
     {
         $event = Event::factory()->create();

--- a/tests/Feature/TaskPipeline/MigrateTaskExecutionsCommandTest.php
+++ b/tests/Feature/TaskPipeline/MigrateTaskExecutionsCommandTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Tests\Feature\TaskPipeline;
+
+use App\Jobs\TaskPipeline\MigrateTaskExecutionsBatchJob;
+use App\Models\Event;
+use App\Models\TaskExecution;
+use App\Services\TaskPipeline\TaskExecutionStore;
+use Illuminate\Support\Facades\Queue;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class MigrateTaskExecutionsCommandTest extends TestCase
+{
+    #[Test]
+    public function dry_run_counts_legacy_metadata_without_dispatching_jobs(): void
+    {
+        Queue::fake();
+
+        Event::factory()->create([
+            'event_metadata' => [
+                'task_executions' => [
+                    'generate_embedding' => [
+                        'last_attempt' => ['status' => 'success'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->artisan('task-pipeline:migrate-executions --model=event --dry-run')
+            ->assertSuccessful();
+
+        Queue::assertNotPushed(MigrateTaskExecutionsBatchJob::class);
+    }
+
+    #[Test]
+    public function dispatches_batch_job_to_migration_queue(): void
+    {
+        Queue::fake();
+
+        $this->artisan('task-pipeline:migrate-executions --model=event --batch-size=25 --limit=50')
+            ->assertSuccessful();
+
+        Queue::assertPushedOn('migration', MigrateTaskExecutionsBatchJob::class, function (MigrateTaskExecutionsBatchJob $job) {
+            return $job->modelType === 'event'
+                && $job->batchSize === 25
+                && $job->limit === 50
+                && $job->force === false;
+        });
+    }
+
+    #[Test]
+    public function batch_job_preserves_existing_rows_unless_forced(): void
+    {
+        $event = Event::factory()->create([
+            'event_metadata' => [
+                'task_executions' => [
+                    'generate_embedding' => [
+                        'last_attempt' => ['status' => 'success', 'attempts' => 1],
+                    ],
+                ],
+            ],
+        ]);
+
+        $existing = TaskExecution::factory()->create([
+            'user_id' => $event->integration->user_id,
+            'entity_type' => 'event',
+            'entity_id' => $event->id,
+            'task_key' => 'generate_embedding',
+            'status' => 'failed',
+        ]);
+
+        (new MigrateTaskExecutionsBatchJob('event', null, 1, 1, false))
+            ->handle(app(TaskExecutionStore::class));
+
+        $this->assertSame('failed', $existing->refresh()->status);
+
+        (new MigrateTaskExecutionsBatchJob('event', null, 1, 1, true))
+            ->handle(app(TaskExecutionStore::class));
+
+        $this->assertSame('success', $existing->refresh()->status);
+    }
+
+    #[Test]
+    public function batch_job_chains_next_batch_on_migration_queue(): void
+    {
+        Queue::fake();
+
+        Event::factory()->count(2)->create([
+            'event_metadata' => [
+                'task_executions' => [
+                    'generate_embedding' => [
+                        'last_attempt' => ['status' => 'success', 'attempts' => 1],
+                    ],
+                ],
+            ],
+        ]);
+
+        (new MigrateTaskExecutionsBatchJob('event', null, 1, 2, false))
+            ->handle(app(TaskExecutionStore::class));
+
+        Queue::assertPushedOn('migration', MigrateTaskExecutionsBatchJob::class, function (MigrateTaskExecutionsBatchJob $job) {
+            return $job->modelType === 'event'
+                && $job->cursor !== null
+                && $job->batchSize === 1
+                && $job->limit === 2;
+        });
+    }
+}

--- a/tests/Feature/TaskPipeline/NewsletterExtractContentTaskTest.php
+++ b/tests/Feature/TaskPipeline/NewsletterExtractContentTaskTest.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Tests\Feature\TaskPipeline;
+
+use App\Integrations\Newsletter\NewsletterPlugin;
+use App\Jobs\TaskPipeline\ProcessTaskPipelineJob;
+use App\Jobs\TaskPipeline\Tasks\NewsletterExtractContentTask;
+use App\Models\Event;
+use App\Models\EventObject;
+use App\Models\Integration;
+use App\Services\TaskPipeline\TaskDefinition;
+use Exception;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use OpenAI\Laravel\Facades\OpenAI;
+use OpenAI\Resources\Chat;
+use OpenAI\Responses\Chat\CreateResponse;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class NewsletterExtractContentTaskTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_extracts_newsletter_content_and_marks_success(): void
+    {
+        Queue::fake([ProcessTaskPipelineJob::class]);
+        $fake = OpenAI::fake([$this->openAiResponse('# Clean Newsletter')]);
+
+        [$event, $publication] = $this->newsletterEvent(rawHtml: '<html>Raw newsletter</html>');
+
+        (new NewsletterExtractContentTask($event, $this->task()))->handle();
+
+        $this->assertSame('# Clean Newsletter', $publication->refresh()->content);
+        $this->assertNotEmpty($publication->metadata['extracted_at']);
+        $this->assertSame('success', $event->refresh()->event_metadata['task_executions']['newsletter_extract_content']['last_attempt']['status']);
+        Queue::assertPushed(ProcessTaskPipelineJob::class);
+        $fake->assertSent(Chat::class, 1);
+    }
+
+    #[Test]
+    public function should_run_guard_skips_when_already_extracted(): void
+    {
+        [$event] = $this->newsletterEvent(rawHtml: '<html>Raw newsletter</html>', extractedAt: now()->toIso8601String());
+
+        $definition = collect(NewsletterPlugin::getTaskDefinitions())
+            ->firstWhere('key', 'newsletter_extract_content');
+
+        $this->assertFalse($definition->isApplicableTo($event));
+    }
+
+    #[Test]
+    public function it_marks_failed_when_raw_html_is_missing(): void
+    {
+        [$event] = $this->newsletterEvent(rawHtml: null);
+
+        $this->expectException(Exception::class);
+
+        try {
+            (new NewsletterExtractContentTask($event, $this->task()))->handle();
+        } finally {
+            $this->assertSame('failed', $event->refresh()->event_metadata['task_executions']['newsletter_extract_content']['last_attempt']['status']);
+        }
+    }
+
+    private function newsletterEvent(?string $rawHtml, ?string $extractedAt = null): array
+    {
+        Queue::fake([ProcessTaskPipelineJob::class]);
+        $integration = Integration::factory()->create(['service' => 'newsletter']);
+        $publication = EventObject::factory()->create([
+            'user_id' => $integration->user_id,
+            'concept' => 'publication',
+            'type' => 'newsletter_publication',
+            'content' => null,
+            'metadata' => array_filter(['extracted_at' => $extractedAt]),
+        ]);
+
+        $event = Event::factory()->create([
+            'integration_id' => $integration->id,
+            'target_id' => $publication->id,
+            'service' => 'newsletter',
+            'domain' => 'knowledge',
+            'action' => 'received_post',
+            'event_metadata' => array_filter([
+                'email_subject' => 'Subject',
+                'raw_html' => $rawHtml,
+            ], fn ($value) => $value !== null),
+        ]);
+
+        return [$event, $publication];
+    }
+
+    private function task(): TaskDefinition
+    {
+        return new TaskDefinition(
+            key: 'newsletter_extract_content',
+            name: 'Newsletter: Extract Content',
+            description: 'Extract clean Markdown from raw newsletter HTML using AI',
+            jobClass: NewsletterExtractContentTask::class,
+            appliesTo: ['event'],
+        );
+    }
+
+    private function openAiResponse(string $content): CreateResponse
+    {
+        return CreateResponse::fake([
+            'choices' => [
+                [
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => $content,
+                    ],
+                ],
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/TaskPipeline/NewsletterGenerateSummariesTaskTest.php
+++ b/tests/Feature/TaskPipeline/NewsletterGenerateSummariesTaskTest.php
@@ -1,0 +1,137 @@
+<?php
+
+namespace Tests\Feature\TaskPipeline;
+
+use App\Integrations\Newsletter\NewsletterPlugin;
+use App\Jobs\TaskPipeline\ProcessTaskPipelineJob;
+use App\Jobs\TaskPipeline\Tasks\NewsletterGenerateSummariesTask;
+use App\Models\Block;
+use App\Models\Event;
+use App\Models\EventObject;
+use App\Models\Integration;
+use App\Services\TaskPipeline\TaskDefinition;
+use Exception;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use OpenAI\Laravel\Facades\OpenAI;
+use OpenAI\Resources\Chat;
+use OpenAI\Responses\Chat\CreateResponse;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class NewsletterGenerateSummariesTaskTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_generates_newsletter_summary_blocks_and_marks_success(): void
+    {
+        $fake = OpenAI::fake([$this->openAiResponse(json_encode($this->summaryPayload()))]);
+
+        [$event] = $this->newsletterEvent(content: 'Clean article text');
+
+        (new NewsletterGenerateSummariesTask($event, $this->task()))->handle();
+
+        $this->assertSame(5, $event->blocks()->whereIn('block_type', [
+            'newsletter_summary_tweet',
+            'newsletter_summary_short',
+            'newsletter_summary_paragraph',
+            'newsletter_key_takeaways',
+            'newsletter_tldr',
+        ])->count());
+        $this->assertSame('success', $event->refresh()->event_metadata['task_executions']['newsletter_generate_summaries']['last_attempt']['status']);
+        $fake->assertSent(Chat::class, 1);
+    }
+
+    #[Test]
+    public function should_run_guard_skips_when_tldr_already_exists(): void
+    {
+        [$event] = $this->newsletterEvent(content: 'Clean article text');
+        Block::factory()->create([
+            'event_id' => $event->id,
+            'block_type' => 'newsletter_tldr',
+            'title' => 'TL;DR',
+            'metadata' => ['content' => 'Already summarized'],
+        ]);
+
+        $definition = collect(NewsletterPlugin::getTaskDefinitions())
+            ->firstWhere('key', 'newsletter_generate_summaries');
+
+        $this->assertFalse($definition->isApplicableTo($event));
+    }
+
+    #[Test]
+    public function it_marks_failed_when_content_is_missing(): void
+    {
+        [$event] = $this->newsletterEvent(content: null);
+
+        $this->expectException(Exception::class);
+
+        try {
+            (new NewsletterGenerateSummariesTask($event, $this->task()))->handle();
+        } finally {
+            $this->assertSame('failed', $event->refresh()->event_metadata['task_executions']['newsletter_generate_summaries']['last_attempt']['status']);
+        }
+    }
+
+    private function newsletterEvent(?string $content): array
+    {
+        Queue::fake([ProcessTaskPipelineJob::class]);
+        $integration = Integration::factory()->create(['service' => 'newsletter']);
+        $publication = EventObject::factory()->create([
+            'user_id' => $integration->user_id,
+            'concept' => 'publication',
+            'type' => 'newsletter_publication',
+            'content' => $content,
+        ]);
+
+        $event = Event::factory()->create([
+            'integration_id' => $integration->id,
+            'target_id' => $publication->id,
+            'service' => 'newsletter',
+            'domain' => 'knowledge',
+            'action' => 'received_post',
+            'event_metadata' => ['email_subject' => 'Subject'],
+        ]);
+
+        return [$event, $publication];
+    }
+
+    private function task(): TaskDefinition
+    {
+        return new TaskDefinition(
+            key: 'newsletter_generate_summaries',
+            name: 'Newsletter: Generate Summaries',
+            description: 'Generate AI summary blocks and tags for a newsletter event',
+            jobClass: NewsletterGenerateSummariesTask::class,
+            appliesTo: ['event'],
+        );
+    }
+
+    private function summaryPayload(): array
+    {
+        return [
+            'summary_tweet' => 'Tweet',
+            'summary_short' => 'Short summary',
+            'summary_paragraph' => 'Paragraph summary',
+            'key_takeaways' => ['One', 'Two', 'Three'],
+            'tldr' => 'TLDR',
+            'emoji' => '',
+            'tags' => [],
+        ];
+    }
+
+    private function openAiResponse(string $content): CreateResponse
+    {
+        return CreateResponse::fake([
+            'choices' => [
+                [
+                    'message' => [
+                        'role' => 'assistant',
+                        'content' => $content,
+                    ],
+                ],
+            ],
+        ]);
+    }
+}

--- a/tests/Feature/TaskPipeline/RecordingDependentTask.php
+++ b/tests/Feature/TaskPipeline/RecordingDependentTask.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\Feature\TaskPipeline;
+
+use App\Jobs\TaskPipeline\BaseTaskJob;
+
+class RecordingDependentTask extends BaseTaskJob
+{
+    public static array $executed = [];
+
+    protected function execute(): void
+    {
+        static::$executed[] = $this->model->id;
+    }
+}

--- a/tests/Feature/TaskPipeline/RecordingPrerequisiteTask.php
+++ b/tests/Feature/TaskPipeline/RecordingPrerequisiteTask.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Tests\Feature\TaskPipeline;
+
+use App\Jobs\TaskPipeline\BaseTaskJob;
+
+class RecordingPrerequisiteTask extends BaseTaskJob
+{
+    public static array $executed = [];
+
+    protected function execute(): void
+    {
+        static::$executed[] = $this->model->id;
+    }
+}

--- a/tests/Feature/TaskPipeline/TaskExecutionApiTest.php
+++ b/tests/Feature/TaskPipeline/TaskExecutionApiTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Feature\TaskPipeline;
+
+use App\Models\TaskExecution;
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class TaskExecutionApiTest extends TestCase
+{
+    #[Test]
+    public function index_is_scoped_to_authenticated_user_and_filterable(): void
+    {
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+
+        $matching = TaskExecution::factory()->create([
+            'user_id' => $user->id,
+            'status' => 'failed',
+            'task_key' => 'generate_embedding',
+            'entity_type' => 'event',
+            'queue' => 'tasks',
+        ]);
+        TaskExecution::factory()->create(['user_id' => $user->id, 'status' => 'success']);
+        TaskExecution::factory()->create(['user_id' => $otherUser->id, 'status' => 'failed']);
+
+        Sanctum::actingAs($user);
+
+        $response = $this->getJson('/api/task-executions?status=failed&task_key=generate_embedding&per_page=10');
+
+        $response->assertOk()
+            ->assertJsonPath('data.0.id', $matching->id)
+            ->assertJsonCount(1, 'data');
+    }
+
+    #[Test]
+    public function show_does_not_expose_other_users_task_execution(): void
+    {
+        $user = User::factory()->create();
+        $otherUser = User::factory()->create();
+        $execution = TaskExecution::factory()->create(['user_id' => $otherUser->id]);
+
+        Sanctum::actingAs($user);
+
+        $this->getJson("/api/task-executions/{$execution->id}")->assertNotFound();
+    }
+}

--- a/tests/Feature/TaskPipeline/TaskPipelineIntegrationTest.php
+++ b/tests/Feature/TaskPipeline/TaskPipelineIntegrationTest.php
@@ -12,6 +12,7 @@ use App\Services\TaskPipeline\TaskDefinition;
 use App\Services\TaskPipeline\TaskRegistry;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Queue;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class TaskPipelineIntegrationTest extends TestCase
@@ -24,9 +25,7 @@ class TaskPipelineIntegrationTest extends TestCase
         TaskRegistry::clear();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function dispatches_applicable_tasks_on_event_creation(): void
     {
         Queue::fake();
@@ -56,9 +55,7 @@ class TaskPipelineIntegrationTest extends TestCase
         Queue::assertPushed(ProcessTaskPipelineJob::class);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function does_not_dispatch_tasks_when_conditions_not_met(): void
     {
         Queue::fake();
@@ -123,9 +120,7 @@ class TaskPipelineIntegrationTest extends TestCase
         $this->assertArrayNotHasKey('monzo_only_task', $executions);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function respects_task_dependencies(): void
     {
         TaskRegistry::clear();
@@ -160,9 +155,142 @@ class TaskPipelineIntegrationTest extends TestCase
         $this->assertEquals('task2', $ordered->last()->key);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
+    public function dispatcher_only_queues_dependent_tasks_after_prerequisites_succeed(): void
+    {
+        Queue::fake();
+
+        TaskRegistry::register(new TaskDefinition(
+            key: 'prerequisite_task',
+            name: 'Prerequisite Task',
+            description: 'Must complete first',
+            jobClass: RecordingPrerequisiteTask::class,
+            appliesTo: ['event'],
+            dependencies: [],
+            priority: 100,
+        ));
+
+        TaskRegistry::register(new TaskDefinition(
+            key: 'dependent_task',
+            name: 'Dependent Task',
+            description: 'Must wait',
+            jobClass: RecordingDependentTask::class,
+            appliesTo: ['event'],
+            dependencies: ['prerequisite_task'],
+            priority: 90,
+        ));
+
+        $event = Event::factory()->create();
+
+        (new ProcessTaskPipelineJob($event, 'created'))->handle();
+
+        Queue::assertPushed(RecordingPrerequisiteTask::class, 1);
+        Queue::assertNotPushed(RecordingDependentTask::class);
+
+        $executions = $event->refresh()->event_metadata['task_executions'];
+        $this->assertSame('pending', $executions['prerequisite_task']['last_attempt']['status']);
+        $this->assertSame('waiting', $executions['dependent_task']['last_attempt']['status']);
+        $this->assertSame('prerequisite_task', $executions['dependent_task']['last_attempt']['waiting_for']);
+    }
+
+    #[Test]
+    public function dependent_task_job_does_not_execute_when_queue_runs_out_of_order(): void
+    {
+        Queue::fake();
+        RecordingDependentTask::$executed = [];
+
+        $prerequisite = new TaskDefinition(
+            key: 'prerequisite_task',
+            name: 'Prerequisite Task',
+            description: 'Must complete first',
+            jobClass: RecordingPrerequisiteTask::class,
+            appliesTo: ['event'],
+        );
+
+        $dependent = new TaskDefinition(
+            key: 'dependent_task',
+            name: 'Dependent Task',
+            description: 'Must wait',
+            jobClass: RecordingDependentTask::class,
+            appliesTo: ['event'],
+            dependencies: ['prerequisite_task'],
+        );
+
+        TaskRegistry::register($prerequisite);
+        TaskRegistry::register($dependent);
+
+        $event = Event::factory()->create();
+
+        (new RecordingDependentTask($event, $dependent))->handle();
+
+        $this->assertSame([], RecordingDependentTask::$executed);
+        $this->assertSame(
+            'waiting',
+            $event->refresh()->event_metadata['task_executions']['dependent_task']['last_attempt']['status']
+        );
+
+        $event->update([
+            'event_metadata' => [
+                'task_executions' => [
+                    'prerequisite_task' => [
+                        'last_attempt' => ['status' => 'failed'],
+                    ],
+                ],
+            ],
+        ]);
+
+        (new RecordingDependentTask($event, $dependent))->handle();
+
+        $executions = $event->refresh()->event_metadata['task_executions'];
+        $this->assertSame([], RecordingDependentTask::$executed);
+        $this->assertSame('blocked', $executions['dependent_task']['last_attempt']['status']);
+        $this->assertSame('prerequisite_task', $executions['dependent_task']['last_attempt']['blocked_by']);
+    }
+
+    #[Test]
+    public function successful_task_completion_dispatches_dependent_tasks_for_re_evaluation(): void
+    {
+        Queue::fake([ProcessTaskPipelineJob::class]);
+        RecordingPrerequisiteTask::$executed = [];
+
+        $prerequisite = new TaskDefinition(
+            key: 'prerequisite_task',
+            name: 'Prerequisite Task',
+            description: 'Must complete first',
+            jobClass: RecordingPrerequisiteTask::class,
+            appliesTo: ['event'],
+        );
+
+        $dependent = new TaskDefinition(
+            key: 'dependent_task',
+            name: 'Dependent Task',
+            description: 'Must wait',
+            jobClass: RecordingDependentTask::class,
+            appliesTo: ['event'],
+            dependencies: ['prerequisite_task'],
+        );
+
+        TaskRegistry::register($prerequisite);
+        TaskRegistry::register($dependent);
+
+        $event = Event::factory()->create();
+
+        (new RecordingPrerequisiteTask($event, $prerequisite))->handle();
+
+        $this->assertSame([$event->id], RecordingPrerequisiteTask::$executed);
+        $this->assertSame(
+            'success',
+            $event->refresh()->event_metadata['task_executions']['prerequisite_task']['last_attempt']['status']
+        );
+
+        Queue::assertPushed(
+            ProcessTaskPipelineJob::class,
+            fn (ProcessTaskPipelineJob $job) => $job->model->is($event)
+                && $job->taskFilter === ['dependent_task']
+        );
+    }
+
+    #[Test]
     public function filters_tasks_by_service_condition(): void
     {
         TaskRegistry::clear();

--- a/tests/Feature/TaskPipeline/TaskPipelineModelObserverTest.php
+++ b/tests/Feature/TaskPipeline/TaskPipelineModelObserverTest.php
@@ -9,6 +9,7 @@ use App\Models\EventObject;
 use App\Models\Integration;
 use App\Models\User;
 use Illuminate\Support\Facades\Queue;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class TaskPipelineModelObserverTest extends TestCase
@@ -20,9 +21,7 @@ class TaskPipelineModelObserverTest extends TestCase
         config(['app.enable_task_pipeline' => false]);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function create_flows_dispatch_pipeline_for_events_blocks_and_objects(): void
     {
         $user = User::factory()->create();
@@ -63,9 +62,7 @@ class TaskPipelineModelObserverTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function event_update_dispatches_for_changed_derived_data_fields(): void
     {
         $event = Event::factory()->create(['action' => 'paid']);
@@ -84,9 +81,7 @@ class TaskPipelineModelObserverTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function event_update_ignores_fields_that_do_not_change_derived_data(): void
     {
         $event = Event::factory()->create(['event_metadata' => []]);
@@ -99,9 +94,7 @@ class TaskPipelineModelObserverTest extends TestCase
         Queue::assertNotPushed(ProcessTaskPipelineJob::class);
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function block_update_dispatches_for_block_and_refreshes_parent_event_summary_embedding(): void
     {
         $event = Event::factory()->create();
@@ -134,9 +127,7 @@ class TaskPipelineModelObserverTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function object_update_dispatches_for_changed_derived_data_fields(): void
     {
         $object = EventObject::factory()->create(['title' => 'Original title']);

--- a/tests/Feature/TaskPipeline/TaskPipelineModelObserverTest.php
+++ b/tests/Feature/TaskPipeline/TaskPipelineModelObserverTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Tests\Feature\TaskPipeline;
+
+use App\Jobs\TaskPipeline\ProcessTaskPipelineJob;
+use App\Models\Block;
+use App\Models\Event;
+use App\Models\EventObject;
+use App\Models\Integration;
+use App\Models\User;
+use Illuminate\Support\Facades\Queue;
+use Tests\TestCase;
+
+class TaskPipelineModelObserverTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['app.enable_task_pipeline' => false]);
+    }
+
+    /**
+     * @test
+     */
+    public function create_flows_dispatch_pipeline_for_events_blocks_and_objects(): void
+    {
+        $user = User::factory()->create();
+        $integration = Integration::factory()->create(['user_id' => $user->id]);
+        $actor = EventObject::factory()->create(['user_id' => $user->id]);
+        $target = EventObject::factory()->create(['user_id' => $user->id]);
+
+        config(['app.enable_task_pipeline' => true]);
+        Queue::fake([ProcessTaskPipelineJob::class]);
+
+        $event = Event::factory()->create([
+            'integration_id' => $integration->id,
+            'actor_id' => $actor->id,
+            'target_id' => $target->id,
+        ]);
+        $block = Block::factory()->create(['event_id' => $event->id]);
+        $object = EventObject::factory()->create(['user_id' => $user->id]);
+
+        Queue::assertPushed(
+            ProcessTaskPipelineJob::class,
+            fn (ProcessTaskPipelineJob $job) => $job->model->is($event)
+                && $job->trigger === 'created'
+                && $job->force === false
+        );
+
+        Queue::assertPushed(
+            ProcessTaskPipelineJob::class,
+            fn (ProcessTaskPipelineJob $job) => $job->model->is($block)
+                && $job->trigger === 'created'
+                && $job->force === false
+        );
+
+        Queue::assertPushed(
+            ProcessTaskPipelineJob::class,
+            fn (ProcessTaskPipelineJob $job) => $job->model->is($object)
+                && $job->trigger === 'created'
+                && $job->force === false
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function event_update_dispatches_for_changed_derived_data_fields(): void
+    {
+        $event = Event::factory()->create(['action' => 'paid']);
+
+        config(['app.enable_task_pipeline' => true]);
+        Queue::fake([ProcessTaskPipelineJob::class]);
+
+        $event->update(['action' => 'refunded']);
+
+        Queue::assertPushed(
+            ProcessTaskPipelineJob::class,
+            fn (ProcessTaskPipelineJob $job) => $job->model->is($event)
+                && $job->trigger === 'updated'
+                && $job->force === true
+                && $job->changedFields === ['action']
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function event_update_ignores_fields_that_do_not_change_derived_data(): void
+    {
+        $event = Event::factory()->create(['event_metadata' => []]);
+
+        config(['app.enable_task_pipeline' => true]);
+        Queue::fake([ProcessTaskPipelineJob::class]);
+
+        $event->update(['event_metadata' => ['task_executions' => []]]);
+
+        Queue::assertNotPushed(ProcessTaskPipelineJob::class);
+    }
+
+    /**
+     * @test
+     */
+    public function block_update_dispatches_for_block_and_refreshes_parent_event_summary_embedding(): void
+    {
+        $event = Event::factory()->create();
+        $block = Block::factory()->create([
+            'event_id' => $event->id,
+            'block_type' => 'event_summary',
+            'title' => 'Original summary',
+        ]);
+
+        config(['app.enable_task_pipeline' => true]);
+        Queue::fake([ProcessTaskPipelineJob::class]);
+
+        $block->update(['title' => 'Updated summary']);
+
+        Queue::assertPushed(
+            ProcessTaskPipelineJob::class,
+            fn (ProcessTaskPipelineJob $job) => $job->model->is($block)
+                && $job->trigger === 'updated'
+                && $job->force === true
+                && $job->changedFields === ['title']
+        );
+
+        Queue::assertPushed(
+            ProcessTaskPipelineJob::class,
+            fn (ProcessTaskPipelineJob $job) => $job->model->is($event)
+                && $job->trigger === 'updated'
+                && $job->taskFilter === ['generate_embedding']
+                && $job->force === true
+                && $job->changedFields === ['blocks.title']
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function object_update_dispatches_for_changed_derived_data_fields(): void
+    {
+        $object = EventObject::factory()->create(['title' => 'Original title']);
+
+        config(['app.enable_task_pipeline' => true]);
+        Queue::fake([ProcessTaskPipelineJob::class]);
+
+        $object->update(['title' => 'Updated title']);
+
+        Queue::assertPushed(
+            ProcessTaskPipelineJob::class,
+            fn (ProcessTaskPipelineJob $job) => $job->model->is($object)
+                && $job->trigger === 'updated'
+                && $job->force === true
+                && $job->changedFields === ['title']
+        );
+    }
+}

--- a/tests/Feature/TaskPipeline/TaskRegistryFilteredDepsTest.php
+++ b/tests/Feature/TaskPipeline/TaskRegistryFilteredDepsTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Tests\Feature\TaskPipeline;
+
+use App\Jobs\TaskPipeline\Tasks\GenerateEmbeddingTask;
+use App\Services\TaskPipeline\Exceptions\CircularDependencyException;
+use App\Services\TaskPipeline\TaskDefinition;
+use App\Services\TaskPipeline\TaskRegistry;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class TaskRegistryFilteredDepsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        TaskRegistry::clear(); // clear before boot to avoid validateDependencies() seeing stale tasks
+        parent::setUp();
+        TaskRegistry::clear();
+    }
+
+    protected function tearDown(): void
+    {
+        TaskRegistry::clear();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function resolves_order_when_dependency_is_excluded_from_filter(): void
+    {
+        // detect_anomalies depends on calculate_metric_stats, but only detect_anomalies is in the batch
+        $detectAnomalies = new TaskDefinition(
+            key: 'detect_anomalies',
+            name: 'Detect Anomalies',
+            description: 'Detects anomalies',
+            jobClass: GenerateEmbeddingTask::class,
+            appliesTo: ['event'],
+            dependencies: ['calculate_metric_stats'],
+        );
+
+        $tasks = collect([$detectAnomalies]);
+
+        // Should not throw — external dependency treated as already satisfied
+        $ordered = TaskRegistry::resolveExecutionOrder($tasks);
+
+        $this->assertCount(1, $ordered);
+        $this->assertEquals('detect_anomalies', $ordered->first()->key);
+    }
+
+    #[Test]
+    public function still_detects_circular_dependency_within_batch(): void
+    {
+        $taskA = new TaskDefinition(
+            key: 'task_a',
+            name: 'Task A',
+            description: 'Depends on task_b',
+            jobClass: GenerateEmbeddingTask::class,
+            appliesTo: ['event'],
+            dependencies: ['task_b'],
+        );
+
+        $taskB = new TaskDefinition(
+            key: 'task_b',
+            name: 'Task B',
+            description: 'Depends on task_a',
+            jobClass: GenerateEmbeddingTask::class,
+            appliesTo: ['event'],
+            dependencies: ['task_a'],
+        );
+
+        $tasks = collect([$taskA, $taskB]);
+
+        $this->expectException(CircularDependencyException::class);
+        TaskRegistry::resolveExecutionOrder($tasks);
+    }
+
+    #[Test]
+    public function resolves_correct_order_when_dependency_is_in_batch(): void
+    {
+        $stats = new TaskDefinition(
+            key: 'calculate_metric_stats',
+            name: 'Calculate Stats',
+            description: 'Calculates metric stats',
+            jobClass: GenerateEmbeddingTask::class,
+            appliesTo: ['event'],
+            dependencies: [],
+        );
+
+        $anomalies = new TaskDefinition(
+            key: 'detect_anomalies',
+            name: 'Detect Anomalies',
+            description: 'Detects anomalies',
+            jobClass: GenerateEmbeddingTask::class,
+            appliesTo: ['event'],
+            dependencies: ['calculate_metric_stats'],
+        );
+
+        $tasks = collect([$anomalies, $stats]); // Wrong order intentionally
+
+        $ordered = TaskRegistry::resolveExecutionOrder($tasks);
+
+        $keys = $ordered->pluck('key')->toArray();
+        $this->assertEquals(['calculate_metric_stats', 'detect_anomalies'], $keys);
+    }
+}

--- a/tests/Feature/TaskPipeline/TaskRegistryValidateDepsTest.php
+++ b/tests/Feature/TaskPipeline/TaskRegistryValidateDepsTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Feature\TaskPipeline;
+
+use App\Jobs\TaskPipeline\Tasks\GenerateEmbeddingTask;
+use App\Services\TaskPipeline\Exceptions\UnresolvableDependencyException;
+use App\Services\TaskPipeline\TaskDefinition;
+use App\Services\TaskPipeline\TaskRegistry;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class TaskRegistryValidateDepsTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        // Clear static registry before app boot; the service provider's validateDependencies()
+        // runs during boot and would throw if stale tasks from a prior test are still present.
+        TaskRegistry::clear();
+        parent::setUp();
+        TaskRegistry::clear(); // also clear the tasks registered by the service provider itself
+    }
+
+    protected function tearDown(): void
+    {
+        TaskRegistry::clear();
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function passes_when_all_dependencies_are_registered(): void
+    {
+        TaskRegistry::register(new TaskDefinition(
+            key: 'step_one',
+            name: 'Step One',
+            description: 'No deps',
+            jobClass: GenerateEmbeddingTask::class,
+            appliesTo: ['event'],
+            dependencies: [],
+        ));
+
+        TaskRegistry::register(new TaskDefinition(
+            key: 'step_two',
+            name: 'Step Two',
+            description: 'Depends on step_one',
+            jobClass: GenerateEmbeddingTask::class,
+            appliesTo: ['event'],
+            dependencies: ['step_one'],
+        ));
+
+        // Should not throw
+        TaskRegistry::validateDependencies();
+
+        $this->addToAssertionCount(1);
+    }
+
+    #[Test]
+    public function throws_when_a_dependency_is_not_registered(): void
+    {
+        TaskRegistry::register(new TaskDefinition(
+            key: 'orphan_task',
+            name: 'Orphan Task',
+            description: 'Declares a dep that does not exist',
+            jobClass: GenerateEmbeddingTask::class,
+            appliesTo: ['event'],
+            dependencies: ['missing_task'],
+        ));
+
+        $this->expectException(UnresolvableDependencyException::class);
+        $this->expectExceptionMessage("'orphan_task' declares dependency 'missing_task'");
+
+        TaskRegistry::validateDependencies();
+    }
+
+    #[Test]
+    public function error_message_lists_all_broken_dependencies(): void
+    {
+        TaskRegistry::register(new TaskDefinition(
+            key: 'task_a',
+            name: 'Task A',
+            description: 'Multiple missing deps',
+            jobClass: GenerateEmbeddingTask::class,
+            appliesTo: ['event'],
+            dependencies: ['missing_x', 'missing_y'],
+        ));
+
+        try {
+            TaskRegistry::validateDependencies();
+            $this->fail('Expected UnresolvableDependencyException was not thrown');
+        } catch (UnresolvableDependencyException $e) {
+            $this->assertStringContainsString('missing_x', $e->getMessage());
+            $this->assertStringContainsString('missing_y', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function passes_for_empty_registry(): void
+    {
+        // No tasks registered — nothing to validate
+        TaskRegistry::validateDependencies();
+
+        $this->addToAssertionCount(1);
+    }
+}

--- a/tests/Unit/Jobs/ProcessNewsletterEmailJobTest.php
+++ b/tests/Unit/Jobs/ProcessNewsletterEmailJobTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Unit\Jobs;
 
-use App\Jobs\Data\Newsletter\ExtractNewsletterContentJob;
 use App\Jobs\Data\Newsletter\ProcessNewsletterEmailJob;
+use App\Jobs\TaskPipeline\ProcessTaskPipelineJob;
 use App\Models\Event;
 use App\Models\Integration;
 use App\Models\IntegrationGroup;
@@ -150,6 +150,7 @@ class ProcessNewsletterEmailJobTest extends TestCase
     #[Test]
     public function it_reuses_existing_event_for_duplicate_message_id()
     {
+        config(['app.enable_task_pipeline' => true]);
         Queue::fake();
 
         $rawEmail = $this->rawEmailContent('duplicate-message@example.test', '<p>Hello duplicate</p>');
@@ -161,12 +162,13 @@ class ProcessNewsletterEmailJobTest extends TestCase
             ->where('source_id', 'duplicate-message@example.test')
             ->count());
 
-        Queue::assertPushed(ExtractNewsletterContentJob::class, 2);
+        Queue::assertPushed(ProcessTaskPipelineJob::class);
     }
 
     #[Test]
-    public function it_does_not_store_raw_html_in_event_metadata()
+    public function it_stores_raw_html_in_event_metadata()
     {
+        config(['app.enable_task_pipeline' => true]);
         Queue::fake();
 
         $rawEmail = $this->rawEmailContent('metadata-message@example.test', '<html><body><p>Stored elsewhere</p></body></html>');
@@ -175,8 +177,9 @@ class ProcessNewsletterEmailJobTest extends TestCase
 
         $event = Event::where('source_id', 'metadata-message@example.test')->firstOrFail();
 
-        $this->assertArrayNotHasKey('raw_html', $event->event_metadata);
+        $this->assertSame('<html><body><p>Stored elsewhere</p></body></html>', $event->event_metadata['raw_html']);
         $this->assertSame('metadata-message@example.test', $event->event_metadata['email_message_id']);
+        Queue::assertPushed(ProcessTaskPipelineJob::class);
     }
 
     private function rawEmailContent(string $messageId, string $html): string

--- a/tests/Unit/Services/EmbeddingServiceTest.php
+++ b/tests/Unit/Services/EmbeddingServiceTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Services\EmbeddingService;
+use Exception;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class EmbeddingServiceTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'services.openai.api_key' => 'test-api-key',
+            'services.openai.embedding_model' => 'text-embedding-3-small',
+        ]);
+    }
+
+    /**
+     * @test
+     */
+    public function returns_valid_embedding_from_provider(): void
+    {
+        $embedding = $this->validEmbedding();
+
+        Http::fake([
+            'api.openai.com/v1/embeddings' => Http::response([
+                'data' => [
+                    ['embedding' => $embedding],
+                ],
+            ]),
+        ]);
+
+        $result = (new EmbeddingService)->embed('searchable text', useCache: false);
+
+        $this->assertCount(1536, $result);
+        $this->assertSame(0.25, $result[0]);
+        $this->assertFalse(EmbeddingService::isZeroVector($result));
+    }
+
+    /**
+     * @test
+     */
+    public function throws_provider_failure_instead_of_returning_zero_vector(): void
+    {
+        Http::fake([
+            'api.openai.com/v1/embeddings' => Http::response(['error' => 'provider unavailable'], 500),
+        ]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('provider unavailable');
+
+        (new EmbeddingService)->embed('searchable text', useCache: false);
+    }
+
+    /**
+     * @test
+     */
+    public function rejects_zero_vector_provider_response(): void
+    {
+        Http::fake([
+            'api.openai.com/v1/embeddings' => Http::response([
+                'data' => [
+                    ['embedding' => array_fill(0, 1536, 0.0)],
+                ],
+            ]),
+        ]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('zero vector');
+
+        (new EmbeddingService)->embed('searchable text', useCache: false);
+    }
+
+    private function validEmbedding(): array
+    {
+        $embedding = array_fill(0, 1536, 0.0);
+        $embedding[0] = 0.25;
+
+        return $embedding;
+    }
+}

--- a/tests/Unit/TaskPipeline/TaskExecutionStoreTest.php
+++ b/tests/Unit/TaskPipeline/TaskExecutionStoreTest.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Tests\Unit\TaskPipeline;
+
+use App\Jobs\TaskPipeline\Tasks\GenerateEmbeddingTask;
+use App\Models\Event;
+use App\Models\TaskExecution;
+use App\Services\TaskPipeline\TaskDefinition;
+use App\Services\TaskPipeline\TaskExecutionStore;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class TaskExecutionStoreTest extends TestCase
+{
+    #[Test]
+    public function reads_table_rows_before_legacy_metadata(): void
+    {
+        $event = Event::factory()->create([
+            'event_metadata' => [
+                'task_executions' => [
+                    'generate_embedding' => [
+                        'last_attempt' => ['status' => 'failed', 'error' => 'legacy'],
+                    ],
+                ],
+            ],
+        ]);
+
+        TaskExecution::factory()->create([
+            'user_id' => $event->integration->user_id,
+            'entity_type' => 'event',
+            'entity_id' => $event->id,
+            'task_key' => 'generate_embedding',
+            'status' => 'success',
+            'attempts' => 2,
+            'task_name' => 'Generate Embedding',
+        ]);
+
+        $executions = app(TaskExecutionStore::class)->getTaskExecutions($event->refresh());
+
+        $this->assertSame('success', $executions['generate_embedding']['last_attempt']['status']);
+        $this->assertSame(2, $executions['generate_embedding']['last_attempt']['attempts']);
+    }
+
+    #[Test]
+    public function falls_back_to_legacy_metadata_when_table_has_no_rows(): void
+    {
+        $event = Event::factory()->create([
+            'event_metadata' => [
+                'task_executions' => [
+                    'legacy_task' => [
+                        'last_attempt' => ['status' => 'success'],
+                    ],
+                ],
+            ],
+        ]);
+
+        $executions = app(TaskExecutionStore::class)->getTaskExecutions($event);
+
+        $this->assertSame('success', $executions['legacy_task']['last_attempt']['status']);
+    }
+
+    #[Test]
+    public function records_status_to_table_metadata_last_success_and_history(): void
+    {
+        $event = Event::factory()->create();
+        $task = new TaskDefinition(
+            key: 'generate_embedding',
+            name: 'Generate Embedding',
+            description: 'Generate AI embedding',
+            jobClass: GenerateEmbeddingTask::class,
+            appliesTo: ['event'],
+        );
+
+        $store = app(TaskExecutionStore::class);
+        $store->recordStatus($event, $task, 'pending', [
+            'started_at' => now()->toIso8601String(),
+            'triggered_by' => 'created',
+        ], mergeLastAttempt: false);
+        $store->recordStatus($event, $task, 'success', [
+            'completed_at' => now()->toIso8601String(),
+            'attempts' => 1,
+        ]);
+
+        $row = TaskExecution::where('entity_type', 'event')
+            ->where('entity_id', $event->id)
+            ->where('task_key', 'generate_embedding')
+            ->firstOrFail();
+
+        $this->assertSame('success', $row->status);
+        $this->assertSame('success', $row->last_success['status']);
+        $this->assertCount(1, $row->history);
+
+        $metadata = $event->refresh()->event_metadata['task_executions']['generate_embedding'];
+        $this->assertSame('success', $metadata['last_attempt']['status']);
+        $this->assertSame('success', $metadata['last_success']['status']);
+    }
+}


### PR DESCRIPTION
## Summary

- **CRX-651** Rolling 90-day baseline window: scope all metric statistics to the last 90 days so baselines adapt to genuine long-term behaviour shifts rather than being dominated by historical data. Stale rows are nulled out when the window contains insufficient events.
- **CRX-652** Baseline review suggestions: set `baseline_reset_suggested_at` on `MetricStatistic` when a monthly/quarterly trend is first detected; clear it on full acknowledgement. Exposed via `GetBaselinesTool`.
- **CRX-653** Fix zero-value handling consistency: money-domain metrics include zero values in baseline calculations; all other domains continue to exclude them — aligned across the batch SQL job and task-pipeline real-time path.
- **CRX-654** Improve significance scoring: replace `min(σ/2, 1.0)` with `tanh(σ/2)` so extreme anomalies above 2σ remain distinguishable. Backfill migration recalculates existing records.
- **CRX-655** Directional suppression: acknowledging an anomaly with `suppress_until` now writes to `anomaly_high_suppressed_until` / `anomaly_low_suppressed_until` on `MetricStatistic`; detection jobs skip record creation during the window. Removes the now-redundant display-level filter in `DaySummaryService`.
- **Oyster transport mode tags**: attach `transport_mode` tags on `touched_in` and `touched_out` events during processing; add `oyster:backfill-transport-tags` Artisan command to tag existing events from stored metadata.

## Test plan

- [ ] Run `MetricTrackingTest` to verify baseline window, zero-value handling, suppression, and trend/anomaly detection logic
- [ ] Run `ProcessOysterEmailJobTest` to verify transport mode tags are attached
- [ ] Run migrations on a dev database and confirm `metric_statistics` columns and significance score backfill apply cleanly
- [ ] Smoke-test `oyster:backfill-transport-tags` command against local dev data

## Linear

Closes CRX-651
Closes CRX-652
Closes CRX-653
Closes CRX-654
Closes CRX-655

🤖 Generated with [Claude Code](https://claude.com/claude-code)