### PR TITLE
:sparkles: Acknowledged timezone as daily_checkin time_travel events (CRX-723)

### DIFF
--- a/app/Http/Controllers/Api/V1/Mobile/CheckInsController.php
+++ b/app/Http/Controllers/Api/V1/Mobile/CheckInsController.php
@@ -12,6 +12,7 @@ use Carbon\Carbon;
 use Carbon\CarbonPeriod;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 class CheckInsController extends Controller
@@ -223,6 +224,67 @@ class CheckInsController extends Controller
             (new CompactEventResource($event->fresh(['actor', 'target', 'blocks', 'tags', 'integration'])))->resolve($request),
             201,
         );
+    }
+
+    /**
+     * GET /api/v1/mobile/check-ins/timezone
+     *
+     * Returns the user's effective timezone state. When a `time_travel`
+     * acknowledgement exists, `source` is `time_travel` and the acknowledgement
+     * fields are populated; otherwise it falls back to the profile timezone.
+     */
+    public function showTimezone(Request $request): JsonResponse
+    {
+        $state = (new DailyCheckinPlugin)->resolveEffectiveTimezone($request->user());
+
+        return response()->json($state);
+    }
+
+    /**
+     * POST /api/v1/mobile/check-ins/timezone
+     *
+     * Atomically records a user-acknowledged change to the effective timezone
+     * as a Daily Check-in `time_travel` event and returns the resulting state.
+     *
+     * The prior timezone is derived server-side from the current effective
+     * timezone; a contradictory client `previous_timezone` is ignored. Repeated
+     * submissions of the already-effective timezone are a no-op (idempotent) so
+     * no duplicate consecutive events are created. The user's profile timezone
+     * is never mutated.
+     */
+    public function storeTimezone(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'timezone' => ['required', 'string', 'timezone:all'],
+            'previous_timezone' => ['nullable', 'string', 'timezone:all'],
+            'device_id' => ['nullable', 'string', 'max:255'],
+        ]);
+
+        $plugin = new DailyCheckinPlugin;
+        $user = $request->user();
+
+        $current = $plugin->resolveEffectiveTimezone($user);
+
+        // Comparing IANA identifiers (not UTC offsets) means DST transitions
+        // within a single zone never trigger a new acknowledgement.
+        if ($validated['timezone'] === $current['timezone']) {
+            return response()->json($current, 200);
+        }
+
+        $state = DB::transaction(function () use ($plugin, $request, $validated, $current) {
+            $integration = $this->resolveIntegration($request);
+
+            $plugin->createTimezoneEvent(
+                $integration,
+                $validated['timezone'],
+                $current['timezone'],
+                $validated['device_id'] ?? null,
+            );
+
+            return $plugin->resolveEffectiveTimezone($request->user());
+        });
+
+        return response()->json($state, 201);
     }
 
     protected function resolveIntegration(Request $request): Integration

--- a/app/Integrations/DailyCheckin/DailyCheckinPlugin.php
+++ b/app/Integrations/DailyCheckin/DailyCheckinPlugin.php
@@ -88,6 +88,21 @@ class DailyCheckinPlugin extends ManualPlugin
                 'value_unit' => null,
                 'hidden' => false,
             ],
+            // Canonical "time travel" event: a user-acknowledged change to their
+            // effective timezone while travelling. The latest such event is the
+            // acknowledged effective timezone; absence falls back to the user's
+            // profile timezone. `time` is the absolute acknowledgement timestamp;
+            // `event_metadata` carries `timezone`, `previous_timezone`,
+            // `device_id` (nullable) and `source` ("user_acknowledged"). It does
+            // not mutate the user's home/profile timezone.
+            'time_travel' => [
+                'icon' => 'fas.plane',
+                'display_name' => 'Time Travel',
+                'description' => 'Acknowledged a change to the effective timezone',
+                'display_with_object' => false,
+                'value_unit' => null,
+                'hidden' => true,
+            ],
         ];
     }
 
@@ -378,5 +393,112 @@ class DailyCheckinPlugin extends ManualPlugin
             'morning' => $events->firstWhere('action', 'had_morning_checkin'),
             'afternoon' => $events->firstWhere('action', 'had_afternoon_checkin'),
         ];
