### PR TITLE
:sparkles: Add missing mobile API endpoints (CRX-694–698)

### DIFF
--- a/app/Http/Controllers/Api/FetchApiController.php
+++ b/app/Http/Controllers/Api/FetchApiController.php
@@ -4,18 +4,14 @@ namespace App\Http\Controllers\Api;
 
 use App\Exceptions\UnsafeUrlException;
 use App\Http\Controllers\Controller;
-use App\Jobs\Fetch\FetchSingleUrl;
-use App\Models\EventObject;
-use App\Services\Fetch\FetchIntegrationResolver;
-use App\Services\Fetch\UrlSafetyValidator;
+use App\Services\Fetch\BookmarkUrlService;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
 
 class FetchApiController extends Controller
 {
     public function __construct(
-        protected UrlSafetyValidator $urlSafety,
-        protected FetchIntegrationResolver $integrationResolver
+        protected BookmarkUrlService $bookmarks,
     ) {}
 
     /**
@@ -38,13 +34,15 @@ class FetchApiController extends Controller
         }
 
         $validated = $validator->validated();
-        $url = $validated['url'];
-        $fetchImmediately = $validated['fetch_immediately'] ?? true;
-        $forceRefresh = $validated['force_refresh'] ?? false;
-        $fetchMode = $validated['fetch_mode'] ?? 'once'; // Default to one-time fetch for API bookmarks
 
         try {
-            $this->urlSafety->validate($url);
+            $result = $this->bookmarks->bookmark(
+                $request->user(),
+                $validated['url'],
+                $validated['fetch_immediately'] ?? true,
+                $validated['force_refresh'] ?? false,
+                $validated['fetch_mode'] ?? 'once', // Default to one-time fetch for API bookmarks
+            );
         } catch (UnsafeUrlException $e) {
             return response()->json([
                 'success' => false,
@@ -53,71 +51,28 @@ class FetchApiController extends Controller
             ], 422);
         }
 
-        // Parse domain from URL
-        $domain = parse_url($url, PHP_URL_HOST);
+        $bookmark = $result['bookmark'];
+        $jobDispatched = $result['job_dispatched'];
 
-        // Check for existing bookmark
-        $existingBookmark = EventObject::where('user_id', $request->user()->id)
-            ->where('concept', 'bookmark')
-            ->where('type', 'fetch_webpage')
-            ->where('url', $url)
-            ->first();
-
-        $integration = $this->integrationResolver->resolve($request->user());
-
-        if ($existingBookmark) {
-            // If force refresh is requested, dispatch job for existing bookmark
-            $jobDispatched = false;
-            if ($forceRefresh && $fetchImmediately) {
-                FetchSingleUrl::dispatch($integration, $existingBookmark->id, $existingBookmark->url, true);
-                $jobDispatched = true;
-            }
-
-            // Return existing bookmark
+        if (! $result['created']) {
             return response()->json([
                 'success' => true,
-                'state' => $jobDispatched ? 'refreshed' : 'already_exists',
+                'state' => $result['state'],
                 'bookmark' => [
-                    'id' => $existingBookmark->id,
-                    'url' => $existingBookmark->url,
-                    'title' => $existingBookmark->title,
-                    'status' => $existingBookmark->metadata['enabled'] ?? true ? 'active' : 'disabled',
-                    'created_at' => $existingBookmark->created_at->toISOString(),
+                    'id' => $bookmark->id,
+                    'url' => $bookmark->url,
+                    'title' => $bookmark->title,
+                    'status' => $bookmark->metadata['enabled'] ?? true ? 'active' : 'disabled',
+                    'created_at' => $bookmark->created_at->toISOString(),
                 ],
                 'job_dispatched' => $jobDispatched,
                 'message' => $jobDispatched ? 'Force refresh dispatched' : 'Bookmark already exists',
             ]);
         }
 
-        // Create new bookmark
-        $bookmark = EventObject::create([
-            'user_id' => $request->user()->id,
-            'concept' => 'bookmark',
-            'type' => 'fetch_webpage',
-            'title' => $url, // Will be updated with actual title after fetch
-            'url' => $url,
-            'time' => now(),
-            'metadata' => [
-                'domain' => $domain,
-                'fetch_integration_id' => $integration?->id,
-                'subscription_source' => 'api',
-                'fetch_mode' => $fetchMode, // Default 'once', but can be 'recurring'
-                'enabled' => true,
-                'subscribed_at' => now()->toISOString(),
-                'fetch_count' => 0,
-            ],
-        ]);
-
-        // Dispatch fetch job if requested
-        $jobDispatched = false;
-        if ($fetchImmediately && $integration) {
-            FetchSingleUrl::dispatch($integration, $bookmark->id, $bookmark->url);
-            $jobDispatched = true;
-        }
-
         return response()->json([
             'success' => true,
-            'state' => $jobDispatched ? 'queued' : 'pending_no_fetch',
+            'state' => $result['state'],
             'bookmark' => [
                 'id' => $bookmark->id,
                 'url' => $bookmark->url,

--- a/app/Http/Controllers/Api/V1/Mobile/ApiTokensController.php
+++ b/app/Http/Controllers/Api/V1/Mobile/ApiTokensController.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Mobile;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Compact\ApiTokenResource;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class ApiTokensController extends Controller
+{
+    /**
+     * Tokens we never expose or allow to be revoked through this endpoint —
+     * the mobile app's own OAuth-issued tokens carry these abilities and
+     * managing them here would let the app revoke its own session.
+     */
+    private const HIDDEN_ABILITIES = ['ios:read', 'ios:write'];
+
+    /**
+     * GET /api/v1/mobile/api-tokens
+     *
+     * Lists the user's personal access tokens (excluding the app's own
+     * iOS session tokens). Never returns plaintext secrets.
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $tokens = $request->user()->tokens()
+            ->latest()
+            ->get()
+            ->reject(fn ($token) => $this->isAppToken($token))
+            ->values();
+
+        return response()->json(
+            ApiTokenResource::collection($tokens)->resolve($request),
+        );
+    }
+
+    /**
+     * POST /api/v1/mobile/api-tokens
+     *
+     * Creates a personal access token and returns the one-time plaintext.
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'name' => ['required', 'string', 'max:255'],
+            'abilities' => ['sometimes', 'array', 'max:20'],
+            'abilities.*' => ['string', 'max:255', 'distinct'],
+        ]);
+
+        $abilities = array_values($validated['abilities'] ?? ['*']);
+
+        // Don't let a mobile-managed token grant itself the app's own session scopes.
+        $abilities = array_values(array_diff($abilities, self::HIDDEN_ABILITIES));
+
+        if (empty($abilities)) {
+            $abilities = ['*'];
+        }
+
+        $token = $request->user()->createToken($validated['name'], $abilities);
+
+        return response()->json([
+            'id' => (string) $token->accessToken->getKey(),
+            'name' => $token->accessToken->name,
+            'plaintext' => $token->plainTextToken,
+        ], 201);
+    }
+
+    /**
+     * DELETE /api/v1/mobile/api-tokens/{id}
+     *
+     * Revokes a token. The app's own iOS session tokens are not revocable here.
+     */
+    public function destroy(Request $request, string $id): JsonResponse
+    {
+        $token = $request->user()->tokens()->whereKey($id)->first();
+
+        if (! $token || $this->isAppToken($token)) {
+            return response()->json(['message' => 'Token not found.'], 404);
+        }
+
+        $token->delete();
+
+        return response()->json([], 204);
+    }
+
+    /**
+     * An app-session token is one issued for the iOS app itself (ios:* scopes).
+     */
+    private function isAppToken(object $token): bool
+    {
+        $abilities = $token->abilities ?? [];
+
+        return ! empty(array_intersect($abilities, self::HIDDEN_ABILITIES));
+    }
+}

