### PR TITLE
✨ Up to Speed: caught_up ledger + aggregation endpoint

### DIFF
--- a/app/Http/Controllers/Api/V1/Mobile/UpToSpeedController.php
+++ b/app/Http/Controllers/Api/V1/Mobile/UpToSpeedController.php
@@ -1,0 +1,276 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Mobile;
+
+use App\Http\Controllers\Controller;
+use App\Integrations\DailyCheckin\DailyCheckinPlugin;
+use App\Models\Block;
+use App\Models\Event;
+use App\Models\MetricStatistic;
+use App\Models\MetricTrend;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Spatie\Activitylog\Models\Activity;
+
+class UpToSpeedController extends Controller
+{
+    /**
+     * GET /api/v1/mobile/up-to-speed
+     *
+     * Returns an ordered, typed queue of catch-up items for the mobile
+     * "Up to Speed" Stories flow.
+     *
+     * Ordering: flint_digest → check_in → anomaly → news_summary
+     * All items are included; caught_up_at is populated for items that have
+     * been marked via POST /up-to-speed/read (or via completion for check-ins).
+     */
+    public function __invoke(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        $timezone = $user->timezone ?? 'UTC';
+        $today = Carbon::today($timezone);
+        $integrationIds = $user->integrations()->pluck('id');
+
+        $digestItems = $this->buildDigestItems($user, $today, $integrationIds);
+        $checkInItems = $this->buildCheckInItems($user, $today);
+        $anomalyItems = $this->buildAnomalyItems($user, $today);
+        $newsItems = $this->buildNewsItems($user, $integrationIds);
+
+        // Batch-fetch caught_up activities for all activity-log-tracked items
+        $subjectIds = collect($digestItems)
+            ->concat($anomalyItems)
+            ->concat($newsItems)
+            ->pluck('_subject_id')
+            ->filter()
+            ->unique()
+            ->values()
+            ->all();
+
+        $caughtUpMap = Activity::query()
+            ->where('causer_type', User::class)
+            ->where('causer_id', $user->id)
+            ->where('event', 'caught_up')
+            ->whereIn('subject_id', $subjectIds)
+            ->get()
+            ->keyBy('subject_id');
+
+        $enrich = function (array $item) use ($caughtUpMap): array {
+            $subjectId = $item['_subject_id'] ?? null;
+            $activity = $subjectId ? $caughtUpMap->get($subjectId) : null;
+            $item['caught_up_at'] = $activity?->created_at?->toIso8601String();
+            unset($item['_subject_id']);
+
+            return $item;
+        };
+
+        $items = collect($digestItems)->map($enrich)
+            ->concat(collect($checkInItems))
+            ->concat(collect($anomalyItems)->map($enrich))
+            ->concat(collect($newsItems)->map($enrich))
+            ->values();
+
+        return response()->json(['items' => $items]);
+    }
+
+    /**
+     * @param  Collection<int, mixed>  $integrationIds
+     * @return array<int, array<string, mixed>>
+     */
+    private function buildDigestItems(User $user, Carbon $today, mixed $integrationIds): array
+    {
+        $events = Event::whereIn('integration_id', $integrationIds)
+            ->where('service', 'flint')
+            ->where('action', 'had_summary')
+            ->whereDate('time', $today)
+            ->with('blocks')
+            ->orderBy('time', 'desc')
+            ->get();
+
+        return $events->map(function (Event $event): array {
+            $meta = $event->event_metadata ?? [];
+
+            return [
+                'id' => $event->id,
+                'type' => 'flint_digest',
+                'caught_up_at' => null,
+                '_subject_id' => $event->id,
+                'payload' => [
+                    'date' => Carbon::parse($event->time)->toDateString(),
+                    'period' => $meta['period'] ?? null,
+                    'title' => $meta['title'] ?? null,
+                    'summary' => $meta['summary'] ?? null,
+                    'block_count' => $event->blocks->count(),
+                    'unanswered_question_count' => $event->blocks->filter(
+                        fn (Block $b) => $b->block_type === 'flint_user_question'
+                            && is_null($b->metadata['answer'] ?? null)
+                    )->count(),
+                ],
+            ];
+        })->all();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function buildCheckInItems(User $user, Carbon $today): array
+    {
+        $dateString = $today->toDateString();
+        $checkins = (new DailyCheckinPlugin)->getCheckinsForDate($user->id, $dateString);
+        $items = [];
+
+        foreach (['morning', 'afternoon'] as $period) {
+            /** @var Event|null $event */
+            $event = $checkins[$period];
+            $items[] = [
+                'id' => "{$period}:{$dateString}",
+                'type' => 'check_in',
+                'caught_up_at' => $event !== null ? $event->time->toIso8601String() : null,
+                'payload' => [
+                    'period' => $period,
+                    'date' => $dateString,
+                    'completed' => $event !== null,
+                    'event_id' => $event?->id,
+                ],
+            ];
+        }
+
+        return $items;
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    private function buildAnomalyItems(User $user, Carbon $today): array
+    {
+        $trends = MetricTrend::query()
+            ->whereHas('metricStatistic', fn ($q) => $q->where('user_id', $user->id))
+            ->anomalies()
+            ->unacknowledged()
+            ->whereDate('detected_at', $today)
+            ->with('metricStatistic')
+            ->get()
+            ->filter(function (MetricTrend $trend): bool {
+                $suppressUntil = $trend->metadata['suppress_until'] ?? null;
+
+                return ! ($suppressUntil && Carbon::parse($suppressUntil)->isFuture());
+            });
+
+        return $trends->map(function (MetricTrend $trend): array {
+            $stat = $trend->metricStatistic;
+
+            $streakCount = $this->calculateStreakDays($trend, $stat);
+
+            return [
+                'id' => $trend->id,
+                'type' => 'anomaly',
+                'caught_up_at' => null,
+                '_subject_id' => $trend->id,
+                'payload' => [
+                    'metric' => $stat->getIdentifier(),
+                    'display_name' => $stat->getDisplayName(),
+                    'type' => $trend->type,
+                    'direction' => $trend->getDirection(),
+                    'current_value' => round($trend->current_value, 2),
+                    'baseline_value' => round($trend->baseline_value, 2),
+                    'deviation' => round($trend->deviation, 2),
+                    'streak_days' => $streakCount,
+                    'detected_at' => $trend->detected_at->toIso8601String(),
+                ],
+            ];
+        })->values()->all();
+    }
+
+    /**
+     * @param  Collection<int, mixed>  $integrationIds
+     * @return array<int, array<string, mixed>>
+     */
+    private function buildNewsItems(User $user, mixed $integrationIds): array
+    {
+        $summaryBlockTypes = [
+            'fetch_tldr',
+            'fetch_summary_paragraph',
+            'fetch_key_takeaways',
+            'newsletter_tldr',
+            'newsletter_summary_paragraph',
+            'newsletter_key_takeaways',
+        ];
+
+        $events = Event::whereIn('integration_id', $integrationIds)
+            ->where('domain', 'knowledge')
+            ->where(function ($q): void {
+                $q->where('action', 'bookmarked')
+                    ->orWhere(function ($q): void {
+                        $q->where('service', 'newsletter')
+                            ->where('action', 'received_post');
+                    });
+            })
+            ->where('time', '>=', now()->subHours(48))
+            ->whereHas('blocks', fn ($q) => $q->whereIn('block_type', $summaryBlockTypes))
+            ->with(['blocks', 'target', 'actor'])
+            ->orderBy('time', 'desc')
+            ->get();
+
+        return $events->map(function (Event $event) use ($summaryBlockTypes): array {
+            $blocks = $event->blocks->keyBy('block_type');
+            $payload = [
+                'title' => $event->target?->title ?? $event->actor?->title ?? 'Untitled',
+                'source' => $event->service,
+                'url' => $event->url ?? $event->target?->url,
+                'time' => $event->time->toIso8601String(),
+                'tldr' => null,
+                'summary' => null,
+                'key_takeaways' => null,
+            ];
+
+            foreach ($summaryBlockTypes as $blockType) {
+                $block = $blocks->get($blockType);
+                if ($block === null) {
+                    continue;
+                }
+
+                if (str_contains($blockType, 'tldr')) {
+                    $payload['tldr'] = $block->getContent();
+                } elseif (str_contains($blockType, 'summary')) {
+                    $payload['summary'] = $block->getContent();
+                } elseif (str_contains($blockType, 'key_takeaways')) {
+                    $payload['key_takeaways'] = $block->getContent();
+                }
+            }
+
+            return [
+                'id' => $event->id,
+                'type' => 'news_summary',
+                'caught_up_at' => null,
+                '_subject_id' => $event->id,
+                'payload' => $payload,
+            ];
+        })->all();
+    }
+
+    private function calculateStreakDays(MetricTrend $trend, MetricStatistic $stat): int
+    {
+        $recentAnomalies = MetricTrend::where('metric_statistic_id', $stat->id)
+            ->anomalies()
+            ->where('detected_at', '<=', $trend->detected_at)
+            ->where('detected_at', '>=', $trend->detected_at->copy()->subDays(30))
+            ->orderByDesc('detected_at')
+            ->get();
+
+        $streakCount = 0;
+        $lastDate = $trend->detected_at;
+
+        foreach ($recentAnomalies as $t) {
+            if ($t->detected_at->diffInDays($lastDate) > 1) {
+                break;
+            }
+
+            $streakCount++;
+            $lastDate = $t->detected_at;
+        }
+
+        return $streakCount;
+    }
+}

--- a/app/Http/Controllers/Api/V1/Mobile/UpToSpeedReadController.php
+++ b/app/Http/Controllers/Api/V1/Mobile/UpToSpeedReadController.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Mobile;
+
+use App\Http\Controllers\Controller;
+use App\Models\Event;
+use App\Models\MetricTrend;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Validation\Rule;
+use Spatie\Activitylog\Models\Activity;
+
+class UpToSpeedReadController extends Controller
+{
+    /**
+     * POST /api/v1/mobile/up-to-speed/read
+     *
+     * Mark one or more Up to Speed items as caught up in the activity log.
+     * Idempotent — reposting the same items is a no-op.
+     *
+     * Body: [ { "type": "flint_digest|anomaly|news_summary", "id": "<uuid>" }, ... ]
+     */
+    public function __invoke(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'items' => ['required', 'array', 'min:1', 'max:50'],
+            'items.*.type' => ['required', 'string', Rule::in(['flint_digest', 'anomaly', 'news_summary'])],
+            'items.*.id' => ['required', 'string', 'uuid'],
+        ]);
+
+        $user = $request->user();
+        $integrationIds = $user->integrations()->pluck('id');
+        $marked = 0;
+
+        foreach ($validated['items'] as $item) {
+            $subject = $this->resolveSubject($item['type'], $item['id'], $user, $integrationIds);
+
+            if ($subject === null) {
+                continue;
+            }
+
+            $alreadyMarked = Activity::query()
+                ->where('causer_type', User::class)
+                ->where('causer_id', $user->id)
+                ->where('subject_type', get_class($subject))
+                ->where('subject_id', $subject->id)
+                ->where('event', 'caught_up')
+                ->exists();
+
+            if ($alreadyMarked) {
+                continue;
+            }
+
+            activity('changelog')
+                ->performedOn($subject)
+                ->causedBy($user)
+                ->event('caught_up')
+                ->log('caught_up');
+
+            $marked++;
+        }
+
+        return response()->json(['marked' => $marked]);
+    }
+
+    /**
+     * Resolve a typed {type, id} pair to its Eloquent model, verifying ownership.
+     * Returns null if not found or not owned by the user.
+     */
+    private function resolveSubject(string $type, string $id, User $user, mixed $integrationIds): Event|MetricTrend|null
+    {
+        return match ($type) {
+            'flint_digest' => Event::whereIn('integration_id', $integrationIds)
+                ->where('service', 'flint')
+                ->where('action', 'had_summary')
+                ->find($id),
+
+            'anomaly' => MetricTrend::query()
+                ->whereHas('metricStatistic', fn ($q) => $q->where('user_id', $user->id))
+                ->find($id),
+
+            'news_summary' => Event::whereIn('integration_id', $integrationIds)
+                ->where('domain', 'knowledge')
+                ->find($id),
+
+            default => null,
+        };
+    }
+}