+    }
+
+    /**
+     * Resolve the user's latest acknowledged "time travel" event, if any.
+     *
+     * This is the single source of truth for the acknowledged effective
+     * timezone. It is scoped to the user's own Daily Check-in integration and
+     * ordered so the most recent acknowledgement wins.
+     *
+     * @param  int|string  $userId  The user ID
+     */
+    public function getLatestTimezoneEvent(int|string $userId): ?Event
+    {
+        return Event::whereHas('integration', function ($q) use ($userId) {
+            $q->where('user_id', $userId);
+        })
+            ->where('service', 'daily_checkin')
+            ->where('action', 'time_travel')
+            ->orderByDesc('time')
+            ->orderByDesc('id')
+            ->first();
+    }
+
+    /**
+     * Resolve the user's effective timezone state.
+     *
+     * Returns the acknowledged travel timezone when a `time_travel` event
+     * exists, otherwise falls back to the user's home/profile timezone. The
+     * shape matches the mobile GET contract.
+     *
+     * @return array{timezone: string, source: string, acknowledged_at: ?string, event_id: ?string, device_id: ?string}
+     */
+    public function resolveEffectiveTimezone(User $user): array
+    {
+        $event = $this->getLatestTimezoneEvent($user->id);
+
+        if ($event === null) {
+            return [
+                'timezone' => $user->getTimezone(),
+                'source' => 'profile',
+                'acknowledged_at' => null,
+                'event_id' => null,
+                'device_id' => null,
+            ];
+        }
+
+        $metadata = $event->event_metadata ?? [];
+
+        return [
+            'timezone' => $metadata['timezone'] ?? $user->getTimezone(),
+            'source' => 'time_travel',
+            'acknowledged_at' => $event->time?->toIso8601String(),
+            'event_id' => $event->id,
+            'device_id' => $metadata['device_id'] ?? null,
+        ];
+    }
+
+    /**
+     * Record a user-acknowledged change to the effective timezone as a new
+     * `time_travel` event.
+     *
+     * The `$previousTimezone` is derived server-side from the current effective
+     * timezone; a contradictory client value must not be trusted. `users`
+     * profile timezone is intentionally left unchanged.
+     *
+     * @param  Integration  $integration  The user's Daily Check-in integration
+     * @param  string  $timezone  The new effective IANA timezone identifier
+     * @param  string  $previousTimezone  The server-derived prior timezone
+     * @param  string|null  $deviceId  Optional registered device id
+     */
+    public function createTimezoneEvent(
+        Integration $integration,
+        string $timezone,
+        string $previousTimezone,
+        ?string $deviceId = null,
+    ): Event {
+        $user = User::find($integration->user_id);
+        $userObject = EventObject::firstOrCreate(
+            [
+                'user_id' => $integration->user_id,
+                'concept' => 'user',
+                'type' => 'user',
+                'title' => $user ? $user->name : 'User',
+            ],
+            [
+                'time' => now(),
+                'content' => null,
+                'metadata' => [],
+            ]
+        );
+
+        return Event::create([
+            'integration_id' => $integration->id,
+            'source_id' => 'daily_checkin_time_travel_' . Str::uuid(),
+            'time' => now(),
+            'service' => 'daily_checkin',
+            'domain' => self::getDomain(),
+            'action' => 'time_travel',
+            'event_metadata' => [
+                'timezone' => $timezone,
+                'previous_timezone' => $previousTimezone,
+                'device_id' => $deviceId,
+                'source' => 'user_acknowledged',
+            ],
+            'target_id' => $userObject->id,
+            'actor_id' => $userObject->id,
+        ]);
     }
 }

--- a/app/Integrations/DailyCheckin/DailyCheckinPlugin.php
+++ b/app/Integrations/DailyCheckin/DailyCheckinPlugin.php
@@ -411,6 +411,9 @@ class DailyCheckinPlugin extends ManualPlugin
         })
             ->where('service', 'daily_checkin')
             ->where('action', 'time_travel')
+            // Order by the microsecond-precision metadata stamp; `time`/`created_at`
+            // are only second-precise and cannot disambiguate same-second events.
+            ->orderByDesc('event_metadata->acknowledged_at')
             ->orderByDesc('time')
             ->orderByDesc('id')
             ->first();
@@ -444,7 +447,7 @@ class DailyCheckinPlugin extends ManualPlugin
         return [
             'timezone' => $metadata['timezone'] ?? $user->getTimezone(),
             'source' => 'time_travel',
-            'acknowledged_at' => $event->time?->toIso8601String(),
+            'acknowledged_at' => $metadata['acknowledged_at'] ?? $event->time?->toIso8601String(),
             'event_id' => $event->id,
             'device_id' => $metadata['device_id'] ?? null,
         ];
@@ -484,10 +487,19 @@ class DailyCheckinPlugin extends ManualPlugin
             ]
         );
 