--- a/app/Http/Controllers/Api/V1/Mobile/BookmarksController.php
+++ b/app/Http/Controllers/Api/V1/Mobile/BookmarksController.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Mobile;
+
+use App\Exceptions\UnsafeUrlException;
+use App\Http\Controllers\Controller;
+use App\Services\Fetch\BookmarkUrlService;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class BookmarksController extends Controller
+{
+    public function __construct(protected BookmarkUrlService $bookmarks) {}
+
+    /**
+     * POST /api/v1/mobile/bookmarks
+     *
+     * Bookmarks a URL shared from the iOS share extension. Delegates to the
+     * same service as FetchApiController::bookmarkUrl so dedupe and fetch-job
+     * dispatch behaviour is identical. The client only needs a 2xx.
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'url' => ['required', 'url', 'max:2048'],
+        ]);
+
+        try {
+            $result = $this->bookmarks->bookmark($request->user(), $validated['url']);
+        } catch (UnsafeUrlException $e) {
+            return response()->json(['message' => 'This URL is not allowed.'], 422);
+        }
+
+        $bookmark = $result['bookmark'];
+
+        return response()->json([
+            'state' => $result['state'],
+            'bookmark' => [
+                'id' => $bookmark->id,
+                'url' => $bookmark->url,
+            ],
+        ], $result['created'] ? 201 : 200);
+    }
+}

--- a/app/Http/Controllers/Api/V1/Mobile/CheckInsController.php
+++ b/app/Http/Controllers/Api/V1/Mobile/CheckInsController.php
@@ -60,8 +60,8 @@ class CheckInsController extends Controller
 
         $sourceIds = [];
         foreach (CarbonPeriod::create($from, $to) as $date) {
-            $sourceIds[] = 'daily_checkin_morning_' . $date->toDateString();
-            $sourceIds[] = 'daily_checkin_afternoon_' . $date->toDateString();
+            $sourceIds[] = 'daily_checkin_morning_'.$date->toDateString();
+            $sourceIds[] = 'daily_checkin_afternoon_'.$date->toDateString();
         }
 
         $events = Event::whereHas('integration', function ($q) use ($request) {
@@ -147,6 +147,80 @@ class CheckInsController extends Controller
 
         return response()->json(
             (new CompactEventResource($event))->resolve($request),
+            201,
+        );
+    }
+
+    /**
+     * Allowed image mime types → file extension for shared photos.
+     */
+    private const ALLOWED_IMAGE_TYPES = [
+        'image/jpeg' => 'jpg',
+        'image/png' => 'png',
+        'image/heic' => 'heic',
+        'image/heif' => 'heif',
+        'image/webp' => 'webp',
+    ];
+
+    private const MAX_IMAGE_BYTES = 25 * 1024 * 1024; // 25 MB
+
+    /**
+     * POST /api/v1/mobile/check-ins/media
+     *
+     * Accepts a raw image body (Content-Type: image/*) from the iOS share
+     * extension's background upload task — this is NOT multipart form data.
+     * The photo is attached to the day's check-in record. An optional `date`
+     * query param (Y-m-d) overrides the default of today.
+     */
+    public function media(Request $request): JsonResponse
+    {
+        $contentType = strtolower(trim(explode(';', (string) $request->header('Content-Type'))[0]));
+
+        if (! array_key_exists($contentType, self::ALLOWED_IMAGE_TYPES)) {
+            return response()->json(['message' => 'Unsupported media type.'], 415);
+        }
+
+        $content = $request->getContent();
+        $size = strlen($content);
+
+        if ($size === 0) {
+            return response()->json(['message' => 'Empty request body.'], 422);
+        }
+
+        if ($size > self::MAX_IMAGE_BYTES) {
+            return response()->json(['message' => 'Image exceeds the maximum allowed size.'], 422);
+        }
+
+        $date = $request->query('date');
+        if (! is_string($date) || ! preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) {
+            $date = Carbon::now()->toDateString();
+        }
+
+        $extension = self::ALLOWED_IMAGE_TYPES[$contentType];
+        $fileName = 'shared_'.Str::uuid().'.'.$extension;
+        $tempPath = tempnam(sys_get_temp_dir(), 'spark_share_') ?: null;
+
+        if ($tempPath === null || file_put_contents($tempPath, $content) === false) {
+            return response()->json(['message' => 'Could not store the uploaded image.'], 500);
+        }
+
+        try {
+            $integration = $this->resolveIntegration($request);
+
+            $event = (new DailyCheckinPlugin)->createPhotoEvent(
+                $integration,
+                $date,
+                $tempPath,
+                $fileName,
+            );
+        } finally {
+            if (file_exists($tempPath)) {
+                unlink($tempPath);
+            }
+        }
+
+        return response()->json(
+            (new CompactEventResource($event->fresh(['actor', 'target', 'blocks', 'tags', 'integration'])))->resolve($request),
             201,
         );
     }

--- a/app/Http/Controllers/Api/V1/Mobile/CheckInsController.php
+++ b/app/Http/Controllers/Api/V1/Mobile/CheckInsController.php
@@ -17,6 +17,19 @@ use Illuminate\Support\Str;
 class CheckInsController extends Controller
 {
     /**
+     * Allowed image mime types → file extension for shared photos.
+     */
+    private const ALLOWED_IMAGE_TYPES = [
+        'image/jpeg' => 'jpg',
+        'image/png' => 'png',
+        'image/heic' => 'heic',
+        'image/heif' => 'heif',
+        'image/webp' => 'webp',
+    ];
+
+    private const MAX_IMAGE_BYTES = 25 * 1024 * 1024; // 25 MB
+
+    /**
      * GET /api/v1/mobile/check-ins?date=YYYY-MM-DD
      *
      * Returns morning and afternoon completion status for a given date.
@@ -60,8 +73,8 @@ class CheckInsController extends Controller
 
         $sourceIds = [];
         foreach (CarbonPeriod::create($from, $to) as $date) {
-            $sourceIds[] = 'daily_checkin_morning_'.$date->toDateString();
-            $sourceIds[] = 'daily_checkin_afternoon_'.$date->toDateString();
+            $sourceIds[] = 'daily_checkin_morning_' . $date->toDateString();
+            $sourceIds[] = 'daily_checkin_afternoon_' . $date->toDateString();
         }
 
         $events = Event::whereHas('integration', function ($q) use ($request) {
@@ -152,19 +165,6 @@ class CheckInsController extends Controller
     }
 
     /**
-     * Allowed image mime types → file extension for shared photos.
-     */
-    private const ALLOWED_IMAGE_TYPES = [
-        'image/jpeg' => 'jpg',
-        'image/png' => 'png',
-        'image/heic' => 'heic',
-        'image/heif' => 'heif',
-        'image/webp' => 'webp',
-    ];
-
-    private const MAX_IMAGE_BYTES = 25 * 1024 * 1024; // 25 MB
-
-    /**
      * POST /api/v1/mobile/check-ins/media
      *
      * Accepts a raw image body (Content-Type: image/*) from the iOS share
@@ -197,7 +197,7 @@ class CheckInsController extends Controller
         }
 
         $extension = self::ALLOWED_IMAGE_TYPES[$contentType];
-        $fileName = 'shared_'.Str::uuid().'.'.$extension;
+        $fileName = 'shared_' . Str::uuid() . '.' . $extension;
         $tempPath = tempnam(sys_get_temp_dir(), 'spark_share_') ?: null;
 
         if ($tempPath === null || file_put_contents($tempPath, $content) === false) {

--- a/app/Http/Controllers/Api/V1/Mobile/EventsController.php
+++ b/app/Http/Controllers/Api/V1/Mobile/EventsController.php
@@ -33,4 +33,51 @@ class EventsController extends Controller
 
         return $response;
     }
+
+    /**
+     * PATCH /api/v1/mobile/events/{id}/note
+     *
+     * Sets or clears the user-authored note for an event. The note is stored
+     * as a dedicated `note` block (see CompactEventResource::NOTE_BLOCK_TYPE);
+     * a null/empty body clears it. Returns the full event detail shape so the
+     * client can re-render without a follow-up fetch.
+     */
+    public function updateNote(Request $request, string $id): JsonResponse
+    {
+        $user = $request->user();
+        $event = $this->lookup->find($user, $id);
+
+        if (! $event) {
+            return response()->json(['message' => 'Event not found.'], 404);
+        }
+
+        $validated = $request->validate([
+            'note' => ['present', 'nullable', 'string', 'max:10000'],
+        ]);
+
+        $note = is_string($validated['note'] ?? null) ? trim($validated['note']) : null;
+
+        // blocks() is withTrashed(); only act on the live note block.
+        $existing = $event->blocks->first(
+            fn ($block) => $block->block_type === CompactEventResource::NOTE_BLOCK_TYPE && $block->deleted_at === null,
+        );
+
+        if ($note === null || $note === '') {
+            $existing?->delete();
+        } else {
+            $event->createBlock([
+                'title' => 'Note',
+                'block_type' => CompactEventResource::NOTE_BLOCK_TYPE,
+                'time' => $event->time,
+                'metadata' => ['content' => $note],
+            ]);
+        }
+
+        // Reload so the resource reflects the freshly written/cleared note block.
+        $event = $this->lookup->find($user, $id);
+
+        return response()->json(
+            (new CompactEventResource($event))->resolve($request),
+        );
+    }
 }

--- a/app/Http/Controllers/Api/V1/Mobile/IntegrationsController.php
+++ b/app/Http/Controllers/Api/V1/Mobile/IntegrationsController.php
@@ -2,10 +2,14 @@
 
 namespace App\Http\Controllers\Api\V1\Mobile;
 
+use App\Actions\DispatchIntegrationFetchJobs;
 use App\Http\Controllers\Controller;
 use App\Http\Resources\Compact\CompactIntegrationResource;
+use App\Integrations\Contracts\OAuthIntegrationPlugin;
+use App\Integrations\PluginRegistry;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Throwable;
 
 class IntegrationsController extends Controller
 {
@@ -38,5 +42,85 @@ class IntegrationsController extends Controller
         return response()->json(
             (new CompactIntegrationResource($integration))->resolve($request),
         );
+    }
+
+    /**
+     * POST /api/v1/mobile/integrations/{id}/sync
+     *
+     * Triggers an immediate fetch for the integration. Mirrors the logic
+     * behind IntegrationApiController::trigger.
+     */
+    public function sync(Request $request, string $id): JsonResponse
+    {
+        $integration = $request->user()->integrations()->find($id);
+
+        if (! $integration) {
+            return response()->json(['message' => 'Integration not found.'], 404);
+        }
+
+        if ($integration->isPaused()) {
+            return response()->json(['message' => 'Integration is paused.'], 422);
+        }
+
+        $jobsDispatched = (new DispatchIntegrationFetchJobs)->dispatch($integration);
+
+        return response()->json([
+            'message' => 'Integration update triggered.',
+            'jobs_dispatched' => $jobsDispatched,
+        ]);
+    }
+
+    /**
+     * POST /api/v1/mobile/integrations/{id}/oauth/start
+     *
+     * Returns a provider OAuth URL for the app to open in
+     * `ASWebAuthenticationSession`. The group is flagged as a mobile-initiated
+     * reauth so the web OAuth callback redirects to the `spark://` custom
+     * scheme (see IntegrationController::oauthCallback) to close the session.
+     */
+    public function oauthStart(Request $request, string $id): JsonResponse
+    {
+        $integration = $request->user()->integrations()->with('group')->find($id);
+
+        if (! $integration) {
+            return response()->json(['message' => 'Integration not found.'], 404);
+        }
+
+        $group = $integration->group;
+
+        if (! $group) {
+            return response()->json(['message' => 'Integration is not connected to an account group.'], 422);
+        }
+
+        $pluginClass = PluginRegistry::getPlugin($integration->service);
+
+        if (! $pluginClass) {
+            return response()->json(['message' => 'Unknown integration service.'], 422);
+        }
+
+        $plugin = new $pluginClass;
+
+        if (! ($plugin instanceof OAuthIntegrationPlugin)) {
+            return response()->json(['message' => 'This integration does not support re-authentication.'], 422);
+        }
+
+        // Flag the group so the shared web OAuth callback bridges back to the app.
+        $metadata = $group->auth_metadata ?? [];
+        $metadata['mobile_reauth_origin'] = true;
+        $metadata['mobile_reauth_started_at'] = now()->toISOString();
+        $group->auth_metadata = $metadata;
+        $group->save();
+
+        try {
+            $url = $plugin->getOAuthUrl($group);
+        } catch (Throwable $e) {
+            return response()->json(['message' => 'Could not start re-authentication.'], 422);
+        }
+
+        if (! filter_var($url, FILTER_VALIDATE_URL)) {
+            return response()->json(['message' => 'Could not start re-authentication.'], 422);
+        }
+
+        return response()->json(['url' => $url]);
     }
 }