--- a/routes/mobile.php
+++ b/routes/mobile.php
@@ -24,6 +24,8 @@ use App\Http\Controllers\Api\V1\Mobile\PingController;
 use App\Http\Controllers\Api\V1\Mobile\PlacesController;
 use App\Http\Controllers\Api\V1\Mobile\SearchController;
 use App\Http\Controllers\Api\V1\Mobile\SyncController;
+use App\Http\Controllers\Api\V1\Mobile\UpToSpeedController;
+use App\Http\Controllers\Api\V1\Mobile\UpToSpeedReadController;
 use App\Http\Controllers\Api\V1\Mobile\WidgetsController;
 use Illuminate\Support\Facades\Route;
 
@@ -177,6 +179,19 @@ Route::delete('notifications/{id}', [NotificationsController::class, 'destroy'])
 Route::post('knowledge/events/{id}/reprocess', [KnowledgeReprocessingController::class, 'store'])
     ->middleware('ability:ios:write')
     ->name('knowledge.events.reprocess');
+
+/*
+|--------------------------------------------------------------------------
+| Up to Speed endpoints
+|--------------------------------------------------------------------------
+*/
+
+Route::get('up-to-speed', UpToSpeedController::class)
+    ->name('up-to-speed.index');
+
+Route::post('up-to-speed/read', UpToSpeedReadController::class)
+    ->middleware('ability:ios:write')
+    ->name('up-to-speed.read');
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/Feature/Api/V1/Mobile/UpToSpeedControllerTest.php
+++ b/tests/Feature/Api/V1/Mobile/UpToSpeedControllerTest.php
@@ -1,0 +1,495 @@
+<?php
+
+namespace Tests\Feature\Api\V1\Mobile;
+
+use App\Models\Block;
+use App\Models\Event;
+use App\Models\Integration;
+use App\Models\IntegrationGroup;
+use App\Models\MetricStatistic;
+use App\Models\MetricTrend;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use PHPUnit\Framework\Attributes\Test;
+use Spatie\Activitylog\Models\Activity;
+use Tests\TestCase;
+
+class UpToSpeedControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+
+    protected Integration $flintIntegration;
+
+    protected Integration $knowledgeIntegration;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['ios.mobile_api_enabled' => true]);
+
+        $this->user = User::factory()->create();
+
+        $flintGroup = IntegrationGroup::factory()->create(['user_id' => $this->user->id]);
+        $this->flintIntegration = Integration::factory()->create([
+            'user_id' => $this->user->id,
+            'integration_group_id' => $flintGroup->id,
+            'service' => 'flint',
+        ]);
+
+        $knowledgeGroup = IntegrationGroup::factory()->create(['user_id' => $this->user->id]);
+        $this->knowledgeIntegration = Integration::factory()->create([
+            'user_id' => $this->user->id,
+            'integration_group_id' => $knowledgeGroup->id,
+            'service' => 'fetch',
+        ]);
+    }
+
+    // -------------------------------------------------------------------------
+    // Auth
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function requires_authentication(): void
+    {
+        $this->getJson('/api/v1/mobile/up-to-speed')
+            ->assertStatus(401);
+    }
+
+    #[Test]
+    public function requires_ios_read_ability(): void
+    {
+        Sanctum::actingAs($this->user, []);
+
+        $this->getJson('/api/v1/mobile/up-to-speed')
+            ->assertStatus(403);
+    }
+
+    // -------------------------------------------------------------------------
+    // Basic response structure
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function returns_empty_items_when_nothing_exists(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $response = $this->getJson('/api/v1/mobile/up-to-speed')
+            ->assertOk()
+            ->assertJsonStructure(['items']);
+
+        // Check-ins are always included (both morning and afternoon)
+        $items = $response->json('items');
+        $this->assertCount(2, $items);
+        $this->assertEquals('check_in', $items[0]['type']);
+        $this->assertEquals('check_in', $items[1]['type']);
+    }
+
+    // -------------------------------------------------------------------------
+    // flint_digest items
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function includes_todays_flint_digests(): void
+    {
+        $event = Event::factory()->create([
+            'integration_id' => $this->flintIntegration->id,
+            'service' => 'flint',
+            'action' => 'had_summary',
+            'time' => now(),
+            'event_metadata' => ['period' => 'morning', 'title' => 'Morning Digest', 'summary' => 'Summary text'],
+        ]);
+
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $response = $this->getJson('/api/v1/mobile/up-to-speed')->assertOk();
+        $items = collect($response->json('items'));
+
+        $digest = $items->firstWhere('type', 'flint_digest');
+        $this->assertNotNull($digest);
+        $this->assertEquals($event->id, $digest['id']);
+        $this->assertNull($digest['caught_up_at']);
+        $this->assertEquals('morning', $digest['payload']['period']);
+        $this->assertEquals('Morning Digest', $digest['payload']['title']);
+    }
+
+    #[Test]
+    public function excludes_flint_digests_from_other_days(): void
+    {
+        Event::factory()->create([
+            'integration_id' => $this->flintIntegration->id,
+            'service' => 'flint',
+            'action' => 'had_summary',
+            'time' => now()->subDays(2),
+        ]);
+
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $items = collect($this->getJson('/api/v1/mobile/up-to-speed')->assertOk()->json('items'));
+        $this->assertEmpty($items->where('type', 'flint_digest'));
+    }
+
+    #[Test]
+    public function flint_digest_caught_up_at_is_set_when_marked(): void
+    {
+        $event = Event::factory()->create([
+            'integration_id' => $this->flintIntegration->id,
+            'service' => 'flint',
+            'action' => 'had_summary',
+            'time' => now(),
+        ]);
+
+        Activity::create([
+            'log_name' => 'changelog',
+            'description' => 'caught_up',
+            'subject_type' => Event::class,
+            'subject_id' => $event->id,
+            'causer_type' => User::class,
+            'causer_id' => $this->user->id,
+            'event' => 'caught_up',
+            'properties' => [],
+        ]);
+
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $items = collect($this->getJson('/api/v1/mobile/up-to-speed')->assertOk()->json('items'));
+        $digest = $items->firstWhere('type', 'flint_digest');
+        $this->assertNotNull($digest['caught_up_at']);
+    }
+
+    // -------------------------------------------------------------------------
+    // check_in items
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function includes_both_check_in_periods(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $items = collect($this->getJson('/api/v1/mobile/up-to-speed')->assertOk()->json('items'));
+        $checkIns = $items->where('type', 'check_in')->values();
+
+        $this->assertCount(2, $checkIns);
+        $this->assertEquals('morning', $checkIns[0]['payload']['period']);
+        $this->assertEquals('afternoon', $checkIns[1]['payload']['period']);
+    }
+
+    #[Test]
+    public function check_in_uses_synthetic_id_format(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $today = Carbon::today('UTC')->toDateString();
+        $items = collect($this->getJson('/api/v1/mobile/up-to-speed')->assertOk()->json('items'));
+        $checkIns = $items->where('type', 'check_in')->values();
+
+        $this->assertEquals("morning:{$today}", $checkIns[0]['id']);
+        $this->assertEquals("afternoon:{$today}", $checkIns[1]['id']);
+    }
+
+    #[Test]
+    public function check_in_caught_up_at_is_set_when_completed(): void
+    {
+        $group = IntegrationGroup::factory()->create(['user_id' => $this->user->id]);
+        $integration = Integration::factory()->create([
+            'user_id' => $this->user->id,
+            'integration_group_id' => $group->id,
+            'service' => 'daily_checkin',
+        ]);
+
+        $today = Carbon::today('UTC')->toDateString();
+        $checkinTime = now()->setTimeFromTimeString('08:00:00');
+
+        Event::factory()->create([
+            'integration_id' => $integration->id,
+            'service' => 'daily_checkin',
+            'action' => 'had_morning_checkin',
+            'source_id' => 'daily_checkin_morning_' . $today,
+            'time' => $checkinTime,
+            'event_metadata' => ['date' => $today],
+        ]);
+
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $items = collect($this->getJson('/api/v1/mobile/up-to-speed')->assertOk()->json('items'));
+        $morning = $items->first(fn ($i) => $i['type'] === 'check_in' && $i['payload']['period'] === 'morning');
+
+        $this->assertNotNull($morning);
+        $this->assertTrue($morning['payload']['completed']);
+        $this->assertNotNull($morning['caught_up_at']);
+    }
+
+    #[Test]
+    public function incomplete_check_in_has_null_caught_up_at(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $items = collect($this->getJson('/api/v1/mobile/up-to-speed')->assertOk()->json('items'));
+        $morning = $items->first(fn ($i) => $i['type'] === 'check_in' && $i['payload']['period'] === 'morning');
+
+        $this->assertNotNull($morning);
+        $this->assertFalse($morning['payload']['completed']);
+        $this->assertNull($morning['caught_up_at']);
+    }
+
+    // -------------------------------------------------------------------------
+    // anomaly items
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function includes_todays_unacknowledged_anomalies(): void
+    {
+        $stat = MetricStatistic::factory()->create(['user_id' => $this->user->id]);
+        $anomaly = MetricTrend::factory()->create([
+            'metric_statistic_id' => $stat->id,
+            'type' => 'anomaly_high',
+            'detected_at' => now(),
+            'acknowledged_at' => null,
+        ]);
+
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $items = collect($this->getJson('/api/v1/mobile/up-to-speed')->assertOk()->json('items'));
+        $anomalyItem = $items->firstWhere('type', 'anomaly');
+
+        $this->assertNotNull($anomalyItem);
+        $this->assertEquals($anomaly->id, $anomalyItem['id']);
+        $this->assertNull($anomalyItem['caught_up_at']);
+        $this->assertArrayHasKey('metric', $anomalyItem['payload']);
+        $this->assertArrayHasKey('direction', $anomalyItem['payload']);
+    }
+
+    #[Test]
+    public function excludes_acknowledged_anomalies(): void
+    {
+        $stat = MetricStatistic::factory()->create(['user_id' => $this->user->id]);
+        MetricTrend::factory()->create([
+            'metric_statistic_id' => $stat->id,
+            'type' => 'anomaly_high',
+            'detected_at' => now(),
+            'acknowledged_at' => now(),
+        ]);
+
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $items = collect($this->getJson('/api/v1/mobile/up-to-speed')->assertOk()->json('items'));
+        $this->assertEmpty($items->where('type', 'anomaly'));
+    }
+
+    #[Test]
+    public function excludes_suppressed_anomalies(): void
+    {
+        $stat = MetricStatistic::factory()->create(['user_id' => $this->user->id]);
+        MetricTrend::factory()->create([
+            'metric_statistic_id' => $stat->id,
+            'type' => 'anomaly_high',
+            'detected_at' => now(),
+            'acknowledged_at' => null,
+            'metadata' => ['suppress_until' => now()->addDay()->toDateString()],
+        ]);
+
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $items = collect($this->getJson('/api/v1/mobile/up-to-speed')->assertOk()->json('items'));
+        $this->assertEmpty($items->where('type', 'anomaly'));
+    }
+
+    #[Test]
+    public function anomaly_caught_up_at_is_set_when_marked(): void
+    {
+        $stat = MetricStatistic::factory()->create(['user_id' => $this->user->id]);
+        $anomaly = MetricTrend::factory()->create([
+            'metric_statistic_id' => $stat->id,
+            'type' => 'anomaly_high',
+            'detected_at' => now(),
+            'acknowledged_at' => null,
+        ]);
+
+        Activity::create([
+            'log_name' => 'changelog',
+            'description' => 'caught_up',
+            'subject_type' => MetricTrend::class,
+            'subject_id' => $anomaly->id,
+            'causer_type' => User::class,
+            'causer_id' => $this->user->id,
+            'event' => 'caught_up',
+            'properties' => [],
+        ]);
+
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $items = collect($this->getJson('/api/v1/mobile/up-to-speed')->assertOk()->json('items'));
+        $anomalyItem = $items->firstWhere('type', 'anomaly');
+        $this->assertNotNull($anomalyItem['caught_up_at']);
+    }
+
+    // -------------------------------------------------------------------------
+    // news_summary items
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function includes_bookmarks_with_summary_blocks_in_48h_window(): void
+    {
+        $event = Event::factory()->create([
+            'integration_id' => $this->knowledgeIntegration->id,
+            'domain' => 'knowledge',
+            'service' => 'fetch',
+            'action' => 'bookmarked',
+            'time' => now()->subHours(12),
+        ]);
+
+        Block::factory()->create([
+            'event_id' => $event->id,
+            'block_type' => 'fetch_tldr',
+            'metadata' => ['text' => 'Short summary'],
+        ]);
+
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $items = collect($this->getJson('/api/v1/mobile/up-to-speed')->assertOk()->json('items'));
+        $newsItem = $items->firstWhere('type', 'news_summary');
+
+        $this->assertNotNull($newsItem);
+        $this->assertEquals($event->id, $newsItem['id']);
+        $this->assertEquals('fetch', $newsItem['payload']['source']);
+    }
+
+    #[Test]
+    public function excludes_bookmarks_without_summary_blocks(): void
+    {
+        Event::factory()->create([
+            'integration_id' => $this->knowledgeIntegration->id,
+            'domain' => 'knowledge',
+            'action' => 'bookmarked',
+            'time' => now()->subHours(12),
+        ]);
+
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $items = collect($this->getJson('/api/v1/mobile/up-to-speed')->assertOk()->json('items'));
+        $this->assertEmpty($items->where('type', 'news_summary'));
+    }
+
+    #[Test]
+    public function excludes_news_older_than_48_hours(): void
+    {
+        $event = Event::factory()->create([
+            'integration_id' => $this->knowledgeIntegration->id,
+            'domain' => 'knowledge',
+            'action' => 'bookmarked',
+            'time' => now()->subHours(49),
+        ]);
+        Block::factory()->create([
+            'event_id' => $event->id,
+            'block_type' => 'fetch_tldr',
+        ]);
+
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $items = collect($this->getJson('/api/v1/mobile/up-to-speed')->assertOk()->json('items'));
+        $this->assertEmpty($items->where('type', 'news_summary'));
+    }
+
+    #[Test]
+    public function news_caught_up_at_is_set_when_marked(): void
+    {
+        $event = Event::factory()->create([
+            'integration_id' => $this->knowledgeIntegration->id,
+            'domain' => 'knowledge',
+            'action' => 'bookmarked',
+            'time' => now()->subHours(12),
+        ]);
+        Block::factory()->create([
+            'event_id' => $event->id,
+            'block_type' => 'fetch_summary_paragraph',
+        ]);
+
+        Activity::create([
+            'log_name' => 'changelog',
+            'description' => 'caught_up',
+            'subject_type' => Event::class,
+            'subject_id' => $event->id,
+            'causer_type' => User::class,
+            'causer_id' => $this->user->id,
+            'event' => 'caught_up',
+            'properties' => [],
+        ]);
+
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $items = collect($this->getJson('/api/v1/mobile/up-to-speed')->assertOk()->json('items'));
+        $newsItem = $items->firstWhere('type', 'news_summary');
+        $this->assertNotNull($newsItem['caught_up_at']);
+    }
+
+    // -------------------------------------------------------------------------
+    // Ordering
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function items_are_ordered_correctly(): void
+    {
+        // Create one of each type
+        Event::factory()->create([
+            'integration_id' => $this->flintIntegration->id,
+            'service' => 'flint',
+            'action' => 'had_summary',
+            'time' => now(),
+        ]);
+
+        $stat = MetricStatistic::factory()->create(['user_id' => $this->user->id]);
+        MetricTrend::factory()->create([
+            'metric_statistic_id' => $stat->id,
+            'type' => 'anomaly_high',
+            'detected_at' => now(),
+            'acknowledged_at' => null,
+        ]);
+
+        $newsEvent = Event::factory()->create([
+            'integration_id' => $this->knowledgeIntegration->id,
+            'domain' => 'knowledge',
+            'action' => 'bookmarked',
+            'time' => now()->subHours(1),
+        ]);
+        Block::factory()->create(['event_id' => $newsEvent->id, 'block_type' => 'fetch_tldr']);
+
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $types = collect($this->getJson('/api/v1/mobile/up-to-speed')->assertOk()->json('items'))
+            ->pluck('type')
+            ->all();
+
+        $this->assertEquals(['flint_digest', 'check_in', 'check_in', 'anomaly', 'news_summary'], $types);
+    }
+
+    // -------------------------------------------------------------------------
+    // Data isolation
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function does_not_include_other_users_items(): void
+    {
+        $other = User::factory()->create();
+        $otherGroup = IntegrationGroup::factory()->create(['user_id' => $other->id]);
+        $otherIntegration = Integration::factory()->create([
+            'user_id' => $other->id,
+            'integration_group_id' => $otherGroup->id,
+            'service' => 'flint',
+        ]);
+
+        Event::factory()->create([
+            'integration_id' => $otherIntegration->id,
+            'service' => 'flint',
+            'action' => 'had_summary',
+            'time' => now(),
+        ]);
+
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $items = collect($this->getJson('/api/v1/mobile/up-to-speed')->assertOk()->json('items'));
+        $this->assertEmpty($items->where('type', 'flint_digest'));
+    }
+}