+        // The events table has no insertion-ordered column (its primary key is a
+        // random UUID) and Eloquent's date grammar truncates the `time`/`created_at`
+        // columns to whole seconds, so two acknowledgements within the same second
+        // cannot be ordered reliably by those columns. We therefore stamp a
+        // microsecond-precision `acknowledged_at` into the metadata and resolve the
+        // latest event by it — see getLatestTimezoneEvent(). The fixed-width format
+        // sorts lexicographically in chronological order.
+        $acknowledgedAt = now();
+
         return Event::create([
             'integration_id' => $integration->id,
             'source_id' => 'daily_checkin_time_travel_' . Str::uuid(),
-            'time' => now(),
+            'time' => $acknowledgedAt,
             'service' => 'daily_checkin',
             'domain' => self::getDomain(),
             'action' => 'time_travel',
@@ -496,6 +508,7 @@ class DailyCheckinPlugin extends ManualPlugin
                 'previous_timezone' => $previousTimezone,
                 'device_id' => $deviceId,
                 'source' => 'user_acknowledged',
+                'acknowledged_at' => $acknowledgedAt->utc()->format('Y-m-d\TH:i:s.u\Z'),
             ],
             'target_id' => $userObject->id,
             'actor_id' => $userObject->id,

--- a/routes/mobile.php
+++ b/routes/mobile.php
@@ -164,6 +164,13 @@ Route::get('check-ins', [CheckInsController::class, 'index'])
 Route::get('check-ins/history', [CheckInsController::class, 'history'])
     ->name('check-ins.history');
 
+Route::get('check-ins/timezone', [CheckInsController::class, 'showTimezone'])
+    ->name('check-ins.timezone.show');
+
+Route::post('check-ins/timezone', [CheckInsController::class, 'storeTimezone'])
+    ->middleware('ability:ios:write')
+    ->name('check-ins.timezone.store');
+
 Route::post('check-ins', [CheckInsController::class, 'store'])
     ->middleware('ability:ios:write')
     ->name('check-ins.store');

--- a/tests/Feature/Api/V1/Mobile/CheckInsControllerTest.php
+++ b/tests/Feature/Api/V1/Mobile/CheckInsControllerTest.php
@@ -295,6 +295,231 @@ class CheckInsControllerTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
+    // GET /api/v1/mobile/check-ins/timezone
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function timezone_show_requires_authentication(): void
+    {
+        $this->getJson('/api/v1/mobile/check-ins/timezone')->assertStatus(401);
+    }
+
+    #[Test]
+    public function timezone_show_requires_read_ability(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:write']);
+
+        $this->getJson('/api/v1/mobile/check-ins/timezone')->assertStatus(403);
+    }
+
+    #[Test]
+    public function timezone_show_falls_back_to_profile_timezone(): void
+    {
+        $this->user->setTimezone('Europe/London');
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $this->getJson('/api/v1/mobile/check-ins/timezone')
+            ->assertStatus(200)
+            ->assertExactJson([
+                'timezone' => 'Europe/London',
+                'source' => 'profile',
+                'acknowledged_at' => null,
+                'event_id' => null,
+                'device_id' => null,
+            ]);
+    }
+
+    #[Test]
+    public function timezone_show_defaults_to_utc_without_profile_timezone(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $this->getJson('/api/v1/mobile/check-ins/timezone')
+            ->assertStatus(200)
+            ->assertJsonPath('timezone', 'UTC')
+            ->assertJsonPath('source', 'profile');
+    }
+
+    #[Test]
+    public function timezone_show_returns_latest_acknowledged_event(): void
+    {
+        $this->user->setTimezone('Europe/London');
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson('/api/v1/mobile/check-ins/timezone', [
+            'timezone' => 'America/New_York',
+        ])->assertStatus(201);
+
+        $response = $this->getJson('/api/v1/mobile/check-ins/timezone')->assertStatus(200);
+
+        $this->assertSame('America/New_York', $response->json('timezone'));
+        $this->assertSame('time_travel', $response->json('source'));
+        $this->assertNotNull($response->json('acknowledged_at'));
+        $this->assertNotNull($response->json('event_id'));
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /api/v1/mobile/check-ins/timezone
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function timezone_store_requires_write_ability(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $this->postJson('/api/v1/mobile/check-ins/timezone', ['timezone' => 'America/New_York'])
+            ->assertStatus(403);
+    }
+
+    #[Test]
+    public function timezone_store_creates_single_time_travel_event(): void
+    {
+        $this->user->setTimezone('Europe/London');
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $response = $this->postJson('/api/v1/mobile/check-ins/timezone', [
+            'timezone' => 'America/New_York',
+        ])->assertStatus(201);
+
+        $response->assertJsonPath('timezone', 'America/New_York')
+            ->assertJsonPath('source', 'time_travel');
+
+        $this->assertSame(1, Event::where('service', 'daily_checkin')->where('action', 'time_travel')->count());
+
+        $event = Event::where('action', 'time_travel')->firstOrFail();
+        $this->assertSame('America/New_York', $event->event_metadata['timezone']);
+        $this->assertSame('Europe/London', $event->event_metadata['previous_timezone']);
+        $this->assertSame('user_acknowledged', $event->event_metadata['source']);
+    }
+
+    #[Test]
+    public function timezone_store_persists_device_id(): void
+    {
+        $this->user->setTimezone('Europe/London');
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson('/api/v1/mobile/check-ins/timezone', [
+            'timezone' => 'America/New_York',
+            'device_id' => 'device-123',
+        ])->assertStatus(201)
+            ->assertJsonPath('device_id', 'device-123');
+
+        $event = Event::where('action', 'time_travel')->firstOrFail();
+        $this->assertSame('device-123', $event->event_metadata['device_id']);
+    }
+
+    #[Test]
+    public function timezone_store_derives_previous_timezone_ignoring_client_value(): void
+    {
+        $this->user->setTimezone('Europe/London');
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson('/api/v1/mobile/check-ins/timezone', [
+            'timezone' => 'America/New_York',
+            'previous_timezone' => 'Asia/Tokyo', // contradictory but valid IANA
+        ])->assertStatus(201);
+
+        $event = Event::where('action', 'time_travel')->firstOrFail();
+        $this->assertSame('Europe/London', $event->event_metadata['previous_timezone']);
+    }
+
+    #[Test]
+    public function timezone_store_rejects_invalid_identifier(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson('/api/v1/mobile/check-ins/timezone', ['timezone' => 'Mars/Phobos'])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['timezone']);
+    }
+
+    #[Test]
+    public function timezone_store_rejects_utc_offset_only_value(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson('/api/v1/mobile/check-ins/timezone', ['timezone' => '+05:00'])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['timezone']);
+    }
+
+    #[Test]
+    public function timezone_store_is_idempotent_for_already_effective_zone(): void
+    {
+        $this->user->setTimezone('Europe/London');
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        // Submitting the already-effective profile timezone is a no-op.
+        $this->postJson('/api/v1/mobile/check-ins/timezone', ['timezone' => 'Europe/London'])
+            ->assertStatus(200)
+            ->assertJsonPath('source', 'profile');
+
+        $this->assertSame(0, Event::where('action', 'time_travel')->count());
+
+        // Acknowledge a real change, then re-submit the same zone — still no dupe.
+        $this->postJson('/api/v1/mobile/check-ins/timezone', ['timezone' => 'America/New_York'])
+            ->assertStatus(201);
+        $this->postJson('/api/v1/mobile/check-ins/timezone', ['timezone' => 'America/New_York'])
+            ->assertStatus(200);
+
+        $this->assertSame(1, Event::where('action', 'time_travel')->count());
+    }
+
+    #[Test]
+    public function timezone_store_records_subsequent_changes_with_latest_winning(): void
+    {
+        $this->user->setTimezone('Europe/London');
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson('/api/v1/mobile/check-ins/timezone', ['timezone' => 'America/New_York'])
+            ->assertStatus(201);
+        $this->postJson('/api/v1/mobile/check-ins/timezone', ['timezone' => 'Asia/Tokyo'])
+            ->assertStatus(201);
+
+        $this->assertSame(2, Event::where('action', 'time_travel')->count());
+
+        $this->getJson('/api/v1/mobile/check-ins/timezone')
+            ->assertStatus(200)
+            ->assertJsonPath('timezone', 'Asia/Tokyo');
+
+        // The second event's derived previous timezone is the first acknowledged zone.
+        $latest = Event::where('action', 'time_travel')->orderByDesc('time')->orderByDesc('id')->first();
+        $this->assertSame('America/New_York', $latest->event_metadata['previous_timezone']);
+    }
+
+    #[Test]
+    public function timezone_store_does_not_mutate_profile_timezone(): void
+    {
+        $this->user->setTimezone('Europe/London');
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson('/api/v1/mobile/check-ins/timezone', ['timezone' => 'America/New_York'])
+            ->assertStatus(201);
+
+        $this->assertSame('Europe/London', $this->user->fresh()->getTimezone());
+    }
+
+    #[Test]
+    public function timezone_state_is_scoped_to_the_authenticated_user(): void
+    {
+        $this->user->setTimezone('Europe/London');
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+        $this->postJson('/api/v1/mobile/check-ins/timezone', ['timezone' => 'America/New_York'])
+            ->assertStatus(201);
+
+        $other = User::factory()->create();
+        $other->setTimezone('Australia/Sydney');
+        Sanctum::actingAs($other, ['ios:read']);
+
+        // The other user sees only their own profile fallback, never the first
+        // user's acknowledged travel timezone.
+        $this->getJson('/api/v1/mobile/check-ins/timezone')
+            ->assertStatus(200)
+            ->assertJsonPath('timezone', 'Australia/Sydney')
+            ->assertJsonPath('source', 'profile');
+    }
+
+    // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
 