--- a/app/Http/Controllers/IntegrationController.php
+++ b/app/Http/Controllers/IntegrationController.php
@@ -61,12 +61,12 @@ class IntegrationController extends Controller
                 }
 
                 // Check if we have an institution selected
-                $institutionId = session('gocardless_institution_id_'.$group->id);
+                $institutionId = session('gocardless_institution_id_' . $group->id);
 
                 Log::info('GoCardless institution ID from session', [
                     'group_id' => $group->id,
                     'institution_id' => $institutionId,
-                    'session_key' => 'gocardless_institution_id_'.$group->id,
+                    'session_key' => 'gocardless_institution_id_' . $group->id,
                     'session_id' => session()->getId(),
                 ]);
 
@@ -117,7 +117,7 @@ class IntegrationController extends Controller
             ]);
 
             return redirect()->route('integrations.index')
-                ->with('error', 'Failed to initiate OAuth flow: '.$e->getMessage());
+                ->with('error', 'Failed to initiate OAuth flow: ' . $e->getMessage());
         }
     }
 
@@ -273,7 +273,7 @@ class IntegrationController extends Controller
             if ($service === 'gocardless') {
                 session()->forget([
                     'gocardless_oauth_group_id',
-                    'gocardless_institution_id_'.$group->id,
+                    'gocardless_institution_id_' . $group->id,
                 ]);
 
                 Log::info('GoCardless OAuth callback: session data cleaned up', [
@@ -346,39 +346,8 @@ class IntegrationController extends Controller
             }
 
             return redirect()->route('integrations.index')
-                ->with('error', 'Failed to connect integration: '.$e->getMessage());
+                ->with('error', 'Failed to connect integration: ' . $e->getMessage());
         }
-    }
-
-    /**
-     * Read and clear the mobile-reauth marker on a group. Returns whether the
-     * OAuth flow was started from the iOS app (see
-     * Api\V1\Mobile\IntegrationsController::oauthStart).
-     */
-    private function consumeMobileReauthOrigin(IntegrationGroup $group): bool
-    {
-        $metadata = $group->auth_metadata ?? [];
-
-        if (empty($metadata['mobile_reauth_origin'])) {
-            return false;
-        }
-
-        unset($metadata['mobile_reauth_origin'], $metadata['mobile_reauth_started_at']);
-        $group->auth_metadata = $metadata;
-        $group->save();
-
-        return true;
-    }
-
-    /**
-     * Redirect to the iOS app's custom scheme to close the in-app
-     * ASWebAuthenticationSession after a mobile-initiated reauth.
-     */
-    private function mobileReauthRedirect(bool $success): RedirectResponse
-    {
-        $status = $success ? 'success' : 'error';
-
-        return redirect()->away('spark://integrations/reauth-complete?status='.$status);
     }
 
     public function initialize(string $service)
@@ -463,7 +432,7 @@ class IntegrationController extends Controller
             ]);
 
             return redirect()->route('integrations.index')
-                ->with('error', 'Failed to initiate reconnection: '.$e->getMessage());
+                ->with('error', 'Failed to initiate reconnection: ' . $e->getMessage());
         }
     }
 
@@ -564,7 +533,7 @@ class IntegrationController extends Controller
                     case 'integer':
                         $fieldRules[] = 'integer';
                         if ($min !== null) {
-                            $fieldRules[] = 'min:'.$min;
+                            $fieldRules[] = 'min:' . $min;
                         }
                         break;
                     case 'array':
@@ -792,7 +761,7 @@ class IntegrationController extends Controller
                             // Name the instance: prefer type label (avoid duplicated service name)
                             $typeLabel = $typesMeta[$type]['label'] ?? ucfirst($type);
                             $base = $instanceNames[$type] ?? $typeLabel;
-                            $customName = trim($base.' - '.($presetName ?? ucfirst($presetKey)));
+                            $customName = trim($base . ' - ' . ($presetName ?? ucfirst($presetKey)));
                             $instance->update(['name' => $customName]);
 
                             if ($request->boolean('run_migration')) {
@@ -835,5 +804,36 @@ class IntegrationController extends Controller
 
         return redirect()->route('integrations.index')
             ->with('success', $successMessage);
+    }
+
+    /**
+     * Read and clear the mobile-reauth marker on a group. Returns whether the
+     * OAuth flow was started from the iOS app (see
+     * Api\V1\Mobile\IntegrationsController::oauthStart).
+     */
+    private function consumeMobileReauthOrigin(IntegrationGroup $group): bool
+    {
+        $metadata = $group->auth_metadata ?? [];
+
+        if (empty($metadata['mobile_reauth_origin'])) {
+            return false;
+        }
+
+        unset($metadata['mobile_reauth_origin'], $metadata['mobile_reauth_started_at']);
+        $group->auth_metadata = $metadata;
+        $group->save();
+
+        return true;
+    }
+
+    /**
+     * Redirect to the iOS app's custom scheme to close the in-app
+     * ASWebAuthenticationSession after a mobile-initiated reauth.
+     */
+    private function mobileReauthRedirect(bool $success): RedirectResponse
+    {
+        $status = $success ? 'success' : 'error';
+
+        return redirect()->away('spark://integrations/reauth-complete?status=' . $status);
     }
 }

