### PR TITLE
:lock: Fix web-layer authorization & IDOR holes (CRX-674/689/690/691)

### DIFF
--- a/app/Http/Middleware/EnsureUserIsAdmin.php
+++ b/app/Http/Middleware/EnsureUserIsAdmin.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Restricts a route to administrators. Applied to the /admin route group so
+ * that merely being an authenticated, email-verified user is not enough to
+ * reach admin tooling (which can act across all users' data).
+ */
+class EnsureUserIsAdmin
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        abort_unless((bool) $request->user()?->is_admin, 403);
+
+        return $next($request);
+    }
+}

--- a/app/Livewire/Media/Index.php
+++ b/app/Livewire/Media/Index.php
@@ -2,8 +2,12 @@
 
 namespace App\Livewire\Media;
 
+use App\Models\Block;
+use App\Models\EventObject;
 use Exception;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
 use Livewire\Component;
@@ -106,6 +110,9 @@ class Index extends Component
             ])
             ->with(['model']);
 
+        // Only ever show media owned by the authenticated user.
+        $this->scopeToOwnedMedia($deduplicatedQuery);
+
         // Search filter
         if ($this->search) {
             $deduplicatedQuery->where(function ($q) {
@@ -165,9 +172,10 @@ class Index extends Component
 
     public function modelTypes()
     {
-        // Cache for 5 minutes to avoid repeated full table scans
-        return Cache::remember('media:model_types', 300, function () {
-            return Media::select('model_type')
+        // Cache per-user for 5 minutes to avoid repeated full table scans
+        return Cache::remember('media:model_types:' . Auth::id(), 300, function () {
+            return $this->scopeToOwnedMedia(Media::query())
+                ->select('model_type')
                 ->distinct()
                 ->whereNotNull('model_type')
                 ->pluck('model_type')
@@ -181,9 +189,10 @@ class Index extends Component
 
     public function collections()
     {
-        // Cache for 5 minutes to avoid repeated full table scans
-        return Cache::remember('media:collection_names', 300, function () {
-            return Media::select('collection_name')
+        // Cache per-user for 5 minutes to avoid repeated full table scans
+        return Cache::remember('media:collection_names:' . Auth::id(), 300, function () {
+            return $this->scopeToOwnedMedia(Media::query())
+                ->select('collection_name')
                 ->distinct()
                 ->whereNotNull('collection_name')
                 ->pluck('collection_name')
@@ -197,9 +206,10 @@ class Index extends Component
 
     public function mimeTypes()
     {
-        // Cache for 5 minutes to avoid repeated full table scans
-        return Cache::remember('media:mime_types', 300, function () {
-            return Media::select('mime_type')
+        // Cache per-user for 5 minutes to avoid repeated full table scans
+        return Cache::remember('media:mime_types:' . Auth::id(), 300, function () {
+            return $this->scopeToOwnedMedia(Media::query())
+                ->select('mime_type')
                 ->distinct()
                 ->whereNotNull('mime_type')
                 ->pluck('mime_type')
@@ -221,7 +231,8 @@ class Index extends Component
 
         try {
             DB::transaction(function () {
-                Media::whereIn('id', $this->selectedItems)->delete();
+                // Scope to owned media so arbitrary ids can't delete another user's files.
+                $this->scopeToOwnedMedia(Media::whereIn('id', $this->selectedItems))->delete();
             });
 
             // Clear media filter caches after deletion
@@ -248,12 +259,34 @@ class Index extends Component
     }
 
     /**
+     * Constrain a Media query to records whose parent model is owned by the
+     * authenticated user. Media hangs off EventObject (user_id) and Block
+     * (through its event's integration); anything else is excluded.
+     */
+    private function scopeToOwnedMedia(Builder $query): Builder
+    {
+        $userId = Auth::id();
+
+        return $query->whereHasMorph(
+            'model',
+            [EventObject::class, Block::class],
+            function (Builder $q, string $type) use ($userId) {
+                if ($type === EventObject::class) {
+                    $q->where('user_id', $userId);
+                } elseif ($type === Block::class) {
+                    $q->whereHas('event.integration', fn (Builder $iq) => $iq->where('user_id', $userId));
+                }
+            },
+        );
+    }
+
+    /**
      * Clear cached media filter values when media changes
      */
     private function clearMediaFilterCaches(): void
     {
-        Cache::forget('media:model_types');
-        Cache::forget('media:collection_names');
-        Cache::forget('media:mime_types');
+        Cache::forget('media:model_types:' . Auth::id());
+        Cache::forget('media:collection_names:' . Auth::id());
+        Cache::forget('media:mime_types:' . Auth::id());
     }
 }

--- a/app/Livewire/Media/Show.php
+++ b/app/Livewire/Media/Show.php
@@ -2,14 +2,18 @@
 
 namespace App\Livewire\Media;
 
+use App\Models\Block;
+use App\Models\EventObject;
+use App\Traits\AuthorizesOwnership;
 use Exception;
+use Illuminate\Support\Facades\Auth;
 use Livewire\Component;
 use Mary\Traits\Toast;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 class Show extends Component
 {
-    use Toast;
+    use AuthorizesOwnership, Toast;
 
     public Media $media;
 
@@ -45,6 +49,7 @@ class Show extends Component
     public function mount(Media $media): void
     {
         $this->media = $media->load(['model']);
+        $this->authorizeMedia();
         $this->resetEditForm();
     }
 
@@ -74,6 +79,8 @@ class Show extends Component
 
     public function saveEdit(): void
     {
+        $this->authorizeMedia();
+
         $this->validate([
             'editName' => 'required|string|max:255',
             'editFileName' => 'required|string|max:255',
@@ -106,6 +113,8 @@ class Show extends Component
 
     public function deleteMedia(): void
     {
+        $this->authorizeMedia();
+
         try {
             $mediaId = $this->media->id;
             $this->media->delete();
@@ -154,7 +163,10 @@ class Show extends Component
         return Media::where('custom_properties->md5_hash', $md5Hash)
             ->with(['model'])
             ->orderBy('created_at', 'desc')
-            ->get();
+            ->get()
+            // Don't reveal other users' copies of a deduplicated file.
+            ->filter(fn (Media $instance) => $this->ownerIdFor($instance) === Auth::id())
+            ->values();
     }
 
     /**
@@ -221,5 +233,30 @@ class Show extends Component
             'allInstances' => $this->getAllInstances(),
             'instancesCount' => $this->getInstancesCount(),
         ]);
+    }
+
+    /**
+     * Resolve the owning user id of a media item via its parent model, then
+     * abort 403 unless it belongs to the authenticated user. Media hangs off
+     * EventObject (user_id) or Block (through its event's integration); any
+     * other parent type is treated as unowned and denied.
+     */
+    private function authorizeMedia(): void
+    {
+        $this->authorizeOwner($this->ownerIdFor($this->media));
+    }
+
+    /**
+     * Resolve the owning user id of an arbitrary media item via its parent model.
+     */
+    private function ownerIdFor(Media $media): int|string|null
+    {
+        $model = $media->model;
+
+        return match (true) {
+            $model instanceof EventObject => $model->user_id,
+            $model instanceof Block => $model->event?->integration?->user_id,
+            default => null,
+        };
     }
 }

--- a/app/Livewire/ReceiptDetail.php
+++ b/app/Livewire/ReceiptDetail.php
@@ -5,22 +5,29 @@ namespace App\Livewire;
 use App\Integrations\Receipt\ReceiptTransactionMatcher;
 use App\Models\Event;
 use App\Models\Relationship;
+use App\Traits\AuthorizesOwnership;
 use Exception;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Storage;
 use Livewire\Component;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 class ReceiptDetail extends Component
 {
+    use AuthorizesOwnership;
+
     public Event $receipt;
 
     public bool $showMatchModal = false;
 
     public function mount(string $id): void
     {
+        // Scope to the authenticated user via the receipt's integration —
+        // a receipt belonging to another user yields a 404.
         $this->receipt = Event::with(['target', 'blocks', 'integration'])
             ->where('service', 'receipt')
+            ->whereHas('integration', fn ($q) => $q->where('user_id', Auth::id()))
             ->findOrFail($id);
     }
 
@@ -36,7 +43,11 @@ class ReceiptDetail extends Component
 
     public function createManualMatch(string $transactionId): void
     {
-        $transaction = Event::find($transactionId);
+        $this->authorizeReceipt();
+
+        $transaction = Event::whereKey($transactionId)
+            ->whereHas('integration', fn ($q) => $q->where('user_id', Auth::id()))
+            ->first();
 
         if (! $transaction) {
             $this->dispatch('notify', [
@@ -68,6 +79,8 @@ class ReceiptDetail extends Component
 
     public function removeMatch(): void
     {
+        $this->authorizeReceipt();
+
         // Find and delete the receipt_for relationship
         Relationship::where('from_type', Event::class)
             ->where('from_id', $this->receipt->id)
@@ -94,6 +107,8 @@ class ReceiptDetail extends Component
 
     public function downloadOriginalEmail(): ?StreamedResponse
     {
+        $this->authorizeReceipt();
+
         $merchant = $this->receipt->target;
         $s3Key = $merchant?->metadata['s3_object_key'] ?? null;
 
@@ -134,6 +149,8 @@ class ReceiptDetail extends Component
 
     public function deleteReceipt(): void
     {
+        $this->authorizeReceipt();
+
         // Soft delete the receipt event (cascade will handle blocks and relationships)
         $this->receipt->delete();
 
@@ -173,6 +190,16 @@ class ReceiptDetail extends Component
             'matchedTransaction' => $this->matchedTransaction,
             'candidateMatches' => $this->candidateMatches,
         ])->title('Receipt Details - ' . $this->receipt->target?->title ?? 'Receipt');
+    }
+
+    /**
+     * Re-assert ownership of the hydrated receipt. Livewire rehydrates public
+     * Eloquent properties by key without re-running mount(), so every action
+     * that touches $this->receipt must guard against a tampered snapshot.
+     */
+    private function authorizeReceipt(): void
+    {
+        $this->authorizeOwner($this->receipt->integration?->user_id);
     }
 
     private function calculateMatchConfidence(Event $receipt, Event $transaction): float

--- a/app/Livewire/Receipts.php
+++ b/app/Livewire/Receipts.php
@@ -6,6 +6,7 @@ use App\Integrations\Receipt\ReceiptTransactionMatcher;
 use App\Models\Event;
 use App\Models\Relationship;
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Facades\Auth;
 use Livewire\Attributes\Title;
 use Livewire\Component;
 use Livewire\WithPagination;
@@ -75,8 +76,8 @@ class Receipts extends Component
 
     public function createManualMatch(string $receiptId, string $transactionId): void
     {
-        $receipt = Event::find($receiptId);
-        $transaction = Event::find($transactionId);
+        $receipt = $this->findOwnedEvent($receiptId);
+        $transaction = $this->findOwnedEvent($transactionId);
 
         if (! $receipt || ! $transaction) {
             $this->dispatch('notify', [
@@ -107,7 +108,7 @@ class Receipts extends Component
 
     public function removeMatch(string $receiptId): void
     {
-        $receipt = Event::find($receiptId);
+        $receipt = $this->findOwnedEvent($receiptId);
 
         if (! $receipt) {
             return;
@@ -137,7 +138,7 @@ class Receipts extends Component
 
     public function deleteReceipt(string $receiptId): void
     {
-        $receipt = Event::find($receiptId);
+        $receipt = $this->findOwnedEvent($receiptId);
 
         if (! $receipt || $receipt->service !== 'receipt') {
             return;
@@ -157,6 +158,7 @@ class Receipts extends Component
         $query = Event::where('service', 'receipt')
             ->where('domain', 'money')
             ->where('action', 'had_receipt_from')
+            ->whereHas('integration', fn ($q) => $q->where('user_id', Auth::id()))
             ->with(['target', 'blocks', 'integration']);
 
         // Apply status filter
@@ -200,6 +202,17 @@ class Receipts extends Component
         return view('livewire.receipts', [
             'receipts' => $this->receipts,
         ]);
+    }
+
+    /**
+     * Resolve an event by id, scoped to the authenticated user via its
+     * integration. Returns null for events the user does not own.
+     */
+    private function findOwnedEvent(string $id): ?Event
+    {
+        return Event::whereKey($id)
+            ->whereHas('integration', fn ($q) => $q->where('user_id', Auth::id()))
+            ->first();
     }
 
     private function calculateMatchConfidence(Event $receipt, Event $transaction): float

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -588,6 +588,7 @@ class User extends Authenticatable
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
             'settings' => 'array',
+            'is_admin' => 'boolean',
         ];
     }
 

--- a/app/Traits/AuthorizesOwnership.php
+++ b/app/Traits/AuthorizesOwnership.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Traits;
+
+/**
+ * Shared ownership guard for Livewire/Volt detail components.
+ *
+ * Event/EventObject/Block are not protected by a global scope (they are
+ * queried freely by background jobs that have no authenticated user), so
+ * route-model-bound detail pages must assert ownership explicitly. This trait
+ * centralises that check so the pattern is consistent and hard to forget.
+ */
+trait AuthorizesOwnership
+{
+    /**
+     * Abort with 403 unless the given owner id matches the authenticated user.
+     *
+     * Pass the resolved owning user id — for records owned through a relation
+     * (e.g. an Event via its integration) resolve it at the call site, e.g.
+     * `$this->authorizeOwner($event->integration?->user_id)`.
+     */
+    protected function authorizeOwner(int|string|null $ownerId): void
+    {
+        abort_if($ownerId === null || (string) $ownerId !== (string) auth()->id(), 403);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -2,6 +2,7 @@
 
 use App\Http\Middleware\CacheApiResponse;
 use App\Http\Middleware\EnsureIosMobileApiEnabled;
+use App\Http\Middleware\EnsureUserIsAdmin;
 use App\Http\Middleware\ETag;
 use App\Http\Middleware\SentryApiLogging;
 use App\Http\Middleware\SentryMobileApiLogging;
@@ -43,6 +44,7 @@ return Application::configure(basePath: dirname(__DIR__))
             'etag' => ETag::class,
             'abilities' => CheckAbilities::class,
             'ability' => CheckForAnyAbility::class,
+            'admin' => EnsureUserIsAdmin::class,
         ]);
 
         // Place mobile logging before auth in the priority list so it wraps the

--- a/database/migrations/2026_06_13_000002_add_is_admin_to_users_table.php
+++ b/database/migrations/2026_06_13_000002_add_is_admin_to_users_table.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->boolean('is_admin')->default(false)->after('email');
+        });
+
+        // Seed admins from the already-trusted Horizon allow-list so the
+        // existing operator(s) don't lose access to the admin panel. Set
+        // HORIZON_ALLOWED_EMAILS (or flip is_admin manually) to grant access.
+        $allowed = array_filter((array) config('horizon.allowed_emails', []));
+
+        if (! empty($allowed)) {
+            DB::table('users')->whereIn('email', $allowed)->update(['is_admin' => true]);
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn('is_admin');
+        });
+    }
+};

--- a/resources/views/components/layouts/app.blade.php
+++ b/resources/views/components/layouts/app.blade.php
@@ -190,6 +190,7 @@
                     <x-menu-item title="API Tokens" icon="fas.key" link="{{ route('settings.api-tokens') }}" :active="request()->routeIs('settings.api-tokens')" />
                 </x-menu-sub>
 
+                @if (auth()->user()?->is_admin)
                 <x-menu-sub title="Admin" icon="fas.shield-halved" :active="request()->routeIs('admin.*')" data-hotkey="g a">
                     <x-menu-item title="Sense Check" icon="fas.brain" link="{{ route('admin.sense-check.index') }}" :active="request()->routeIs('admin.sense-check.*')" />
                     <x-menu-item title="Day Notes" icon="fas.calendar-day" link="{{ route('admin.daynotes.index') }}" :active="request()->routeIs('admin.daynotes.*')" />
@@ -206,6 +207,7 @@
                     <x-menu-item title="Logs" icon="fas.file-lines" link="{{ route('admin.logs.index') }}" :active="request()->routeIs('admin.logs.*')" />
                     <x-menu-item title="Bin" icon="fas.trash" link="{{ route('admin.bin.index') }}" :active="request()->routeIs('admin.bin.*')" />
                 </x-menu-sub>
+                @endif
                 <x-menu-item title="Updates" icon="fas.cloud-arrow-down" link="{{ route('updates.index') }}" :active="request()->routeIs('updates.*')" data-hotkey="g u" />
             </x-menu>
         </x-slot:sidebar>

--- a/resources/views/livewire/blocks/show.blade.php
+++ b/resources/views/livewire/blocks/show.blade.php
@@ -3,6 +3,7 @@
 use App\Integrations\PluginRegistry;
 use App\Models\Block;
 use App\Models\Event;
+use App\Traits\AuthorizesOwnership;
 use Illuminate\Support\Facades\Log;
 use Livewire\Volt\Component;
 use Spatie\Activitylog\Models\Activity;
@@ -13,6 +14,8 @@ layout('components.layouts.app');
 
 new class extends Component
 {
+    use AuthorizesOwnership;
+
     public Block $block;
     public bool $showSidebar = false;
     public string $comment = '';
@@ -53,7 +56,10 @@ new class extends Component
     public function mount(Block $block): void
     {
         // Load only the event relationship initially
-        $this->block = $block->load(['event']);
+        $this->block = $block->load(['event.integration']);
+
+        // Ownership: blocks belong to a user through their event's integration.
+        $this->authorizeOwner($this->block->event?->integration?->user_id);
 
         // Track this view in the activity log (debounced to prevent duplicate views)
         $this->block->logViewIfNotRecent(5);

--- a/resources/views/livewire/events/show.blade.php
+++ b/resources/views/livewire/events/show.blade.php
@@ -2,6 +2,7 @@
 
 use App\Integrations\PluginRegistry;
 use App\Models\Event;
+use App\Traits\AuthorizesOwnership;
 use App\Traits\HasProgressiveLoading;
 use Illuminate\Support\Facades\Log;
 use Livewire\Attributes\Computed;
@@ -12,6 +13,7 @@ use Spatie\Tags\Tag;
 
 new class extends Component
 {
+    use AuthorizesOwnership;
     use HasProgressiveLoading;
 
     public Event $event;
@@ -68,6 +70,9 @@ new class extends Component
     {
         // Load only the bare minimum - just the event with integration for display
         $this->event = $event->load(['integration']);
+
+        // Ownership: events belong to a user through their integration.
+        $this->authorizeOwner($this->event->integration?->user_id);
 
         // Track this view in the activity log (debounced to prevent duplicate views)
         $this->event->logViewIfNotRecent(5);

--- a/resources/views/livewire/objects/show.blade.php
+++ b/resources/views/livewire/objects/show.blade.php
@@ -4,6 +4,7 @@ use App\Integrations\PluginRegistry;
 use App\Models\Block;
 use App\Models\Event;
 use App\Models\EventObject;
+use App\Traits\AuthorizesOwnership;
 use App\Traits\HasProgressiveLoading;
 use Livewire\Attributes\Computed;
 use Livewire\Attributes\On;
@@ -17,6 +18,7 @@ layout('components.layouts.app');
 
 new class extends Component
 {
+    use AuthorizesOwnership;
     use HasProgressiveLoading;
 
     public EventObject $object;
@@ -72,6 +74,9 @@ new class extends Component
             'user_id' => $object->user_id,
             'auth_id' => auth()->id(),
         ]);
+
+        // Ownership: objects are owned directly by a user.
+        $this->authorizeOwner($object->user_id);
 
         try {
             // Load only the bare minimum - just the object itself

--- a/routes/web.php
+++ b/routes/web.php
@@ -312,7 +312,7 @@ Route::get('auth/authelia/callback', function () {
 });
 
 // Admin routes
-Route::middleware(['auth', 'verified'])->prefix('admin')->name('admin.')->group(function () {
+Route::middleware(['auth', 'verified', 'admin'])->prefix('admin')->name('admin.')->group(function () {
     Route::get('gocardless', [GoCardlessAdminController::class, 'index'])->name('gocardless.index');
     Route::delete('gocardless/agreements/{agreementId}', [GoCardlessAdminController::class, 'deleteAgreement'])->name('gocardless.deleteAgreement');
     Route::delete('gocardless/requisitions/{requisitionId}', [GoCardlessAdminController::class, 'deleteRequisition'])->name('gocardless.deleteRequisition');

--- a/tests/Feature/AdminAuthorizationTest.php
+++ b/tests/Feature/AdminAuthorizationTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class AdminAuthorizationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function guests_are_redirected_from_admin_routes(): void
+    {
+        $this->get(route('admin.events.index'))->assertRedirect();
+    }
+
+    #[Test]
+    public function non_admin_users_are_forbidden_from_admin_routes(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+
+        $this->actingAs($user)->get(route('admin.events.index'))->assertForbidden();
+        $this->actingAs($user)->get(route('admin.gocardless.index'))->assertForbidden();
+        $this->actingAs($user)->get(route('admin.migrations.index'))->assertForbidden();
+    }
+
+    #[Test]
+    public function non_admin_cannot_delete_gocardless_connections(): void
+    {
+        $user = User::factory()->create(['email_verified_at' => now()]);
+
+        $this->actingAs($user)
+            ->delete(route('admin.gocardless.deleteAgreement', ['agreementId' => 'some-id']))
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function admin_users_can_reach_admin_routes(): void
+    {
+        $admin = User::factory()->create(['email_verified_at' => now()]);
+        $admin->is_admin = true;
+        $admin->save();
+
+        // GoCardless admin index swallows API errors and always renders, so it
+        // is a stable check that the admin middleware lets admins through.
+        $this->actingAs($admin)->get(route('admin.gocardless.index'))->assertOk();
+    }
+}

--- a/tests/Feature/BinAdminTest.php
+++ b/tests/Feature/BinAdminTest.php
@@ -4,24 +4,33 @@ namespace Tests\Feature;
 
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class BinAdminTest extends TestCase
 {
     use RefreshDatabase;
 
-    /** @test */
-    public function admin_bin_page_loads_for_authenticated_user()
+    #[Test]
+    public function admin_bin_page_loads_for_admin_user()
     {
-        $user = User::factory()->create();
-
-        $response = $this->actingAs($user)
+        $response = $this->actingAs($this->admin())
             ->get(route('admin.bin.index'));
 
         $response->assertSuccessful();
     }
 
-    /** @test */
+    #[Test]
+    public function admin_bin_page_is_forbidden_for_non_admin()
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->get(route('admin.bin.index'))
+            ->assertForbidden();
+    }
+
+    #[Test]
     public function admin_bin_page_requires_authentication()
     {
         $response = $this->get(route('admin.bin.index'));
@@ -29,17 +38,34 @@ class BinAdminTest extends TestCase
         $response->assertRedirect(route('login'));
     }
 
-    /** @test */
-    public function admin_bin_delete_endpoint_works()
+    #[Test]
+    public function admin_bin_delete_endpoint_works_for_admin()
     {
-        $user = User::factory()->create();
-
-        $response = $this->actingAs($user)
+        $response = $this->actingAs($this->admin())
             ->post(route('admin.bin.delete'));
 
         $response->assertSuccessful();
         $response->assertJson([
             'message' => 'Deletion process started. All items will be permanently deleted.',
         ]);
+    }
+
+    #[Test]
+    public function admin_bin_delete_endpoint_is_forbidden_for_non_admin()
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)
+            ->post(route('admin.bin.delete'))
+            ->assertForbidden();
+    }
+
+    private function admin(): User
+    {
+        $admin = User::factory()->create();
+        $admin->is_admin = true;
+        $admin->save();
+
+        return $admin;
     }
 }

--- a/tests/Feature/DetailPageOwnershipTest.php
+++ b/tests/Feature/DetailPageOwnershipTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Block;
+use App\Models\Event;
+use App\Models\EventObject;
+use App\Models\Integration;
+use App\Models\IntegrationGroup;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class DetailPageOwnershipTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $owner;
+
+    protected User $intruder;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['app.enable_task_pipeline' => false]);
+
+        $this->owner = User::factory()->create();
+        $this->intruder = User::factory()->create();
+    }
+
+    #[Test]
+    public function event_detail_is_forbidden_for_non_owner(): void
+    {
+        $event = $this->ownedEvent();
+
+        $this->actingAs($this->intruder)
+            ->get(route('events.show', $event))
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function event_detail_is_visible_to_owner(): void
+    {
+        $event = $this->ownedEvent();
+
+        $this->actingAs($this->owner)
+            ->get(route('events.show', $event))
+            ->assertOk();
+    }
+
+    #[Test]
+    public function object_detail_is_forbidden_for_non_owner(): void
+    {
+        $object = EventObject::factory()->create(['user_id' => $this->owner->id]);
+
+        $this->actingAs($this->intruder)
+            ->get(route('objects.show', $object))
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function object_detail_is_visible_to_owner(): void
+    {
+        $object = EventObject::factory()->create(['user_id' => $this->owner->id]);
+
+        $this->actingAs($this->owner)
+            ->get(route('objects.show', $object))
+            ->assertOk();
+    }
+
+    #[Test]
+    public function block_detail_is_forbidden_for_non_owner(): void
+    {
+        $block = Block::factory()->create(['event_id' => $this->ownedEvent()->id]);
+
+        $this->actingAs($this->intruder)
+            ->get(route('blocks.show', $block))
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function block_detail_is_visible_to_owner(): void
+    {
+        $block = Block::factory()->create(['event_id' => $this->ownedEvent()->id]);
+
+        $this->actingAs($this->owner)
+            ->get(route('blocks.show', $block))
+            ->assertOk();
+    }
+
+    protected function ownedEvent(): Event
+    {
+        $group = IntegrationGroup::factory()->create([
+            'user_id' => $this->owner->id,
+            'service' => 'monzo',
+        ]);
+
+        $integration = Integration::factory()->create([
+            'user_id' => $this->owner->id,
+            'integration_group_id' => $group->id,
+            'service' => 'monzo',
+        ]);
+
+        return Event::factory()->create([
+            'integration_id' => $integration->id,
+            'service' => 'monzo',
+        ]);
+    }
+}

--- a/tests/Feature/Livewire/MediaScopingTest.php
+++ b/tests/Feature/Livewire/MediaScopingTest.php
@@ -1,0 +1,121 @@
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Livewire\Media\Index;
+use App\Livewire\Media\Show;
+use App\Models\EventObject;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+use Tests\TestCase;
+
+class MediaScopingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Storage::fake('public');
+        config(['media-library.disk_name' => 'public']);
+        config(['app.enable_task_pipeline' => false]);
+
+        $this->user = User::factory()->create();
+    }
+
+    #[Test]
+    public function index_only_lists_media_owned_by_the_user(): void
+    {
+        $ownMedia = $this->mediaForUser($this->user);
+        $otherMedia = $this->mediaForUser(User::factory()->create());
+
+        $this->actingAs($this->user);
+
+        $items = Livewire::test(Index::class)->instance()->media()->items();
+        $ids = collect($items)->pluck('id');
+
+        $this->assertTrue($ids->contains($ownMedia->id));
+        $this->assertFalse($ids->contains($otherMedia->id));
+    }
+
+    #[Test]
+    public function bulk_delete_cannot_remove_another_users_media(): void
+    {
+        $otherMedia = $this->mediaForUser(User::factory()->create());
+
+        $this->actingAs($this->user);
+
+        Livewire::test(Index::class)
+            ->set('selectedItems', [$otherMedia->id])
+            ->call('bulkDelete');
+
+        $this->assertDatabaseHas('media', ['id' => $otherMedia->id]);
+    }
+
+    #[Test]
+    public function bulk_delete_removes_own_media(): void
+    {
+        $ownMedia = $this->mediaForUser($this->user);
+
+        $this->actingAs($this->user);
+
+        Livewire::test(Index::class)
+            ->set('selectedItems', [$ownMedia->id])
+            ->call('bulkDelete');
+
+        $this->assertDatabaseMissing('media', ['id' => $ownMedia->id]);
+    }
+
+    #[Test]
+    public function show_is_forbidden_for_another_users_media(): void
+    {
+        $otherMedia = $this->mediaForUser(User::factory()->create());
+
+        $this->actingAs($this->user)
+            ->get(route('media.show', $otherMedia->uuid))
+            ->assertForbidden();
+    }
+
+    #[Test]
+    public function owner_can_open_their_media(): void
+    {
+        $ownMedia = $this->mediaForUser($this->user);
+
+        $this->actingAs($this->user);
+
+        Livewire::test(Show::class, ['media' => $ownMedia])->assertOk();
+    }
+
+    private function mediaForUser(User $user): Media
+    {
+        $object = EventObject::factory()->create(['user_id' => $user->id]);
+
+        // Insert the Media row directly. The scoping logic only reads
+        // model_type/model_id/custom_properties, so we skip Spatie's file
+        // pipeline (which is unstable in this container) entirely.
+        $media = new Media;
+        $media->model_type = EventObject::class;
+        $media->model_id = $object->id;
+        $media->uuid = (string) Str::uuid();
+        $media->collection_name = 'downloaded_documents';
+        $media->name = 'fixture';
+        $media->file_name = 'fixture.txt';
+        $media->mime_type = 'text/plain';
+        $media->disk = 'public';
+        $media->size = 16;
+        $media->manipulations = [];
+        $media->custom_properties = ['md5_hash' => Str::random(32)];
+        $media->generated_conversions = [];
+        $media->responsive_images = [];
+        $media->save();
+
+        return $media;
+    }
+}

--- a/tests/Feature/Livewire/ReceiptDetailTest.php
+++ b/tests/Feature/Livewire/ReceiptDetailTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Livewire\ReceiptDetail;
+use App\Models\Event;
+use App\Models\Integration;
+use App\Models\IntegrationGroup;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ReceiptDetailTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = User::factory()->create();
+    }
+
+    #[Test]
+    public function detail_is_not_found_for_another_users_receipt(): void
+    {
+        $receipt = $this->receiptFor(User::factory()->create());
+
+        $this->actingAs($this->user)
+            ->get(route('receipts.show', $receipt->id))
+            ->assertNotFound();
+    }
+
+    #[Test]
+    public function owner_can_open_and_delete_their_receipt(): void
+    {
+        $receipt = $this->receiptFor($this->user);
+
+        $this->actingAs($this->user);
+
+        Livewire::test(ReceiptDetail::class, ['id' => $receipt->id])
+            ->assertOk()
+            ->call('deleteReceipt');
+
+        $this->assertSoftDeleted('events', ['id' => $receipt->id]);
+    }
+
+    private function receiptFor(User $user): Event
+    {
+        $group = IntegrationGroup::factory()->create([
+            'user_id' => $user->id,
+            'service' => 'receipt',
+        ]);
+        $integration = Integration::factory()->create([
+            'user_id' => $user->id,
+            'integration_group_id' => $group->id,
+            'service' => 'receipt',
+        ]);
+
+        return Event::factory()->create([
+            'integration_id' => $integration->id,
+            'service' => 'receipt',
+            'domain' => 'money',
+            'action' => 'had_receipt_from',
+        ]);
+    }
+}

--- a/tests/Feature/Livewire/ReceiptsTest.php
+++ b/tests/Feature/Livewire/ReceiptsTest.php
@@ -7,6 +7,7 @@ use App\Models\Event;
 use App\Models\EventObject;
 use App\Models\Integration;
 use App\Models\IntegrationGroup;
+use App\Models\Relationship;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
@@ -230,6 +231,60 @@ class ReceiptsTest extends TestCase
     }
 
     #[Test]
+    public function listing_only_includes_the_authenticated_users_receipts(): void
+    {
+        $merchant = EventObject::factory()->create(['user_id' => $this->user->id]);
+        $ownReceipt = Event::factory()->create([
+            'integration_id' => $this->integration->id,
+            'service' => 'receipt',
+            'domain' => 'money',
+            'action' => 'had_receipt_from',
+            'target_id' => $merchant->id,
+        ]);
+
+        $otherReceipt = $this->otherUsersReceipt();
+
+        $receipts = Livewire::test(Receipts::class)->viewData('receipts');
+        $ids = collect($receipts->items())->pluck('id');
+
+        $this->assertTrue($ids->contains($ownReceipt->id));
+        $this->assertFalse($ids->contains($otherReceipt->id));
+    }
+
+    #[Test]
+    public function delete_receipt_ignores_another_users_receipt(): void
+    {
+        $otherReceipt = $this->otherUsersReceipt();
+
+        Livewire::test(Receipts::class)->call('deleteReceipt', $otherReceipt->id);
+
+        $this->assertDatabaseHas('events', ['id' => $otherReceipt->id, 'deleted_at' => null]);
+    }
+
+    #[Test]
+    public function remove_match_ignores_another_users_receipt(): void
+    {
+        $otherReceipt = $this->otherUsersReceipt();
+
+        // Pre-existing match relationship for the other user's receipt.
+        Relationship::create([
+            'user_id' => $otherReceipt->integration->user_id,
+            'from_type' => Event::class,
+            'from_id' => $otherReceipt->id,
+            'to_type' => Event::class,
+            'to_id' => (string) Str::uuid(),
+            'type' => 'receipt_for',
+        ]);
+
+        Livewire::test(Receipts::class)->call('removeMatch', $otherReceipt->id);
+
+        $this->assertDatabaseHas('relationships', [
+            'from_id' => $otherReceipt->id,
+            'type' => 'receipt_for',
+        ]);
+    }
+
+    #[Test]
     public function per_page_can_be_changed(): void
     {
         $component = Livewire::test(Receipts::class);
@@ -260,5 +315,26 @@ class ReceiptsTest extends TestCase
 
         // The page should be reset (this is handled by resetPage in updatedStatusFilter)
         $component->assertOk();
+    }
+
+    private function otherUsersReceipt(): Event
+    {
+        $otherUser = User::factory()->create();
+        $otherGroup = IntegrationGroup::factory()->create([
+            'user_id' => $otherUser->id,
+            'service' => 'receipt',
+        ]);
+        $otherIntegration = Integration::factory()->create([
+            'user_id' => $otherUser->id,
+            'integration_group_id' => $otherGroup->id,
+            'service' => 'receipt',
+        ]);
+
+        return Event::factory()->create([
+            'integration_id' => $otherIntegration->id,
+            'service' => 'receipt',
+            'domain' => 'money',
+            'action' => 'had_receipt_from',
+        ]);
     }
 }


### PR DESCRIPTION
Four Urgent security fixes in the Livewire/Volt web layer, each with feature tests. Full suite green (1339 passed).

- CRX-691: Event/Object/Block detail pages had no ownership check (cross-user IDOR via route binding). Add shared App\Traits\AuthorizesOwnership and guard each mount() — objects via user_id, events/blocks via integration->user_id. No global scope (these models are queried by background jobs with no auth user).
- CRX-689: Receipts/ReceiptDetail had zero user scoping. Scope listing and all lookups through the receipt's integration->user_id, and re-assert ownership in every ReceiptDetail action (Livewire rehydrates models by key without re-running mount()).
- CRX-690: Media library listed and let any user edit/delete all media. Scope via whereHasMorph over the owning EventObject (user_id) / Block (event->integration); guard Show mount/edit/delete and bulk delete.
- CRX-674: /admin was gated only by [auth, verified] — any registered user reached admin tooling (incl. cross-tenant GoCardless deletion). Add is_admin flag + EnsureUserIsAdmin middleware on the /admin group (migration seeds admins from HORIZON_ALLOWED_EMAILS), gate the nav, and update BinAdminTest.

Closes CRX-674, CRX-689, CRX-690, CRX-691