--- a/tests/Feature/Api/V1/Mobile/CheckInsControllerTest.php
+++ b/tests/Feature/Api/V1/Mobile/CheckInsControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Api\V1\Mobile;
 
+use App\Integrations\DailyCheckin\DailyCheckinPlugin;
 use App\Models\Event;
 use App\Models\Integration;
 use App\Models\IntegrationGroup;
@@ -482,8 +483,9 @@ class CheckInsControllerTest extends TestCase
             ->assertStatus(200)
             ->assertJsonPath('timezone', 'Asia/Tokyo');
 
-        // The second event's derived previous timezone is the first acknowledged zone.
-        $latest = Event::where('action', 'time_travel')->orderByDesc('time')->orderByDesc('id')->first();
+        // The latest event's derived previous timezone is the first acknowledged zone.
+        $latest = (new DailyCheckinPlugin)->getLatestTimezoneEvent($this->user->id);
+        $this->assertSame('Asia/Tokyo', $latest->event_metadata['timezone']);
         $this->assertSame('America/New_York', $latest->event_metadata['previous_timezone']);
     }
 


### PR DESCRIPTION
## Summary

Implements [CRX-723](https://linear.app/cronx/issue/CRX-723) — an explicit, user-acknowledged effective timezone for travel, represented as `daily_checkin` / `time_travel` events. The latest such event is the acknowledged effective timezone; absence falls back to the user's profile timezone. The user's profile timezone is never mutated.

## Endpoints

- `GET /api/v1/mobile/check-ins/timezone` — returns the effective timezone state (requires `ios:read`).
- `POST /api/v1/mobile/check-ins/timezone` — atomically records an acknowledgement and returns the new state (requires `ios:write`).

### GET response
```json
{
  "timezone": "Europe/London",
  "source": "profile",          // or "time_travel"
  "acknowledged_at": null,        // ISO8601 when an event exists
  "event_id": null,
  "device_id": null
}
```

### POST request
```json
{
  "timezone": "America/New_York",
  "previous_timezone": "Europe/London",   // optional; ignored, derived server-side
  "device_id": "optional-registered-device-id"
}
```

### Event metadata (`daily_checkin` / `time_travel`)
```json
{
  "timezone": "America/New_York",
  "previous_timezone": "Europe/London",
  "device_id": "optional-registered-device-id",
  "source": "user_acknowledged"
}
```

## Behaviour / acceptance criteria

- IANA identifiers validated (`timezone:all`); UTC-offset-only values rejected.
- `previous_timezone` is derived server-side from the current effective timezone — a contradictory client value is ignored.
- A valid acknowledgement creates exactly one `daily_checkin/time_travel` event inside a DB transaction.
- Re-submitting the already-effective zone is idempotent (HTTP 200, no duplicate event). Because IANA identifiers are compared (not offsets), DST transitions within a zone never require a new event.
- Scoped to the authenticated user's own Daily Check-in integration; users cannot read or create acknowledgements for another user.
- `users.timezone` (profile) is preserved.

## Implementation

- `DailyCheckinPlugin`: documents the canonical `time_travel` action shape and adds `getLatestTimezoneEvent`, `resolveEffectiveTimezone`, `createTimezoneEvent`.
- `CheckInsController`: `showTimezone` / `storeTimezone`.
- `routes/mobile.php`: two new named routes.

## Tests

15 new feature tests in `CheckInsControllerTest` covering fallback, first acknowledgement, subsequent changes with latest-wins resolution, invalid identifiers, authorization/scoping, idempotency, device id, server-derived previous timezone, and profile-timezone immutability.

`sail artisan test --filter CheckInsControllerTest` → **36 passed (108 assertions)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)