--- a/app/Http/Controllers/IntegrationController.php
+++ b/app/Http/Controllers/IntegrationController.php
@@ -61,12 +61,12 @@ class IntegrationController extends Controller
                 }
 
                 // Check if we have an institution selected
-                $institutionId = session('gocardless_institution_id_' . $group->id);
+                $institutionId = session('gocardless_institution_id_'.$group->id);
 
                 Log::info('GoCardless institution ID from session', [
                     'group_id' => $group->id,
                     'institution_id' => $institutionId,
-                    'session_key' => 'gocardless_institution_id_' . $group->id,
+                    'session_key' => 'gocardless_institution_id_'.$group->id,
                     'session_id' => session()->getId(),
                 ]);
 
@@ -117,7 +117,7 @@ class IntegrationController extends Controller
             ]);
 
             return redirect()->route('integrations.index')
-                ->with('error', 'Failed to initiate OAuth flow: ' . $e->getMessage());
+                ->with('error', 'Failed to initiate OAuth flow: '.$e->getMessage());
         }
     }
 
@@ -247,6 +247,11 @@ class IntegrationController extends Controller
             }
         }
 
+        // If the OAuth flow was started from the iOS app, bridge the terminal
+        // redirects back to the `spark://` custom scheme so the in-app
+        // ASWebAuthenticationSession closes. Consume (clear) the marker now.
+        $mobileReauthOrigin = $this->consumeMobileReauthOrigin($group);
+
         try {
             if (method_exists($plugin, 'handleOAuthCallback')) {
                 Log::info('Calling plugin handleOAuthCallback', [
@@ -268,7 +273,7 @@ class IntegrationController extends Controller
             if ($service === 'gocardless') {
                 session()->forget([
                     'gocardless_oauth_group_id',
-                    'gocardless_institution_id_' . $group->id,
+                    'gocardless_institution_id_'.$group->id,
                 ]);
 
                 Log::info('GoCardless OAuth callback: session data cleaned up', [
@@ -307,6 +312,10 @@ class IntegrationController extends Controller
                 'group_id' => $group->id,
             ]);
 
+            if ($mobileReauthOrigin) {
+                return $this->mobileReauthRedirect(true);
+            }
+
             // If group already has integrations, this is a reconnect — skip onboarding
             if ($group->integrations()->exists()) {
                 return redirect()->route('integrations.index')
@@ -332,9 +341,44 @@ class IntegrationController extends Controller
                 ],
             ]);
 
+            if ($mobileReauthOrigin) {
+                return $this->mobileReauthRedirect(false);
+            }
+
             return redirect()->route('integrations.index')
-                ->with('error', 'Failed to connect integration: ' . $e->getMessage());
+                ->with('error', 'Failed to connect integration: '.$e->getMessage());
         }
+    }
+
+    /**
+     * Read and clear the mobile-reauth marker on a group. Returns whether the
+     * OAuth flow was started from the iOS app (see
+     * Api\V1\Mobile\IntegrationsController::oauthStart).
+     */
+    private function consumeMobileReauthOrigin(IntegrationGroup $group): bool
+    {
+        $metadata = $group->auth_metadata ?? [];
+
+        if (empty($metadata['mobile_reauth_origin'])) {
+            return false;
+        }
+
+        unset($metadata['mobile_reauth_origin'], $metadata['mobile_reauth_started_at']);
+        $group->auth_metadata = $metadata;
+        $group->save();
+
+        return true;
+    }
+
+    /**
+     * Redirect to the iOS app's custom scheme to close the in-app
+     * ASWebAuthenticationSession after a mobile-initiated reauth.
+     */
+    private function mobileReauthRedirect(bool $success): RedirectResponse
+    {
+        $status = $success ? 'success' : 'error';
+
+        return redirect()->away('spark://integrations/reauth-complete?status='.$status);
     }
 
     public function initialize(string $service)
@@ -419,7 +463,7 @@ class IntegrationController extends Controller
             ]);
 
             return redirect()->route('integrations.index')
-                ->with('error', 'Failed to initiate reconnection: ' . $e->getMessage());
+                ->with('error', 'Failed to initiate reconnection: '.$e->getMessage());
         }
     }
 
@@ -520,7 +564,7 @@ class IntegrationController extends Controller
                     case 'integer':
                         $fieldRules[] = 'integer';
                         if ($min !== null) {
-                            $fieldRules[] = 'min:' . $min;
+                            $fieldRules[] = 'min:'.$min;
                         }
                         break;
                     case 'array':
@@ -748,7 +792,7 @@ class IntegrationController extends Controller
                             // Name the instance: prefer type label (avoid duplicated service name)
                             $typeLabel = $typesMeta[$type]['label'] ?? ucfirst($type);
                             $base = $instanceNames[$type] ?? $typeLabel;
-                            $customName = trim($base . ' - ' . ($presetName ?? ucfirst($presetKey)));
+                            $customName = trim($base.' - '.($presetName ?? ucfirst($presetKey)));
                             $instance->update(['name' => $customName]);
 
                             if ($request->boolean('run_migration')) {

--- a/app/Http/Resources/Compact/ApiTokenResource.php
+++ b/app/Http/Resources/Compact/ApiTokenResource.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Resources\Compact;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Laravel\Sanctum\PersonalAccessToken;
+
+/**
+ * @mixin PersonalAccessToken
+ *
+ * Mobile shape for a personal access token. The iOS client decodes this into
+ * the `ApiToken` Swift struct, so `id` is stringified and timestamps are
+ * ISO-8601. Never includes the plaintext secret — that is only returned once,
+ * at creation, by ApiTokensController::store.
+ */
+class ApiTokenResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => (string) $this->id,
+            'name' => $this->name,
+            'abilities' => $this->abilities ?? [],
+            'last_used_at' => $this->last_used_at?->toIso8601String(),
+            'created_at' => $this->created_at?->toIso8601String(),
+        ];
+    }
+}

--- a/app/Http/Resources/Compact/CompactEventResource.php
+++ b/app/Http/Resources/Compact/CompactEventResource.php
@@ -18,6 +18,12 @@ use Illuminate\Http\Resources\Json\JsonResource;
 class CompactEventResource extends JsonResource
 {
     /**
+     * Block type that stores a user-authored note for an event. Mirrored in
+     * EventsController::updateNote, which writes/clears this block.
+     */
+    public const NOTE_BLOCK_TYPE = 'note';
+
+    /**
      * @return array<string, mixed>
      */
     public function toArray(Request $request): array
@@ -81,10 +87,26 @@ class CompactEventResource extends JsonResource
                 $data['tldr'] = $tldr->getContent();
             }
 
+            // User-authored note lives in a dedicated `note` block. It surfaces as a
+            // top-level `note` field (the iOS detail screen has its own note editor)
+            // and is excluded from the generic blocks grid below to avoid duplication.
+            // The blocks relation is withTrashed(), so ignore soft-deleted note
+            // blocks (a cleared note) when surfacing the current note.
+            $note = $this->blocks->first(
+                fn ($block) => $block->block_type === self::NOTE_BLOCK_TYPE && $block->deleted_at === null,
+            );
+
+            if ($note) {
+                $data['note'] = $note->getContent();
+            }
+
             // Full blocks array only in the detail endpoint. The feed uses withCount('blocks')
             // which sets blocks_count, signalling list mode where the array would be too heavy.
             if (! isset($this->blocks_count)) {
-                $data['blocks'] = CompactBlockResource::collection($this->blocks)->resolve($request);
+                $blocks = $this->blocks->reject(
+                    fn ($block) => $block->block_type === self::NOTE_BLOCK_TYPE,
+                );
+                $data['blocks'] = CompactBlockResource::collection($blocks)->resolve($request);
             }
         }
 

--- a/app/Integrations/DailyCheckin/DailyCheckinPlugin.php
+++ b/app/Integrations/DailyCheckin/DailyCheckinPlugin.php
@@ -181,7 +181,7 @@ class DailyCheckinPlugin extends ManualPlugin
                 'title' => $date,
             ],
             [
-                'time' => $date.' 00:00:00',
+                'time' => $date . ' 00:00:00',
                 'content' => null,
                 'metadata' => [],
             ]
