### PR TITLE
:bug: Align GET /devices with iOS RegisteredDevice contract (CRX-627)

### DIFF
--- a/app/Http/Controllers/Api/V1/Mobile/DevicesController.php
+++ b/app/Http/Controllers/Api/V1/Mobile/DevicesController.php
@@ -23,6 +23,14 @@ class DevicesController extends Controller
             ->get()
             ->map(fn (PushSubscription $sub) => [
                 'id' => $sub->id,
+                // Fields consumed by the iOS RegisteredDevice model. `name` and
+                // `platform` are required by the client decoder, so they must
+                // always be present and non-null.
+                'name' => $sub->device_name ?: 'iPhone',
+                'platform' => $sub->device_type,
+                'last_seen_at' => $sub->updated_at?->toIso8601String(),
+                'is_current_device' => false,
+                // Richer fields retained for web/admin consumers.
                 'device_type' => $sub->device_type,
                 'endpoint' => $sub->endpoint,
                 'app_environment' => $sub->app_environment,

--- a/tests/Feature/Api/V1/Mobile/DevicesControllerTest.php
+++ b/tests/Feature/Api/V1/Mobile/DevicesControllerTest.php
@@ -42,15 +42,38 @@ class DevicesControllerTest extends TestCase
             'bundle_id' => 'co.cronx.spark',
             'app_version' => '1.0.0',
             'os_version' => '18.1',
+            'device_name' => 'Will’s iPhone',
         ]);
 
         $this->getJson('/api/v1/mobile/devices')
             ->assertOk()
             ->assertJsonCount(1, 'devices')
+            // iOS RegisteredDevice contract: name + platform are required by the
+            // client decoder, last_seen_at and is_current_device are optional.
+            ->assertJsonPath('devices.0.name', 'Will’s iPhone')
+            ->assertJsonPath('devices.0.platform', 'ios')
+            ->assertJsonPath('devices.0.is_current_device', false)
+            ->assertJsonStructure(['devices' => [['id', 'name', 'platform', 'last_seen_at', 'is_current_device']]])
             ->assertJsonPath('devices.0.device_type', 'ios')
             ->assertJsonPath('devices.0.app_environment', 'sandbox')
             ->assertJsonPath('devices.0.app_version', '1.0.0')
             ->assertJsonPath('devices.0.os_version', '18.1');
+    }
+
+    #[Test]
+    public function index_falls_back_to_a_default_name_when_device_name_is_missing(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        // device_name is nullable, but the iOS decoder requires a non-null name.
+        $this->user->pushSubscriptions()->create([
+            'endpoint' => str_repeat('a', 64),
+            'device_type' => PushSubscription::DEVICE_TYPE_IOS,
+        ]);
+
+        $this->getJson('/api/v1/mobile/devices')
+            ->assertOk()
+            ->assertJsonPath('devices.0.name', 'iPhone');
     }
 
     #[Test]

--- a/tests/Feature/Api/V1/Mobile/MapControllerTest.php
+++ b/tests/Feature/Api/V1/Mobile/MapControllerTest.php
@@ -138,6 +138,39 @@ class MapControllerTest extends TestCase
     }
 
     #[Test]
+    public function maps_event_kind_from_domain_and_action(): void
+    {
+        $integration = Integration::factory()->create(['user_id' => $this->user->id]);
+
+        $workout = Event::factory()->create([
+            'integration_id' => $integration->id,
+            'service' => 'apple_health',
+            'domain' => 'health',
+            'action' => 'did_workout',
+            'location' => Point::makeGeodetic(51.5, 0.1),
+        ]);
+
+        $generic = Event::factory()->create([
+            'integration_id' => $integration->id,
+            'service' => 'calendar',
+            'domain' => 'calendar',
+            'action' => 'attended',
+            'location' => Point::makeGeodetic(51.6, 0.2),
+        ]);
+
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $markers = collect(
+            $this->getJson('/api/v1/mobile/map/data?bbox=51.0,-0.5,52.0,0.5')
+                ->assertOk()
+                ->json('markers.events')
+        )->keyBy('id');
+
+        $this->assertSame('workout', $markers[$workout->id]['kind']);
+        $this->assertSame('event', $markers[$generic->id]['kind']);
+    }
+
+    #[Test]
     public function returns_empty_marker_arrays_when_nothing_in_bbox(): void
     {
         Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);


### PR DESCRIPTION
Closes CRX-627.

## Background

CRX-627 originally reported two iOS decode failures. Investigation found **both already fixed** by later work:

- **`GET /map/data` markers** — fixed in #809; the endpoint now returns the compact `{id, kind, lat, lng, title, subtitle, time, service}` shape the iOS `MapDataPoint` expects, omitting location-less events.
- **`POST /devices` 201 body** — fixed in #862; the body (`id/device_type/endpoint/app_environment`) already matches the iOS `DeviceRegistrationResponse`.

Auditing the devices endpoints (as the ticket asked) surfaced a **still-live sibling bug**, which this PR fixes.

## The bug

`GET /api/v1/mobile/devices` returned `device_type`/`endpoint`/`bundle_id`/… but **not** `name` or `platform`. The iOS `RegisteredDevice` model decodes `name` and `platform` as **required**, so Settings → Devices threw `keyNotFound: "name"` whenever any device existed. The existing controller test only asserted the server's own shape, so it never caught the cross-contract break.

## Changes

- `DevicesController::index()` now also returns the iOS-contract fields: `name` (← `device_name`, falling back to `"iPhone"` since the client requires a non-null name), `platform` (← `device_type`), `last_seen_at` (← `updated_at`), `is_current_device` (`false` — the server can't identify the caller's token). Existing richer fields kept for web/admin consumers (backward compatible; the iOS decoder ignores unknown keys).
- `DevicesControllerTest`: assert the iOS contract fields + the null-name fallback.
- `MapControllerTest`: add coverage for the `workout` and generic `event` kind mappings (only `transaction`/`place` were tested).

No iOS change needed — `RegisteredDevice` decodes the response as-is.

## Tests

`DevicesControllerTest` + `MapControllerTest`: **21 passed**, duster clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)