--- a/tests/Feature/Api/V1/Mobile/UpToSpeedReadControllerTest.php
+++ b/tests/Feature/Api/V1/Mobile/UpToSpeedReadControllerTest.php
@@ -1,0 +1,298 @@
+<?php
+
+namespace Tests\Feature\Api\V1\Mobile;
+
+use App\Models\Event;
+use App\Models\Integration;
+use App\Models\IntegrationGroup;
+use App\Models\MetricStatistic;
+use App\Models\MetricTrend;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use PHPUnit\Framework\Attributes\Test;
+use Spatie\Activitylog\Models\Activity;
+use Tests\TestCase;
+
+class UpToSpeedReadControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+
+    protected Integration $integration;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['ios.mobile_api_enabled' => true]);
+
+        $this->user = User::factory()->create();
+
+        $group = IntegrationGroup::factory()->create(['user_id' => $this->user->id]);
+        $this->integration = Integration::factory()->create([
+            'user_id' => $this->user->id,
+            'integration_group_id' => $group->id,
+            'service' => 'flint',
+        ]);
+    }
+
+    // -------------------------------------------------------------------------
+    // Auth
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function requires_ios_write_ability(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $this->postJson('/api/v1/mobile/up-to-speed/read', ['items' => []])
+            ->assertStatus(403);
+    }
+
+    // -------------------------------------------------------------------------
+    // Validation
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function rejects_missing_items(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson('/api/v1/mobile/up-to-speed/read', [])
+            ->assertStatus(422);
+    }
+
+    #[Test]
+    public function rejects_unknown_type(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson('/api/v1/mobile/up-to-speed/read', [
+            'items' => [['type' => 'invalid_type', 'id' => '00000000-0000-0000-0000-000000000001']],
+        ])->assertStatus(422);
+    }
+
+    #[Test]
+    public function rejects_non_uuid_id(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson('/api/v1/mobile/up-to-speed/read', [
+            'items' => [['type' => 'flint_digest', 'id' => 'not-a-uuid']],
+        ])->assertStatus(422);
+    }
+
+    // -------------------------------------------------------------------------
+    // flint_digest
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function marks_flint_digest_as_caught_up(): void
+    {
+        $event = Event::factory()->create([
+            'integration_id' => $this->integration->id,
+            'service' => 'flint',
+            'action' => 'had_summary',
+        ]);
+
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson('/api/v1/mobile/up-to-speed/read', [
+            'items' => [['type' => 'flint_digest', 'id' => $event->id]],
+        ])->assertOk()->assertJsonPath('marked', 1);
+
+        $this->assertDatabaseHas('activity_log', [
+            'subject_type' => Event::class,
+            'subject_id' => $event->id,
+            'causer_id' => $this->user->id,
+            'event' => 'caught_up',
+        ]);
+    }
+
+    #[Test]
+    public function marking_flint_digest_twice_is_idempotent(): void
+    {
+        $event = Event::factory()->create([
+            'integration_id' => $this->integration->id,
+            'service' => 'flint',
+            'action' => 'had_summary',
+        ]);
+
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $payload = ['items' => [['type' => 'flint_digest', 'id' => $event->id]]];
+
+        $this->postJson('/api/v1/mobile/up-to-speed/read', $payload)->assertOk();
+        $this->postJson('/api/v1/mobile/up-to-speed/read', $payload)->assertOk();
+
+        $this->assertEquals(1, Activity::where('subject_id', $event->id)->where('event', 'caught_up')->count());
+    }
+
+    #[Test]
+    public function silently_ignores_another_users_flint_digest(): void
+    {
+        $other = User::factory()->create();
+        $otherGroup = IntegrationGroup::factory()->create(['user_id' => $other->id]);
+        $otherIntegration = Integration::factory()->create([
+            'user_id' => $other->id,
+            'integration_group_id' => $otherGroup->id,
+            'service' => 'flint',
+        ]);
+        $event = Event::factory()->create([
+            'integration_id' => $otherIntegration->id,
+            'service' => 'flint',
+            'action' => 'had_summary',
+        ]);
+
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson('/api/v1/mobile/up-to-speed/read', [
+            'items' => [['type' => 'flint_digest', 'id' => $event->id]],
+        ])->assertOk()->assertJsonPath('marked', 0);
+
+        $this->assertEquals(0, Activity::where('event', 'caught_up')->count());
+    }
+
+    // -------------------------------------------------------------------------
+    // anomaly
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function marks_anomaly_as_caught_up(): void
+    {
+        $stat = MetricStatistic::factory()->create(['user_id' => $this->user->id]);
+        $anomaly = MetricTrend::factory()->create([
+            'metric_statistic_id' => $stat->id,
+            'type' => 'anomaly_high',
+        ]);
+
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson('/api/v1/mobile/up-to-speed/read', [
+            'items' => [['type' => 'anomaly', 'id' => $anomaly->id]],
+        ])->assertOk()->assertJsonPath('marked', 1);
+
+        $this->assertDatabaseHas('activity_log', [
+            'subject_type' => MetricTrend::class,
+            'subject_id' => $anomaly->id,
+            'causer_id' => $this->user->id,
+            'event' => 'caught_up',
+        ]);
+    }
+
+    #[Test]
+    public function marking_anomaly_twice_is_idempotent(): void
+    {
+        $stat = MetricStatistic::factory()->create(['user_id' => $this->user->id]);
+        $anomaly = MetricTrend::factory()->create([
+            'metric_statistic_id' => $stat->id,
+            'type' => 'anomaly_high',
+        ]);
+
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $payload = ['items' => [['type' => 'anomaly', 'id' => $anomaly->id]]];
+
+        $this->postJson('/api/v1/mobile/up-to-speed/read', $payload)->assertOk();
+        $this->postJson('/api/v1/mobile/up-to-speed/read', $payload)->assertOk();
+
+        $this->assertEquals(1, Activity::where('subject_id', $anomaly->id)->where('event', 'caught_up')->count());
+    }
+
+    #[Test]
+    public function silently_ignores_another_users_anomaly(): void
+    {
+        $other = User::factory()->create();
+        $stat = MetricStatistic::factory()->create(['user_id' => $other->id]);
+        $anomaly = MetricTrend::factory()->create([
+            'metric_statistic_id' => $stat->id,
+            'type' => 'anomaly_high',
+        ]);
+
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson('/api/v1/mobile/up-to-speed/read', [
+            'items' => [['type' => 'anomaly', 'id' => $anomaly->id]],
+        ])->assertOk()->assertJsonPath('marked', 0);
+
+        $this->assertEquals(0, Activity::where('event', 'caught_up')->count());
+    }
+
+    // -------------------------------------------------------------------------
+    // news_summary
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function marks_news_summary_as_caught_up(): void
+    {
+        $event = Event::factory()->create([
+            'integration_id' => $this->integration->id,
+            'domain' => 'knowledge',
+            'action' => 'bookmarked',
+        ]);
+
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson('/api/v1/mobile/up-to-speed/read', [
+            'items' => [['type' => 'news_summary', 'id' => $event->id]],
+        ])->assertOk()->assertJsonPath('marked', 1);
+
+        $this->assertDatabaseHas('activity_log', [
+            'subject_type' => Event::class,
+            'subject_id' => $event->id,
+            'causer_id' => $this->user->id,
+            'event' => 'caught_up',
+        ]);
+    }
+
+    // -------------------------------------------------------------------------
+    // Batch
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function handles_batch_of_mixed_types(): void
+    {
+        $digest = Event::factory()->create([
+            'integration_id' => $this->integration->id,
+            'service' => 'flint',
+            'action' => 'had_summary',
+        ]);
+
+        $stat = MetricStatistic::factory()->create(['user_id' => $this->user->id]);
+        $anomaly = MetricTrend::factory()->create([
+            'metric_statistic_id' => $stat->id,
+            'type' => 'anomaly_high',
+        ]);
+
+        $news = Event::factory()->create([
+            'integration_id' => $this->integration->id,
+            'domain' => 'knowledge',
+            'action' => 'bookmarked',
+        ]);
+
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson('/api/v1/mobile/up-to-speed/read', [
+            'items' => [
+                ['type' => 'flint_digest', 'id' => $digest->id],
+                ['type' => 'anomaly', 'id' => $anomaly->id],
+                ['type' => 'news_summary', 'id' => $news->id],
+            ],
+        ])->assertOk()->assertJsonPath('marked', 3);
+
+        $this->assertEquals(3, Activity::where('event', 'caught_up')->count());
+    }
+
+    #[Test]
+    public function skips_nonexistent_ids_without_error(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson('/api/v1/mobile/up-to-speed/read', [
+            'items' => [
+                ['type' => 'flint_digest', 'id' => '00000000-0000-0000-0000-000000000001'],
+            ],
+        ])->assertOk()->assertJsonPath('marked', 0);
+    }
+}