@@ -205,13 +205,13 @@ class DailyCheckinPlugin extends ManualPlugin
 
         // Determine action and default time based on period
         $action = $period === 'morning' ? 'had_morning_checkin' : 'had_afternoon_checkin';
-        $defaultTime = $period === 'morning' ? $date.' 08:00:00' : $date.' 17:00:00';
+        $defaultTime = $period === 'morning' ? $date . ' 08:00:00' : $date . ' 17:00:00';
 
         // Calculate combined value (out of 10)
         $combinedValue = $physical + $mental;
 
         // Create or update the event
-        $sourceId = 'daily_checkin_'.$period.'_'.$date;
+        $sourceId = 'daily_checkin_' . $period . '_' . $date;
 
         $event = Event::updateOrCreate(
             [
@@ -298,7 +298,7 @@ class DailyCheckinPlugin extends ManualPlugin
                 'title' => $date,
             ],
             [
-                'time' => $date.' 00:00:00',
+                'time' => $date . ' 00:00:00',
                 'content' => null,
                 'metadata' => [],
             ]
@@ -321,7 +321,7 @@ class DailyCheckinPlugin extends ManualPlugin
 
         $event = Event::create([
             'integration_id' => $integration->id,
-            'source_id' => 'daily_checkin_photo_'.$date.'_'.Str::uuid(),
+            'source_id' => 'daily_checkin_photo_' . $date . '_' . Str::uuid(),
             'time' => now(),
             'service' => 'daily_checkin',
             'domain' => self::getDomain(),
@@ -366,8 +366,8 @@ class DailyCheckinPlugin extends ManualPlugin
         })
             ->where('service', 'daily_checkin')
             ->whereIn('source_id', [
-                'daily_checkin_morning_'.$date,
-                'daily_checkin_afternoon_'.$date,
+                'daily_checkin_morning_' . $date,
+                'daily_checkin_afternoon_' . $date,
             ])
             ->with('blocks')
             ->get();

--- a/app/Integrations/DailyCheckin/DailyCheckinPlugin.php
+++ b/app/Integrations/DailyCheckin/DailyCheckinPlugin.php
@@ -85,6 +85,7 @@ class DailyCheckinPlugin extends ManualPlugin
                 'display_name' => 'Shared a Photo',
                 'description' => 'A photo shared to Spark for the day',
                 'display_with_object' => false,
+                'value_unit' => null,
                 'hidden' => false,
             ],
         ];
@@ -114,6 +115,7 @@ class DailyCheckinPlugin extends ManualPlugin
                 'display_name' => 'Photo',
                 'description' => 'A photo shared to Spark',
                 'display_with_object' => false,
+                'value_unit' => null,
                 'hidden' => false,
             ],
         ];

--- a/app/Integrations/DailyCheckin/DailyCheckinPlugin.php
+++ b/app/Integrations/DailyCheckin/DailyCheckinPlugin.php
@@ -7,7 +7,9 @@ use App\Models\Event;
 use App\Models\EventObject;
 use App\Models\Integration;
 use App\Models\User;
+use App\Services\Media\MediaDownloadHelper;
 use App\Services\PlaceDetectionService;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 
 class DailyCheckinPlugin extends ManualPlugin
@@ -78,6 +80,13 @@ class DailyCheckinPlugin extends ManualPlugin
                 'value_formatter' => '{{ round($value) }}<span class="text-[0.875em]">/10</span>',
                 'hidden' => false,
             ],
+            'shared_a_photo' => [
+                'icon' => 'fas.camera',
+                'display_name' => 'Shared a Photo',
+                'description' => 'A photo shared to Spark for the day',
+                'display_with_object' => false,
+                'hidden' => false,
+            ],
         ];
     }
 
@@ -98,6 +107,13 @@ class DailyCheckinPlugin extends ManualPlugin
                 'description' => 'Mental energy rating (1-5)',
                 'display_with_object' => false,
                 'value_unit' => 'out of 5',
+                'hidden' => false,
+            ],
+            'photo' => [
+                'icon' => 'fas.camera',
+                'display_name' => 'Photo',
+                'description' => 'A photo shared to Spark',
+                'display_with_object' => false,
                 'hidden' => false,
             ],
         ];
@@ -165,7 +181,7 @@ class DailyCheckinPlugin extends ManualPlugin
                 'title' => $date,
             ],
             [
-                'time' => $date . ' 00:00:00',
+                'time' => $date.' 00:00:00',
                 'content' => null,
                 'metadata' => [],
             ]
@@ -189,13 +205,13 @@ class DailyCheckinPlugin extends ManualPlugin
 
         // Determine action and default time based on period
         $action = $period === 'morning' ? 'had_morning_checkin' : 'had_afternoon_checkin';
-        $defaultTime = $period === 'morning' ? $date . ' 08:00:00' : $date . ' 17:00:00';
+        $defaultTime = $period === 'morning' ? $date.' 08:00:00' : $date.' 17:00:00';
 
         // Calculate combined value (out of 10)
         $combinedValue = $physical + $mental;
 
         // Create or update the event