### PR DESCRIPTION
## Summary

Implements the two foundational endpoints for the mobile "Up to Speed" catch-up feature.

**CRX-629 — `POST /api/v1/mobile/up-to-speed/read`**
- Batch mark-read endpoint writing `caught_up` entries to the activity log
- Supports `flint_digest`, `anomaly`, and `news_summary` item types
- Idempotent via check-then-insert (a partial unique index would require a migration; documented trade-off)
- Unknown/unauthorised items silently skipped (no ownership leak via 403)
- Requires `ios:write` ability

**CRX-630 — `GET /api/v1/mobile/up-to-speed`**
- Aggregation endpoint returning an ordered, typed queue of catch-up items
- Ordering: `flint_digest` → `check_in` → `anomaly` → `news_summary`
- All items included; `caught_up_at` populated for read items (null = unread)
- Check-ins use synthetic IDs (`morning:YYYY-MM-DD` / `afternoon:YYYY-MM-DD`); `caught_up_at` uses event time since completion is the read signal
- Anomalies: today's unacknowledged + unsuppressed `MetricTrend` entries
- News: knowledge-domain bookmarks + newsletters in a rolling 48h window, filtered to events with AI summary blocks
- Caught-up status resolved in a single batched query (no N+1)
- ETag handled by existing middleware in the route stack

## Test plan

- [ ] `vendor/bin/sail artisan test tests/Feature/Api/V1/Mobile/UpToSpeedReadControllerTest.php` — 13 tests (auth, validation, per-type write, idempotency, cross-user isolation, batch)
- [ ] `vendor/bin/sail artisan test tests/Feature/Api/V1/Mobile/UpToSpeedControllerTest.php` — 20 tests (auth, all item types, filtering, caught_up_at population, ordering, isolation)
- [ ] Full mobile suite: `vendor/bin/sail artisan test tests/Feature/Api/V1/Mobile/` — 237 tests, all passing

Closes CRX-629
Closes CRX-630

🤖 Generated with [Claude Code](https://claude.com/claude-code)