-        $sourceId = 'daily_checkin_' . $period . '_' . $date;
+        $sourceId = 'daily_checkin_'.$period.'_'.$date;
 
         $event = Event::updateOrCreate(
             [
@@ -257,6 +273,86 @@ class DailyCheckinPlugin extends ManualPlugin
     }
 
     /**
+     * Attach a shared photo to the given day.
+     *
+     * Creates an event (action `shared_a_photo`) targeting the day object and
+     * a `photo` block, then attaches the supplied image file to the block's
+     * media library collection. Mirrors createCheckinEvent's day/user wiring.
+     *
+     * @param  Integration  $integration  The daily check-in integration
+     * @param  string  $date  Date in Y-m-d format the photo belongs to
+     * @param  string  $imagePath  Absolute path to the image file on disk
+     * @param  string  $fileName  Original/desired file name (with extension)
+     */
+    public function createPhotoEvent(
+        Integration $integration,
+        string $date,
+        string $imagePath,
+        string $fileName,
+    ): Event {
+        $dayObject = EventObject::firstOrCreate(
+            [
+                'user_id' => $integration->user_id,
+                'concept' => 'day',
+                'type' => 'day',
+                'title' => $date,
+            ],
+            [
+                'time' => $date.' 00:00:00',
+                'content' => null,
+                'metadata' => [],
+            ]
+        );
+
+        $user = User::find($integration->user_id);
+        $userObject = EventObject::firstOrCreate(
+            [
+                'user_id' => $integration->user_id,
+                'concept' => 'user',
+                'type' => 'user',
+                'title' => $user ? $user->name : 'User',
+            ],
+            [
+                'time' => now(),
+                'content' => null,
+                'metadata' => [],
+            ]
+        );
+
+        $event = Event::create([
+            'integration_id' => $integration->id,
+            'source_id' => 'daily_checkin_photo_'.$date.'_'.Str::uuid(),
+            'time' => now(),
+            'service' => 'daily_checkin',
+            'domain' => self::getDomain(),
+            'action' => 'shared_a_photo',
+            'event_metadata' => [
+                'date' => $date,
+                'source' => 'ios_share_extension',
+            ],
+            'target_id' => $dayObject->id,
+            'actor_id' => $userObject->id,
+        ]);
+
+        $block = $event->createBlock([
+            'title' => 'Photo',
+            'block_type' => 'photo',
+            'time' => $event->time,
+            'metadata' => ['date' => $date],
+        ]);
+
+        app(MediaDownloadHelper::class)->attachMediaFromBase64(
+            base64_encode((string) file_get_contents($imagePath)),
+            $block,
+            $fileName,
+            'downloaded_images',
+            ['source' => 'ios_share_extension'],
+        );
+
+        return $event;
+    }
+
+    /**
      * Get check-in events for a specific date
      *
      * @param  int|string  $userId  The user ID
@@ -270,8 +366,8 @@ class DailyCheckinPlugin extends ManualPlugin
         })
             ->where('service', 'daily_checkin')
             ->whereIn('source_id', [
-                'daily_checkin_morning_' . $date,
-                'daily_checkin_afternoon_' . $date,
+                'daily_checkin_morning_'.$date,
+                'daily_checkin_afternoon_'.$date,
             ])
             ->with('blocks')
             ->get();

--- a/app/Services/Fetch/BookmarkUrlService.php
+++ b/app/Services/Fetch/BookmarkUrlService.php
@@ -1,0 +1,96 @@
+<?php
+
+namespace App\Services\Fetch;
+
+use App\Exceptions\UnsafeUrlException;
+use App\Jobs\Fetch\FetchSingleUrl;
+use App\Models\EventObject;
+use App\Models\User;
+
+/**
+ * Shared bookmark-creation logic used by both the public fetch API
+ * (FetchApiController::bookmarkUrl) and the mobile share-extension endpoint
+ * (Api\V1\Mobile\BookmarksController). Keeping it here guarantees dedupe and
+ * fetch-job dispatch behaviour stays identical across both surfaces.
+ */
+class BookmarkUrlService
+{
+    public function __construct(
+        protected UrlSafetyValidator $urlSafety,
+        protected FetchIntegrationResolver $integrationResolver,
+    ) {}
+
+    /**
+     * Create (or resolve an existing) bookmark for the user and optionally
+     * dispatch a fetch job.
+     *
+     * @return array{state: string, bookmark: EventObject, job_dispatched: bool, created: bool}
+     *
+     * @throws UnsafeUrlException when the URL fails the safety validator.
+     */
+    public function bookmark(
+        User $user,
+        string $url,
+        bool $fetchImmediately = true,
+        bool $forceRefresh = false,
+        string $fetchMode = 'once',
+    ): array {
+        $this->urlSafety->validate($url);
+
+        $domain = parse_url($url, PHP_URL_HOST);
+
+        $existingBookmark = EventObject::where('user_id', $user->id)
+            ->where('concept', 'bookmark')
+            ->where('type', 'fetch_webpage')
+            ->where('url', $url)
+            ->first();
+
+        $integration = $this->integrationResolver->resolve($user);
+
+        if ($existingBookmark) {
+            $jobDispatched = false;
+            if ($forceRefresh && $fetchImmediately) {
+                FetchSingleUrl::dispatch($integration, $existingBookmark->id, $existingBookmark->url, true);
+                $jobDispatched = true;
+            }
+
+            return [
+                'state' => $jobDispatched ? 'refreshed' : 'already_exists',
+                'bookmark' => $existingBookmark,
+                'job_dispatched' => $jobDispatched,
+                'created' => false,
+            ];
+        }
+
+        $bookmark = EventObject::create([
+            'user_id' => $user->id,
+            'concept' => 'bookmark',
+            'type' => 'fetch_webpage',
+            'title' => $url, // Will be updated with the real title after fetch
+            'url' => $url,
+            'time' => now(),
+            'metadata' => [
+                'domain' => $domain,
+                'fetch_integration_id' => $integration?->id,
+                'subscription_source' => 'api',
+                'fetch_mode' => $fetchMode,
+                'enabled' => true,
+                'subscribed_at' => now()->toISOString(),
+                'fetch_count' => 0,
+            ],
+        ]);
+
+        $jobDispatched = false;
+        if ($fetchImmediately && $integration) {
+            FetchSingleUrl::dispatch($integration, $bookmark->id, $bookmark->url);
+            $jobDispatched = true;
+        }
+
+        return [
+            'state' => $jobDispatched ? 'queued' : 'pending_no_fetch',
+            'bookmark' => $bookmark,
+            'job_dispatched' => $jobDispatched,
+            'created' => true,
+        ];
+    }
+}

--- a/routes/mobile.php
+++ b/routes/mobile.php
@@ -1,7 +1,9 @@
 <?php
 
 use App\Http\Controllers\Api\V1\Mobile\AnomaliesController;
+use App\Http\Controllers\Api\V1\Mobile\ApiTokensController;
 use App\Http\Controllers\Api\V1\Mobile\BlocksController;
+use App\Http\Controllers\Api\V1\Mobile\BookmarksController;
 use App\Http\Controllers\Api\V1\Mobile\BriefingController;
 use App\Http\Controllers\Api\V1\Mobile\CheckInsController;
 use App\Http\Controllers\Api\V1\Mobile\DevicesController;
@@ -60,6 +62,9 @@ Route::get('feed', [FeedController::class, 'index'])->name('feed.index');
 Route::get('notifications', [NotificationsController::class, 'index'])->name('notifications.index');
 
 Route::get('events/{id}', [EventsController::class, 'show'])->name('events.show');
+Route::patch('events/{id}/note', [EventsController::class, 'updateNote'])
+    ->middleware('ability:ios:write')
+    ->name('events.note.update');
 Route::get('objects/{id}', [ObjectsController::class, 'show'])->name('objects.show');
 Route::get('blocks/{id}', [BlocksController::class, 'show'])->name('blocks.show');
 Route::get('metrics', [MetricsController::class, 'index'])->name('metrics.index');
@@ -73,6 +78,12 @@ Route::get('search', [SearchController::class, 'index'])->name('search.index');
 
 Route::get('integrations', [IntegrationsController::class, 'index'])->name('integrations.index');
 Route::get('integrations/{id}', [IntegrationsController::class, 'show'])->name('integrations.show');
+Route::post('integrations/{id}/sync', [IntegrationsController::class, 'sync'])
+    ->middleware('ability:ios:write')
+    ->name('integrations.sync');
+Route::post('integrations/{id}/oauth/start', [IntegrationsController::class, 'oauthStart'])
+    ->middleware('ability:ios:write')
+    ->name('integrations.oauth.start');
 
 Route::get('places/{id}', [PlacesController::class, 'show'])->name('places.show');
 
@@ -157,6 +168,10 @@ Route::post('check-ins', [CheckInsController::class, 'store'])
     ->middleware('ability:ios:write')
     ->name('check-ins.store');
 
+Route::post('check-ins/media', [CheckInsController::class, 'media'])
+    ->middleware('ability:ios:write')
+    ->name('check-ins.media');
+
 Route::patch('settings/notifications', [NotificationSettingsController::class, 'update'])
     ->middleware('ability:ios:write')
     ->name('settings.notifications.update');
@@ -179,6 +194,27 @@ Route::delete('notifications/{id}', [NotificationsController::class, 'destroy'])
 Route::post('knowledge/events/{id}/reprocess', [KnowledgeReprocessingController::class, 'store'])
     ->middleware('ability:ios:write')
     ->name('knowledge.events.reprocess');
+
+Route::post('bookmarks', [BookmarksController::class, 'store'])
+    ->middleware('ability:ios:write')
+    ->name('bookmarks.store');
+
+/*
+|--------------------------------------------------------------------------
+| API token management
+|--------------------------------------------------------------------------
+*/
+
+Route::get('api-tokens', [ApiTokensController::class, 'index'])
+    ->name('api-tokens.index');
+
+Route::post('api-tokens', [ApiTokensController::class, 'store'])
+    ->middleware('ability:ios:write')
+    ->name('api-tokens.store');
+
+Route::delete('api-tokens/{id}', [ApiTokensController::class, 'destroy'])
+    ->middleware('ability:ios:write')
+    ->name('api-tokens.destroy');
 
 /*
 |--------------------------------------------------------------------------

--- a/tests/Feature/Api/V1/Mobile/ApiTokensControllerTest.php
+++ b/tests/Feature/Api/V1/Mobile/ApiTokensControllerTest.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Tests\Feature\Api\V1\Mobile;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ApiTokensControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['ios.mobile_api_enabled' => true]);
+
+        $this->user = User::factory()->create();
+    }
+
+    #[Test]
+    public function requires_authentication(): void
+    {
+        $this->getJson('/api/v1/mobile/api-tokens')->assertStatus(401);
+    }
+
+    #[Test]
+    public function index_lists_user_tokens(): void
+    {
+        $this->user->createToken('CLI', ['*']);
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->getJson('/api/v1/mobile/api-tokens')
+            ->assertOk()
+            ->assertJsonCount(1)
+            ->assertJsonPath('0.name', 'CLI')
+            ->assertJsonStructure([['id', 'name', 'abilities', 'last_used_at', 'created_at']]);
+    }
+
+    #[Test]
+    public function index_hides_ios_app_session_tokens(): void
+    {
+        $this->user->createToken('iOS App', ['ios:read', 'ios:write']);
+        $this->user->createToken('MCP', ['*']);
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->getJson('/api/v1/mobile/api-tokens')
+            ->assertOk()
+            ->assertJsonCount(1)
+            ->assertJsonPath('0.name', 'MCP');
+    }
+
+    #[Test]
+    public function store_creates_token_and_returns_plaintext(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $response = $this->postJson('/api/v1/mobile/api-tokens', [
+            'name' => 'My MCP token',
+            'abilities' => ['mcp:read'],
+        ])
+            ->assertStatus(201)
+            ->assertJsonStructure(['id', 'name', 'plaintext'])
+            ->assertJsonPath('name', 'My MCP token');
+
+        $this->assertDatabaseHas('personal_access_tokens', [
+            'tokenable_id' => $this->user->id,
+            'name' => 'My MCP token',
+        ]);
+
+        // Plaintext is the bearer that follows the `id|secret` Sanctum format.
+        $this->assertStringContainsString('|', $response->json('plaintext'));
+    }
+
+    #[Test]
+    public function store_defaults_to_wildcard_when_no_abilities_given(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson('/api/v1/mobile/api-tokens', ['name' => 'Default'])
+            ->assertStatus(201);
+
+        $token = $this->user->tokens()->where('name', 'Default')->first();
+        $this->assertSame(['*'], $token->abilities);
+    }
+
+    #[Test]
+    public function store_strips_ios_session_abilities(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson('/api/v1/mobile/api-tokens', [
+            'name' => 'Sneaky',
+            'abilities' => ['ios:write', 'mcp:read'],
+        ])->assertStatus(201);
+
+        $token = $this->user->tokens()->where('name', 'Sneaky')->first();
+        $this->assertSame(['mcp:read'], $token->abilities);
+    }
+
+    #[Test]
+    public function store_requires_write_ability(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $this->postJson('/api/v1/mobile/api-tokens', ['name' => 'Nope'])
+            ->assertStatus(403);
+    }
+
+    #[Test]
+    public function store_requires_name(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson('/api/v1/mobile/api-tokens', ['abilities' => ['mcp:read']])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['name']);
+    }
+
+    #[Test]
+    public function destroy_revokes_a_token(): void
+    {
+        $token = $this->user->createToken('MCP', ['*'])->accessToken;
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->deleteJson("/api/v1/mobile/api-tokens/{$token->getKey()}")
+            ->assertStatus(204);
+
+        $this->assertDatabaseMissing('personal_access_tokens', ['id' => $token->getKey()]);
+    }
+
+    #[Test]
+    public function destroy_will_not_revoke_ios_session_tokens(): void
+    {
+        $token = $this->user->createToken('iOS App', ['ios:read', 'ios:write'])->accessToken;
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->deleteJson("/api/v1/mobile/api-tokens/{$token->getKey()}")
+            ->assertStatus(404);
+
+        $this->assertDatabaseHas('personal_access_tokens', ['id' => $token->getKey()]);
+    }
+
+    #[Test]
+    public function destroy_denies_other_users_tokens(): void
+    {
+        $other = User::factory()->create();
+        $token = $other->createToken('Theirs', ['*'])->accessToken;
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->deleteJson("/api/v1/mobile/api-tokens/{$token->getKey()}")
+            ->assertStatus(404);
+
+        $this->assertDatabaseHas('personal_access_tokens', ['id' => $token->getKey()]);
+    }
+
+    #[Test]
+    public function destroy_requires_write_ability(): void
+    {
+        $token = $this->user->createToken('MCP', ['*'])->accessToken;
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $this->deleteJson("/api/v1/mobile/api-tokens/{$token->getKey()}")
+            ->assertStatus(403);
+    }
+}

--- a/tests/Feature/Api/V1/Mobile/BookmarksControllerTest.php
+++ b/tests/Feature/Api/V1/Mobile/BookmarksControllerTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Tests\Feature\Api\V1\Mobile;
+
+use App\Jobs\Fetch\FetchSingleUrl;
+use App\Models\EventObject;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
+use Laravel\Sanctum\Sanctum;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class BookmarksControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['ios.mobile_api_enabled' => true]);
+
+        $this->user = User::factory()->create();
+    }
+
+    #[Test]
+    public function requires_authentication(): void
+    {
+        $this->postJson('/api/v1/mobile/bookmarks', ['url' => 'https://example.com/article'])
+            ->assertStatus(401);
+    }
+
+    #[Test]
+    public function requires_write_ability(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $this->postJson('/api/v1/mobile/bookmarks', ['url' => 'https://example.com/article'])
+            ->assertStatus(403);
+    }
+
+    #[Test]
+    public function stores_bookmark_and_dispatches_fetch_job(): void
+    {
+        Queue::fake();
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson('/api/v1/mobile/bookmarks', ['url' => 'https://example.com/article'])
+            ->assertStatus(201)
+            ->assertJsonPath('bookmark.url', 'https://example.com/article');
+
+        $this->assertDatabaseHas('objects', [
+            'user_id' => $this->user->id,
+            'concept' => 'bookmark',
+            'type' => 'fetch_webpage',
+            'url' => 'https://example.com/article',
+        ]);
+
+        Queue::assertPushed(FetchSingleUrl::class);
+    }
+
+    #[Test]
+    public function duplicate_bookmark_does_not_create_a_second(): void
+    {
+        Queue::fake();
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        EventObject::create([
+            'user_id' => $this->user->id,
+            'concept' => 'bookmark',
+            'type' => 'fetch_webpage',
+            'title' => 'Example Article',
+            'url' => 'https://example.com/article',
+            'time' => now(),
+            'metadata' => ['domain' => 'example.com', 'enabled' => true],
+        ]);
+
+        $this->postJson('/api/v1/mobile/bookmarks', ['url' => 'https://example.com/article'])
+            ->assertStatus(200);
+
+        $this->assertSame(1, EventObject::where('url', 'https://example.com/article')->count());
+        Queue::assertNothingPushed();
+    }
+
+    #[Test]
+    public function validates_url_format(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson('/api/v1/mobile/bookmarks', ['url' => 'not-a-url'])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['url']);
+    }
+
+    #[Test]
+    public function rejects_unsafe_ssrf_targets(): void
+    {
+        Queue::fake();
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson('/api/v1/mobile/bookmarks', ['url' => 'http://169.254.169.254/latest/meta-data/'])
+            ->assertStatus(422);
+
+        $this->assertSame(0, EventObject::query()->count());
+        Queue::assertNothingPushed();
+    }
+}

--- a/tests/Feature/Api/V1/Mobile/CheckInsControllerTest.php
+++ b/tests/Feature/Api/V1/Mobile/CheckInsControllerTest.php
@@ -7,6 +7,8 @@ use App\Models\Integration;
 use App\Models\IntegrationGroup;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Testing\TestResponse;
 use Laravel\Sanctum\Sanctum;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -232,8 +234,97 @@ class CheckInsControllerTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
+    // POST /api/v1/mobile/check-ins/media
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function media_requires_authentication(): void
+    {
+        $this->uploadImage($this->createTestImageContent())->assertStatus(401);
+    }
+
+    #[Test]
+    public function media_requires_write_ability(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $this->uploadImage($this->createTestImageContent())->assertStatus(403);
+    }
+
+    #[Test]
+    public function media_rejects_unsupported_content_type(): void
+    {
+        $this->prepareMediaTest();
+
+        $this->uploadImage('not an image', 'application/pdf')->assertStatus(415);
+    }
+
+    #[Test]
+    public function media_rejects_empty_body(): void
+    {
+        $this->prepareMediaTest();
+
+        $this->uploadImage('', 'image/jpeg')->assertStatus(422);
+    }
+
+    #[Test]
+    public function media_stores_photo_and_attaches_it_to_the_day(): void
+    {
+        $this->prepareMediaTest();
+
+        $this->uploadImage($this->createTestImageContent())
+            ->assertStatus(201)
+            ->assertJsonPath('action', 'shared_a_photo');
+
+        $event = Event::where('service', 'daily_checkin')
+            ->where('action', 'shared_a_photo')
+            ->first();
+
+        $this->assertNotNull($event);
+
+        $block = $event->blocks()->where('block_type', 'photo')->first();
+        $this->assertNotNull($block);
+        $this->assertSame(1, $block->getMedia('downloaded_images')->count());
+
+        // Attached to the day object.
+        $this->assertDatabaseHas('objects', [
+            'id' => $event->target_id,
+            'concept' => 'day',
+            'type' => 'day',
+        ]);
+    }
+
+    // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
+
+    protected function prepareMediaTest(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+        Storage::fake('public');
+        config(['media-library.disk_name' => 'public']);
+        // The photo event/block dispatches the task pipeline on create; keep it out.
+        config(['app.enable_task_pipeline' => false]);
+    }
+
+    protected function uploadImage(string $content, string $contentType = 'image/jpeg'): TestResponse
+    {
+        return $this->call('POST', '/api/v1/mobile/check-ins/media', [], [], [], [
+            'CONTENT_TYPE' => $contentType,
+            'HTTP_ACCEPT' => 'application/json',
+        ], $content);
+    }
+
+    protected function createTestImageContent(): string
+    {
+        $image = imagecreatetruecolor(1, 1);
+        ob_start();
+        imagejpeg($image);
+        $content = ob_get_clean();
+        imagedestroy($image);
+
+        return $content;
+    }
 
     protected function payload(array $overrides = []): array
     {

--- a/tests/Feature/Api/V1/Mobile/EventsControllerTest.php
+++ b/tests/Feature/Api/V1/Mobile/EventsControllerTest.php
@@ -25,6 +25,8 @@ class EventsControllerTest extends TestCase
     {
         parent::setUp();
         config(['ios.mobile_api_enabled' => true]);
+        // Note writes create a block; keep the task pipeline (embedding etc.) out of these tests.
+        config(['app.enable_task_pipeline' => false]);
 
         $this->user = User::factory()->create();
 
@@ -100,6 +102,90 @@ class EventsControllerTest extends TestCase
 
         $this->getJson("/api/v1/mobile/events/{$event->id}", ['If-None-Match' => $etag])
             ->assertStatus(304);
+    }
+
+    #[Test]
+    public function update_note_sets_a_note_and_returns_it(): void
+    {
+        $event = $this->createEvent();
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->patchJson("/api/v1/mobile/events/{$event->id}/note", ['note' => 'Remember this one'])
+            ->assertOk()
+            ->assertJsonPath('id', $event->id)
+            ->assertJsonPath('note', 'Remember this one');
+
+        $this->assertDatabaseHas('blocks', [
+            'event_id' => $event->id,
+            'block_type' => 'note',
+            'title' => 'Note',
+        ]);
+
+        // The note block must not leak into the generic blocks grid.
+        $this->getJson("/api/v1/mobile/events/{$event->id}")
+            ->assertOk()
+            ->assertJsonPath('note', 'Remember this one')
+            ->assertJsonMissing(['block_type' => 'note']);
+    }
+
+    #[Test]
+    public function update_note_is_idempotent_and_updates_existing_note(): void
+    {
+        $event = $this->createEvent();
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->patchJson("/api/v1/mobile/events/{$event->id}/note", ['note' => 'First'])->assertOk();
+        $this->patchJson("/api/v1/mobile/events/{$event->id}/note", ['note' => 'Second'])
+            ->assertOk()
+            ->assertJsonPath('note', 'Second');
+
+        $this->assertSame(1, $event->blocks()->where('block_type', 'note')->count());
+    }
+
+    #[Test]
+    public function update_note_with_null_clears_the_note(): void
+    {
+        $event = $this->createEvent();
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->patchJson("/api/v1/mobile/events/{$event->id}/note", ['note' => 'Temp'])->assertOk();
+        $this->patchJson("/api/v1/mobile/events/{$event->id}/note", ['note' => null])
+            ->assertOk()
+            ->assertJsonMissingPath('note');
+
+        // The note block is soft-deleted; no live note block should remain.
+        $this->assertSame(0, $event->blocks()->where('block_type', 'note')->whereNull('deleted_at')->count());
+    }
+
+    #[Test]
+    public function update_note_requires_write_ability(): void
+    {
+        $event = $this->createEvent();
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $this->patchJson("/api/v1/mobile/events/{$event->id}/note", ['note' => 'nope'])
+            ->assertStatus(403);
+    }
+
+    #[Test]
+    public function update_note_denies_other_users_events(): void
+    {
+        $event = $this->createEvent();
+        $otherUser = User::factory()->create();
+        Sanctum::actingAs($otherUser, ['ios:read', 'ios:write']);
+
+        $this->patchJson("/api/v1/mobile/events/{$event->id}/note", ['note' => 'hi'])
+            ->assertStatus(404);
+    }
+
+    #[Test]
+    public function update_note_rejects_overlong_note(): void
+    {
+        $event = $this->createEvent();
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->patchJson("/api/v1/mobile/events/{$event->id}/note", ['note' => str_repeat('a', 10001)])
+            ->assertStatus(422);
     }
 
     protected function createEvent(): Event

--- a/tests/Feature/Api/V1/Mobile/IntegrationsControllerTest.php
+++ b/tests/Feature/Api/V1/Mobile/IntegrationsControllerTest.php
@@ -6,6 +6,7 @@ use App\Models\Integration;
 use App\Models\IntegrationGroup;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Queue;
 use Laravel\Sanctum\Sanctum;
 use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
@@ -75,5 +76,105 @@ class IntegrationsControllerTest extends TestCase
 
         $this->getJson("/api/v1/mobile/integrations/{$this->integration->id}")
             ->assertStatus(404);
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /api/v1/mobile/integrations/{id}/sync
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function sync_requires_write_ability(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $this->postJson("/api/v1/mobile/integrations/{$this->integration->id}/sync")
+            ->assertStatus(403);
+    }
+
+    #[Test]
+    public function sync_triggers_a_fetch_for_the_owner(): void
+    {
+        Queue::fake();
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson("/api/v1/mobile/integrations/{$this->integration->id}/sync")
+            ->assertOk()
+            ->assertJsonStructure(['message', 'jobs_dispatched']);
+    }
+
+    #[Test]
+    public function sync_returns_404_for_other_users_integration(): void
+    {
+        $other = User::factory()->create();
+        Sanctum::actingAs($other, ['ios:read', 'ios:write']);
+
+        $this->postJson("/api/v1/mobile/integrations/{$this->integration->id}/sync")
+            ->assertStatus(404);
+    }
+
+    #[Test]
+    public function sync_returns_422_when_paused(): void
+    {
+        $this->integration->update(['configuration' => ['paused' => true]]);
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson("/api/v1/mobile/integrations/{$this->integration->id}/sync")
+            ->assertStatus(422);
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /api/v1/mobile/integrations/{id}/oauth/start
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function oauth_start_requires_write_ability(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $this->postJson("/api/v1/mobile/integrations/{$this->integration->id}/oauth/start")
+            ->assertStatus(403);
+    }
+
+    #[Test]
+    public function oauth_start_returns_a_url_and_flags_the_group(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $response = $this->postJson("/api/v1/mobile/integrations/{$this->integration->id}/oauth/start")
+            ->assertOk()
+            ->assertJsonStructure(['url']);
+
+        $this->assertStringStartsWith('https://auth.monzo.com', $response->json('url'));
+
+        $group = $this->integration->group()->first();
+        $this->assertTrue($group->auth_metadata['mobile_reauth_origin'] ?? false);
+    }
+
+    #[Test]
+    public function oauth_start_returns_404_for_other_users_integration(): void
+    {
+        $other = User::factory()->create();
+        Sanctum::actingAs($other, ['ios:read', 'ios:write']);
+
+        $this->postJson("/api/v1/mobile/integrations/{$this->integration->id}/oauth/start")
+            ->assertStatus(404);
+    }
+
+    #[Test]
+    public function oauth_start_returns_422_for_non_oauth_integration(): void
+    {
+        $group = IntegrationGroup::factory()->create([
+            'user_id' => $this->user->id,
+            'service' => 'daily_checkin',
+        ]);
+        $manual = Integration::factory()->create([
+            'user_id' => $this->user->id,
+            'integration_group_id' => $group->id,
+            'service' => 'daily_checkin',
+        ]);
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson("/api/v1/mobile/integrations/{$manual->id}/oauth/start")
+            ->assertStatus(422);
     }
 }


### PR DESCRIPTION
Implement five mobile API endpoints the iOS app already ships against but that 404 in production. Mounted under /api/v1/mobile with ios:write guards and ownership checks; feature tests added for each.

- CRX-694: PATCH /events/{id}/note — notes stored as a `note` Block, surfaced as a top-level `note` field and excluded from the blocks grid.
- CRX-695: GET/POST/DELETE /api-tokens — one-time plaintext on create; the app's own ios:* session tokens are hidden from list/revoke.
- CRX-696: POST /integrations/{id}/sync and /oauth/start — sync reuses DispatchIntegrationFetchJobs; oauth/start flags the group so the shared web OAuth callback bridges back to the spark:// custom scheme.
- CRX-697: POST /bookmarks — shared BookmarkUrlService keeps dedupe and fetch-job dispatch identical to FetchApiController::bookmarkUrl.
- CRX-698: POST /check-ins/media — raw image body attached to the day via DailyCheckinPlugin::createPhotoEvent (mime + size validation).

Closes CRX-694, CRX-695, CRX-696, CRX-697, CRX-698