### PR TITLE
:sparkles: Point-in-time effective timezone + event-driven Flint digests (CRX-723)

### DIFF
--- a/app/Http/Controllers/Api/V1/Mobile/CheckInsController.php
+++ b/app/Http/Controllers/Api/V1/Mobile/CheckInsController.php
@@ -12,6 +12,7 @@ use Carbon\Carbon;
 use Carbon\CarbonPeriod;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 
 class CheckInsController extends Controller
@@ -223,6 +224,67 @@ class CheckInsController extends Controller
             (new CompactEventResource($event->fresh(['actor', 'target', 'blocks', 'tags', 'integration'])))->resolve($request),
             201,
         );
+    }
+
+    /**
+     * GET /api/v1/mobile/check-ins/timezone
+     *
+     * Returns the user's effective timezone state. When a `time_travel`
+     * acknowledgement exists, `source` is `time_travel` and the acknowledgement
+     * fields are populated; otherwise it falls back to the profile timezone.
+     */
+    public function showTimezone(Request $request): JsonResponse
+    {
+        $state = (new DailyCheckinPlugin)->resolveEffectiveTimezone($request->user());
+
+        return response()->json($state);
+    }
+
+    /**
+     * POST /api/v1/mobile/check-ins/timezone
+     *
+     * Atomically records a user-acknowledged change to the effective timezone
+     * as a Daily Check-in `time_travel` event and returns the resulting state.
+     *
+     * The prior timezone is derived server-side from the current effective
+     * timezone; a contradictory client `previous_timezone` is ignored. Repeated
+     * submissions of the already-effective timezone are a no-op (idempotent) so
+     * no duplicate consecutive events are created. The user's profile timezone
+     * is never mutated.
+     */
+    public function storeTimezone(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'timezone' => ['required', 'string', 'timezone:all'],
+            'previous_timezone' => ['nullable', 'string', 'timezone:all'],
+            'device_id' => ['nullable', 'string', 'max:255'],
+        ]);
+
+        $plugin = new DailyCheckinPlugin;
+        $user = $request->user();
+
+        $current = $plugin->resolveEffectiveTimezone($user);
+
+        // Comparing IANA identifiers (not UTC offsets) means DST transitions
+        // within a single zone never trigger a new acknowledgement.
+        if ($validated['timezone'] === $current['timezone']) {
+            return response()->json($current, 200);
+        }
+
+        $state = DB::transaction(function () use ($plugin, $request, $validated, $current) {
+            $integration = $this->resolveIntegration($request);
+
+            $plugin->createTimezoneEvent(
+                $integration,
+                $validated['timezone'],
+                $current['timezone'],
+                $validated['device_id'] ?? null,
+            );
+
+            return $plugin->resolveEffectiveTimezone($request->user());
+        });
+
+        return response()->json($state, 201);
     }
 
     protected function resolveIntegration(Request $request): Integration

--- a/app/Http/Controllers/Api/V1/Mobile/TagsController.php
+++ b/app/Http/Controllers/Api/V1/Mobile/TagsController.php
@@ -1,0 +1,380 @@
+<?php
+
+namespace App\Http\Controllers\Api\V1\Mobile;
+
+use App\Http\Controllers\Controller;
+use App\Models\Block;
+use App\Models\Event;
+use App\Models\EventObject;
+use App\Models\User;
+use App\Services\Mobile\EventLookup;
+use App\Services\Mobile\ObjectLookup;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\Rule;
+use Spatie\Tags\Tag;
+
+class TagsController extends Controller
+{
+    private const DEFAULT_LIMIT = 30;
+
+    private const MAX_LIMIT = 100;
+
+    public function __construct(
+        protected EventLookup $eventLookup,
+        protected ObjectLookup $objectLookup,
+    ) {}
+
+    public function index(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'q' => ['nullable', 'string', 'max:255'],
+            'cursor' => ['nullable', 'string'],
+            'limit' => ['nullable', 'integer', 'min:1', 'max:' . self::MAX_LIMIT],
+        ]);
+
+        $tags = $this->withTotals(
+            $this->tagQuery($request->user(), $validated['q'] ?? null)->get(),
+        )->sortBy([['total_count', 'desc'], ['id', 'asc']])->values();
+
+        [$tags, $nextCursor, $hasMore] = $this->paginate(
+            $tags,
+            $validated['cursor'] ?? null,
+            (int) ($validated['limit'] ?? self::DEFAULT_LIMIT),
+        );
+
+        return response()->json([
+            'data' => $tags->map(fn (Tag $tag) => $this->tagPayload($tag))->values(),
+            'next_cursor' => $nextCursor,
+            'has_more' => $hasMore,
+        ]);
+    }
+
+    public function show(Request $request, string $id): JsonResponse
+    {
+        $validated = $request->validate([
+            'cursor' => ['nullable', 'string'],
+            'limit' => ['nullable', 'integer', 'min:1', 'max:' . self::MAX_LIMIT],
+        ]);
+
+        $tag = $this->tagQuery($request->user())
+            ->where('tags.id', $id)
+            ->first();
+
+        if (! $tag) {
+            return response()->json(['message' => 'Tag not found.'], 404);
+        }
+
+        $tag = $this->withTotals(collect([$tag]))->first();
+        $items = $this->taggedItems($request->user(), $tag);
+        [$page, $nextCursor, $hasMore] = $this->paginate(
+            $items,
+            $validated['cursor'] ?? null,
+            (int) ($validated['limit'] ?? self::DEFAULT_LIMIT),
+        );
+
+        return response()->json([
+            'tag' => $this->tagPayload($tag),
+            'data' => $page->map(fn (array $item) => $item['payload'])->values(),
+            'next_cursor' => $nextCursor,
+            'has_more' => $hasMore,
+        ]);
+    }
+
+    public function suggest(Request $request): JsonResponse
+    {
+        $validated = $request->validate([
+            'q' => ['nullable', 'string', 'max:255'],
+            'limit' => ['nullable', 'integer', 'min:1', 'max:25'],
+        ]);
+        $queryText = trim((string) ($validated['q'] ?? ''));
+        $limit = (int) ($validated['limit'] ?? 10);
+
+        $lower = mb_strtolower($queryText);
+        $tags = $this->withTotals(
+            $this->tagQuery($request->user(), $queryText)->get(),
+        )->sortBy(function (Tag $tag) use ($lower) {
+            $name = mb_strtolower((string) $tag->name);
+            $matchRank = match (true) {
+                $lower === '' => 0,
+                $name === $lower => 0,
+                str_starts_with($name, $lower) => 1,
+                default => 2,
+            };
+
+            return [
+                $matchRank,
+                -((int) $tag->total_count),
+                (string) $tag->id,
+            ];
+        })->take($limit)->values();
+
+        return response()->json([
+            'data' => $tags->map(fn (Tag $tag) => $this->tagPayload($tag))->values(),
+        ]);
+    }
+
+    public function storeEventTag(Request $request, string $id): JsonResponse
+    {
+        $event = $this->eventLookup->find($request->user(), $id);
+        if (! $event) {
+            return response()->json(['message' => 'Event not found.'], 404);
+        }
+
+        return $this->attach($request, $event);
+    }
+
+    public function destroyEventTag(Request $request, string $id, string $tagId): JsonResponse
+    {
+        $event = $this->eventLookup->find($request->user(), $id);
+        if (! $event) {
+            return response()->json(['message' => 'Event not found.'], 404);
+        }
+
+        return $this->detach($event, $tagId);
+    }
+
+    public function storeObjectTag(Request $request, string $id): JsonResponse
+    {
+        $object = $this->objectLookup->find($request->user(), $id);
+        if (! $object) {
+            return response()->json(['message' => 'Object not found.'], 404);
+        }
+
+        return $this->attach($request, $object);
+    }
+
+    public function destroyObjectTag(Request $request, string $id, string $tagId): JsonResponse
+    {
+        $object = $this->objectLookup->find($request->user(), $id);
+        if (! $object) {
+            return response()->json(['message' => 'Object not found.'], 404);
+        }
+
+        return $this->detach($object, $tagId);
+    }
+
+    private function attach(Request $request, Event|EventObject $entity): JsonResponse
+    {
+        $validated = $request->validate([
+            'tag_id' => ['nullable', 'string', Rule::exists('tags', 'id')],
+            'name' => ['required_without:tag_id', 'nullable', 'string', 'max:255'],
+            'type' => ['nullable', 'string', 'max:100'],
+        ]);
+
+        if (isset($validated['tag_id'])) {
+            $tag = Tag::findOrFail($validated['tag_id']);
+        } else {
+            [$name, $type] = $this->normaliseTag(
+                (string) $validated['name'],
+                $validated['type'] ?? null,
+            );
+            if ($name === '') {
+                return response()->json(['message' => 'The tag name field is required.'], 422);
+            }
+
+            $tag = Tag::findOrCreate($name, $type);
+        }
+
+        $entity->attachTags([$tag]);
+        $entity->load('tags');
+
+        return response()->json([
+            'tag' => $this->tagPayload($tag),
+            'tags' => $entity->tags->map(fn (Tag $item) => $this->tagPayload($item))->values(),
+        ], 201);
+    }
+
+    private function detach(Event|EventObject $entity, string $tagId): JsonResponse
+    {
+        $tag = Tag::find($tagId);
+        if (! $tag || ! $entity->tags()->where('tags.id', $tagId)->exists()) {
+            return response()->json(['message' => 'Tag not found on entity.'], 404);
+        }
+
+        $entity->detachTags([$tag]);
+        $entity->load('tags');
+
+        return response()->json([
+            'tags' => $entity->tags->map(fn (Tag $item) => $this->tagPayload($item))->values(),
+        ]);
+    }
+
+    private function tagQuery(User $user, ?string $search = null): Builder
+    {
+        $integrationIds = $user->integrations()->pluck('id');
+
+        $query = Tag::query()
+            ->select('tags.*')
+            ->selectSub(
+                Event::query()
+                    ->selectRaw('COUNT(*)')
+                    ->join('taggables', function ($join) {
+                        $join->on('taggables.taggable_id', '=', 'events.id')
+                            ->where('taggables.taggable_type', Event::class);
+                    })
+                    ->whereColumn('taggables.tag_id', 'tags.id')
+                    ->whereIn('events.integration_id', $integrationIds),
+                'events_count',
+            )
+            ->selectSub(
+                EventObject::query()
+                    ->selectRaw('COUNT(*)')
+                    ->join('taggables', function ($join) {
+                        $join->on('taggables.taggable_id', '=', 'objects.id')
+                            ->where('taggables.taggable_type', EventObject::class);
+                    })
+                    ->whereColumn('taggables.tag_id', 'tags.id')
+                    ->where('objects.user_id', $user->id),
+                'objects_count',
+            )
+            ->where(function (Builder $query) use ($user, $integrationIds) {
+                $query->whereExists(function ($events) use ($integrationIds) {
+                    $events->selectRaw('1')
+                        ->from('taggables')
+                        ->join('events', 'events.id', '=', 'taggables.taggable_id')
+                        ->whereColumn('taggables.tag_id', 'tags.id')
+                        ->where('taggables.taggable_type', Event::class)
+                        ->whereIn('events.integration_id', $integrationIds);
+                })->orWhereExists(function ($objects) use ($user) {
+                    $objects->selectRaw('1')
+                        ->from('taggables')
+                        ->join('objects', 'objects.id', '=', 'taggables.taggable_id')
+                        ->whereColumn('taggables.tag_id', 'tags.id')
+                        ->where('taggables.taggable_type', EventObject::class)
+                        ->where('objects.user_id', $user->id);
+                });
+            });
+
+        $search = trim((string) $search);
+        if ($search !== '') {
+            $query->where(function (Builder $query) use ($search) {
+                $query->where('name->en', 'ilike', '%' . $search . '%')
+                    ->orWhere('type', 'ilike', '%' . $search . '%');
+            });
+        }
+
+        return $query;
+    }
+
+    private function withTotals(Collection $tags): Collection
+    {
+        return $tags->each(function (Tag $tag) {
+            $tag->setAttribute(
+                'total_count',
+                (int) $tag->events_count + (int) $tag->objects_count,
+            );
+        });
+    }
+
+    private function taggedItems(User $user, Tag $tag): Collection
+    {
+        $integrationIds = $user->integrations()->pluck('id');
+
+        $events = Event::query()
+            ->withAnyTags([$tag])
+            ->whereIn('integration_id', $integrationIds)
+            ->with(['actor', 'target'])
+            ->get()
+            ->map(fn (Event $event) => [
+                'sort_time' => $event->time ?? $event->created_at,
+                'payload' => [
+                    'kind' => 'event',
+                    'id' => (string) $event->id,
+                    'title' => $event->target?->title ?? $event->actor?->title ?? format_action_title($event->action),
+                    'subtitle' => $event->time?->toIso8601String(),
+                    'domain' => $event->domain,
+                ],
+            ]);
+
+        $objects = EventObject::query()
+            ->withAnyTags([$tag])
+            ->where('user_id', $user->id)
+            ->get()
+            ->map(fn (EventObject $object) => [
+                'sort_time' => $object->time ?? $object->created_at,
+                'payload' => [
+                    'kind' => 'object',
+                    'id' => (string) $object->id,
+                    'title' => $object->title,
+                    'subtitle' => $object->concept,
+                    'concept' => $object->concept,
+                ],
+            ]);
+
+        $blockIds = DB::table('taggables')
+            ->where('tag_id', $tag->id)
+            ->where('taggable_type', Block::class)
+            ->pluck('taggable_id');
+
+        $blocks = Block::query()
+            ->whereIn('id', $blockIds)
+            ->whereHas('event', fn (Builder $events) => $events->whereIn('integration_id', $integrationIds))
+            ->get()
+            ->map(fn (Block $block) => [
+                'sort_time' => $block->time ?? $block->created_at,
+                'payload' => [
+                    'kind' => 'block',
+                    'id' => (string) $block->id,
+                    'title' => $block->title,
+                    'subtitle' => $block->block_type,
+                    'block_type' => $block->block_type,
+                ],
+            ]);
+
+        return $events
+            ->concat($objects)
+            ->concat($blocks)
+            ->sortByDesc('sort_time')
+            ->values();
+    }
+
+    private function tagPayload(Tag $tag): array
+    {
+        return [
+            'id' => (string) $tag->id,
+            'name' => $tag->name,
+            'type' => $tag->type,
+            'events_count' => (int) ($tag->events_count ?? 0),
+            'objects_count' => (int) ($tag->objects_count ?? 0),
+            'total_count' => (int) ($tag->total_count ?? 0),
+        ];
+    }
+
+    private function normaliseTag(string $value, ?string $type): array
+    {
+        $name = trim($value);
+        $detectedType = $type !== null ? trim($type) : null;
+
+        if ($detectedType === null && preg_match('/^([A-Za-z0-9-]+)[_:](.+)$/', $name, $matches) === 1) {
+            $detectedType = strtolower($matches[1]);
+            $name = trim($matches[2]);
+        } elseif ($detectedType !== null
+            && preg_match('/^' . preg_quote($detectedType, '/') . '[_:](.+)$/i', $name, $matches) === 1) {
+            $name = trim($matches[1]);
+        }
+
+        $detectedType ??= preg_match('/^\p{Extended_Pictographic}(?:[\x{FE0F}\x{FE0E}])?(?:\x{200D}\p{Extended_Pictographic}(?:[\x{FE0F}\x{FE0E}])?)*$/u', $name) === 1
+            ? 'emoji'
+            : 'spark';
+
+        return [$name, $detectedType];
+    }
+
+    private function paginate(Collection $items, ?string $cursor, int $limit): array
+    {
+        $limit = max(1, min($limit, self::MAX_LIMIT));
+        $offset = $cursor ? (int) base64_decode(strtr($cursor, '-_', '+/')) : 0;
+        $page = $items->slice($offset, $limit)->values();
+        $nextOffset = $offset + $page->count();
+        $hasMore = $nextOffset < $items->count();
+        $nextCursor = $hasMore
+            ? rtrim(strtr(base64_encode((string) $nextOffset), '+/', '-_'), '=')
+            : null;
+
+        return [$page, $nextCursor, $hasMore];
+    }
+}

--- a/app/Http/Controllers/Api/V1/Mobile/TagsController.php
+++ b/app/Http/Controllers/Api/V1/Mobile/TagsController.php
@@ -13,8 +13,6 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\DB;
-use Illuminate\Validation\Rule;
 use Spatie\Tags\Tag;
 
 class TagsController extends Controller
@@ -69,11 +67,13 @@ class TagsController extends Controller
         }
 
         $tag = $this->withTotals(collect([$tag]))->first();
-        $items = $this->taggedItems($request->user(), $tag);
+        $limit = (int) ($validated['limit'] ?? self::DEFAULT_LIMIT);
+        $offset = $this->cursorOffset($validated['cursor'] ?? null);
+        $items = $this->taggedItems($request->user(), $tag, $offset + $limit + 1);
         [$page, $nextCursor, $hasMore] = $this->paginate(
             $items,
             $validated['cursor'] ?? null,
-            (int) ($validated['limit'] ?? self::DEFAULT_LIMIT),
+            $limit,
         );
 
         return response()->json([
@@ -160,13 +160,19 @@ class TagsController extends Controller
     private function attach(Request $request, Event|EventObject $entity): JsonResponse
     {
         $validated = $request->validate([
-            'tag_id' => ['nullable', 'string', Rule::exists('tags', 'id')],
+            'tag_id' => ['nullable', 'integer'],
             'name' => ['required_without:tag_id', 'nullable', 'string', 'max:255'],
             'type' => ['nullable', 'string', 'max:100'],
         ]);
 
         if (isset($validated['tag_id'])) {
-            $tag = Tag::findOrFail($validated['tag_id']);
+            $tag = $this->tagQuery($request->user())
+                ->whereKey($validated['tag_id'])
+                ->first();
+
+            if (! $tag) {
+                return response()->json(['message' => 'Tag not found.'], 404);
+            }
         } else {
             [$name, $type] = $this->normaliseTag(
                 (string) $validated['name'],
@@ -270,7 +276,7 @@ class TagsController extends Controller
         });
     }
 
-    private function taggedItems(User $user, Tag $tag): Collection
+    private function taggedItems(User $user, Tag $tag, int $maximumItems): Collection
     {
         $integrationIds = $user->integrations()->pluck('id');
 
@@ -278,6 +284,8 @@ class TagsController extends Controller
             ->withAnyTags([$tag])
             ->whereIn('integration_id', $integrationIds)
             ->with(['actor', 'target'])
+            ->latest('time')
+            ->limit($maximumItems)
             ->get()
             ->map(fn (Event $event) => [
                 'sort_time' => $event->time ?? $event->created_at,
@@ -293,6 +301,8 @@ class TagsController extends Controller
         $objects = EventObject::query()
             ->withAnyTags([$tag])
             ->where('user_id', $user->id)
+            ->latest('time')
+            ->limit($maximumItems)
             ->get()
             ->map(fn (EventObject $object) => [
                 'sort_time' => $object->time ?? $object->created_at,
@@ -305,14 +315,16 @@ class TagsController extends Controller
                 ],
             ]);
 
-        $blockIds = DB::table('taggables')
-            ->where('tag_id', $tag->id)
-            ->where('taggable_type', Block::class)
-            ->pluck('taggable_id');
-
         $blocks = Block::query()
-            ->whereIn('id', $blockIds)
+            ->join('taggables', function ($join) {
+                $join->on('taggables.taggable_id', '=', 'blocks.id')
+                    ->where('taggables.taggable_type', Block::class);
+            })
+            ->where('taggables.tag_id', $tag->id)
             ->whereHas('event', fn (Builder $events) => $events->whereIn('integration_id', $integrationIds))
+            ->latest('time')
+            ->limit($maximumItems)
+            ->select('blocks.*')
             ->get()
             ->map(fn (Block $block) => [
                 'sort_time' => $block->time ?? $block->created_at,
@@ -367,7 +379,7 @@ class TagsController extends Controller
     private function paginate(Collection $items, ?string $cursor, int $limit): array
     {
         $limit = max(1, min($limit, self::MAX_LIMIT));
-        $offset = $cursor ? (int) base64_decode(strtr($cursor, '-_', '+/')) : 0;
+        $offset = $this->cursorOffset($cursor);
         $page = $items->slice($offset, $limit)->values();
         $nextOffset = $offset + $page->count();
         $hasMore = $nextOffset < $items->count();
@@ -376,5 +388,10 @@ class TagsController extends Controller
             : null;
 
         return [$page, $nextCursor, $hasMore];
+    }
+
+    private function cursorOffset(?string $cursor): int
+    {
+        return $cursor ? max(0, (int) base64_decode(strtr($cursor, '-_', '+/'), true)) : 0;
     }
 }

--- a/app/Http/Resources/Compact/CompactEventResource.php
+++ b/app/Http/Resources/Compact/CompactEventResource.php
@@ -73,6 +73,7 @@ class CompactEventResource extends JsonResource
 
         if ($this->relationLoaded('tags')) {
             $data['tags'] = $this->tags->map(fn ($tag) => [
+                'id' => (string) $tag->id,
                 'name' => $tag->name,
                 'type' => $tag->type,
             ])->values()->all();

--- a/app/Http/Resources/Compact/CompactObjectResource.php
+++ b/app/Http/Resources/Compact/CompactObjectResource.php
@@ -36,6 +36,14 @@ class CompactObjectResource extends JsonResource
             $data['media_url'] = $this->media_url;
         }
 
+        if ($this->relationLoaded('tags')) {
+            $data['tags'] = $this->tags->map(fn ($tag) => [
+                'id' => (string) $tag->id,
+                'name' => $tag->name,
+                'type' => $tag->type,
+            ])->values()->all();
+        }
+
         return $data;
     }
 }

--- a/app/Integrations/DailyCheckin/DailyCheckinPlugin.php
+++ b/app/Integrations/DailyCheckin/DailyCheckinPlugin.php
@@ -414,7 +414,7 @@ class DailyCheckinPlugin extends ManualPlugin
             ->where('action', 'time_travel')
             // Order by the microsecond-precision metadata stamp; `time`/`created_at`
             // are only second-precise and cannot disambiguate same-second events.
-            ->orderByDesc('event_metadata->acknowledged_at')
+            ->orderByRaw("COALESCE((event_metadata->>'acknowledged_at')::timestamptz, time) DESC")
             ->orderByDesc('time')
             ->orderByDesc('id')
             ->first();

--- a/app/Integrations/DailyCheckin/DailyCheckinPlugin.php
+++ b/app/Integrations/DailyCheckin/DailyCheckinPlugin.php
@@ -9,6 +9,7 @@ use App\Models\Integration;
 use App\Models\User;
 use App\Services\Media\MediaDownloadHelper;
 use App\Services\PlaceDetectionService;
+use Carbon\Carbon;
 use Illuminate\Support\Str;
 use InvalidArgumentException;
 
@@ -413,6 +414,41 @@ class DailyCheckinPlugin extends ManualPlugin
             ->where('action', 'time_travel')
             // Order by the microsecond-precision metadata stamp; `time`/`created_at`
             // are only second-precise and cannot disambiguate same-second events.
+            ->orderByDesc('event_metadata->acknowledged_at')
+            ->orderByDesc('time')
+            ->orderByDesc('id')
+            ->first();
+    }
+
+    /**
+     * Resolve the user's latest acknowledged "time travel" event as of a given
+     * instant — the most recent acknowledgement whose timestamp is at-or-before
+     * `$instant`. Used to render historical days in the timezone that was
+     * acknowledged on that date (point-in-time resolution).
+     *
+     * The comparison prefers the microsecond-precision `acknowledged_at` metadata
+     * stamp (written in the fixed-width `Y-m-d\TH:i:s.u\Z` format, which sorts
+     * lexicographically in chronological order). Older events that predate that
+     * stamp lack the key, so they fall back to the second-precise `time` column.
+     *
+     * @param  int|string  $userId  The user ID
+     */
+    public function getLatestTimezoneEventAt(int|string $userId, Carbon $instant): ?Event
+    {
+        $stamp = $instant->copy()->utc()->format('Y-m-d\TH:i:s.u\Z');
+
+        return Event::whereHas('integration', function ($q) use ($userId) {
+            $q->where('user_id', $userId);
+        })
+            ->where('service', 'daily_checkin')
+            ->where('action', 'time_travel')
+            ->where(function ($q) use ($stamp, $instant) {
+                $q->where('event_metadata->acknowledged_at', '<=', $stamp)
+                    ->orWhere(function ($q2) use ($instant) {
+                        $q2->whereNull('event_metadata->acknowledged_at')
+                            ->where('time', '<=', $instant);
+                    });
+            })
             ->orderByDesc('event_metadata->acknowledged_at')
             ->orderByDesc('time')
             ->orderByDesc('id')

--- a/app/Integrations/DailyCheckin/DailyCheckinPlugin.php
+++ b/app/Integrations/DailyCheckin/DailyCheckinPlugin.php
@@ -199,7 +199,7 @@ class DailyCheckinPlugin extends ManualPlugin
                 'title' => $date,
             ],
             [
-                'time' => $date.' 00:00:00',
+                'time' => $date . ' 00:00:00',
                 'content' => null,
                 'metadata' => [],
             ]
@@ -223,13 +223,13 @@ class DailyCheckinPlugin extends ManualPlugin
 
         // Determine action and default time based on period
         $action = $period === 'morning' ? 'had_morning_checkin' : 'had_afternoon_checkin';
-        $defaultTime = $period === 'morning' ? $date.' 08:00:00' : $date.' 17:00:00';
+        $defaultTime = $period === 'morning' ? $date . ' 08:00:00' : $date . ' 17:00:00';
 
         // Calculate combined value (out of 10)
         $combinedValue = $physical + $mental;
 
         // Create or update the event
-        $sourceId = 'daily_checkin_'.$period.'_'.$date;
+        $sourceId = 'daily_checkin_' . $period . '_' . $date;
 
         $event = Event::updateOrCreate(
             [
@@ -316,7 +316,7 @@ class DailyCheckinPlugin extends ManualPlugin
                 'title' => $date,
             ],
             [
-                'time' => $date.' 00:00:00',
+                'time' => $date . ' 00:00:00',
                 'content' => null,
                 'metadata' => [],
             ]
@@ -339,7 +339,7 @@ class DailyCheckinPlugin extends ManualPlugin
 
         $event = Event::create([
             'integration_id' => $integration->id,
-            'source_id' => 'daily_checkin_photo_'.$date.'_'.Str::uuid(),
+            'source_id' => 'daily_checkin_photo_' . $date . '_' . Str::uuid(),
             'time' => now(),
             'service' => 'daily_checkin',
             'domain' => self::getDomain(),
@@ -384,8 +384,8 @@ class DailyCheckinPlugin extends ManualPlugin
         })
             ->where('service', 'daily_checkin')
             ->whereIn('source_id', [
-                'daily_checkin_morning_'.$date,
-                'daily_checkin_afternoon_'.$date,
+                'daily_checkin_morning_' . $date,
+                'daily_checkin_afternoon_' . $date,
             ])
             ->with('blocks')
             ->get();
@@ -537,7 +537,7 @@ class DailyCheckinPlugin extends ManualPlugin
 
         return Event::create([
             'integration_id' => $integration->id,
-            'source_id' => 'daily_checkin_time_travel_'.Str::uuid(),
+            'source_id' => 'daily_checkin_time_travel_' . Str::uuid(),
             'time' => $acknowledgedAt,
             'service' => 'daily_checkin',
             'domain' => self::getDomain(),

--- a/app/Integrations/DailyCheckin/DailyCheckinPlugin.php
+++ b/app/Integrations/DailyCheckin/DailyCheckinPlugin.php
@@ -88,6 +88,21 @@ class DailyCheckinPlugin extends ManualPlugin
                 'value_unit' => null,
                 'hidden' => false,
             ],
+            // Canonical "time travel" event: a user-acknowledged change to their
+            // effective timezone while travelling. The latest such event is the
+            // acknowledged effective timezone; absence falls back to the user's
+            // profile timezone. `time` is the absolute acknowledgement timestamp;
+            // `event_metadata` carries `timezone`, `previous_timezone`,
+            // `device_id` (nullable) and `source` ("user_acknowledged"). It does
+            // not mutate the user's home/profile timezone.
+            'time_travel' => [
+                'icon' => 'fas.plane',
+                'display_name' => 'Time Travel',
+                'description' => 'Acknowledged a change to the effective timezone',
+                'display_with_object' => false,
+                'value_unit' => null,
+                'hidden' => true,
+            ],
         ];
     }
 
@@ -378,5 +393,112 @@ class DailyCheckinPlugin extends ManualPlugin
             'morning' => $events->firstWhere('action', 'had_morning_checkin'),
             'afternoon' => $events->firstWhere('action', 'had_afternoon_checkin'),
         ];
+    }
+
+    /**
+     * Resolve the user's latest acknowledged "time travel" event, if any.
+     *
+     * This is the single source of truth for the acknowledged effective
+     * timezone. It is scoped to the user's own Daily Check-in integration and
+     * ordered so the most recent acknowledgement wins.
+     *
+     * @param  int|string  $userId  The user ID
+     */
+    public function getLatestTimezoneEvent(int|string $userId): ?Event
+    {
+        return Event::whereHas('integration', function ($q) use ($userId) {
+            $q->where('user_id', $userId);
+        })
+            ->where('service', 'daily_checkin')
+            ->where('action', 'time_travel')
+            ->orderByDesc('time')
+            ->orderByDesc('id')
+            ->first();
+    }
+
+    /**
+     * Resolve the user's effective timezone state.
+     *
+     * Returns the acknowledged travel timezone when a `time_travel` event
+     * exists, otherwise falls back to the user's home/profile timezone. The
+     * shape matches the mobile GET contract.
+     *
+     * @return array{timezone: string, source: string, acknowledged_at: ?string, event_id: ?string, device_id: ?string}
+     */
+    public function resolveEffectiveTimezone(User $user): array
+    {
+        $event = $this->getLatestTimezoneEvent($user->id);
+
+        if ($event === null) {
+            return [
+                'timezone' => $user->getTimezone(),
+                'source' => 'profile',
+                'acknowledged_at' => null,
+                'event_id' => null,
+                'device_id' => null,
+            ];
+        }
+
+        $metadata = $event->event_metadata ?? [];
+
+        return [
+            'timezone' => $metadata['timezone'] ?? $user->getTimezone(),
+            'source' => 'time_travel',
+            'acknowledged_at' => $event->time?->toIso8601String(),
+            'event_id' => $event->id,
+            'device_id' => $metadata['device_id'] ?? null,
+        ];
+    }
+
+    /**
+     * Record a user-acknowledged change to the effective timezone as a new
+     * `time_travel` event.
+     *
+     * The `$previousTimezone` is derived server-side from the current effective
+     * timezone; a contradictory client value must not be trusted. `users`
+     * profile timezone is intentionally left unchanged.
+     *
+     * @param  Integration  $integration  The user's Daily Check-in integration
+     * @param  string  $timezone  The new effective IANA timezone identifier
+     * @param  string  $previousTimezone  The server-derived prior timezone
+     * @param  string|null  $deviceId  Optional registered device id
+     */
+    public function createTimezoneEvent(
+        Integration $integration,
+        string $timezone,
+        string $previousTimezone,
+        ?string $deviceId = null,
+    ): Event {
+        $user = User::find($integration->user_id);
+        $userObject = EventObject::firstOrCreate(
+            [
+                'user_id' => $integration->user_id,
+                'concept' => 'user',
+                'type' => 'user',
+                'title' => $user ? $user->name : 'User',
+            ],
+            [
+                'time' => now(),
+                'content' => null,
+                'metadata' => [],
+            ]
+        );
+
+        return Event::create([
+            'integration_id' => $integration->id,
+            'source_id' => 'daily_checkin_time_travel_' . Str::uuid(),
+            'time' => now(),
+            'service' => 'daily_checkin',
+            'domain' => self::getDomain(),
+            'action' => 'time_travel',
+            'event_metadata' => [
+                'timezone' => $timezone,
+                'previous_timezone' => $previousTimezone,
+                'device_id' => $deviceId,
+                'source' => 'user_acknowledged',
+            ],
+            'target_id' => $userObject->id,
+            'actor_id' => $userObject->id,
+        ]);
     }
 }

--- a/app/Integrations/DailyCheckin/DailyCheckinPlugin.php
+++ b/app/Integrations/DailyCheckin/DailyCheckinPlugin.php
@@ -199,7 +199,7 @@ class DailyCheckinPlugin extends ManualPlugin
                 'title' => $date,
             ],
             [
-                'time' => $date . ' 00:00:00',
+                'time' => $date.' 00:00:00',
                 'content' => null,
                 'metadata' => [],
             ]
@@ -223,13 +223,13 @@ class DailyCheckinPlugin extends ManualPlugin
 
         // Determine action and default time based on period
         $action = $period === 'morning' ? 'had_morning_checkin' : 'had_afternoon_checkin';
-        $defaultTime = $period === 'morning' ? $date . ' 08:00:00' : $date . ' 17:00:00';
+        $defaultTime = $period === 'morning' ? $date.' 08:00:00' : $date.' 17:00:00';
 
         // Calculate combined value (out of 10)
         $combinedValue = $physical + $mental;
 
         // Create or update the event
-        $sourceId = 'daily_checkin_' . $period . '_' . $date;
+        $sourceId = 'daily_checkin_'.$period.'_'.$date;
 
         $event = Event::updateOrCreate(
             [
@@ -316,7 +316,7 @@ class DailyCheckinPlugin extends ManualPlugin
                 'title' => $date,
             ],
             [
-                'time' => $date . ' 00:00:00',
+                'time' => $date.' 00:00:00',
                 'content' => null,
                 'metadata' => [],
             ]
@@ -339,7 +339,7 @@ class DailyCheckinPlugin extends ManualPlugin
 
         $event = Event::create([
             'integration_id' => $integration->id,
-            'source_id' => 'daily_checkin_photo_' . $date . '_' . Str::uuid(),
+            'source_id' => 'daily_checkin_photo_'.$date.'_'.Str::uuid(),
             'time' => now(),
             'service' => 'daily_checkin',
             'domain' => self::getDomain(),
@@ -384,8 +384,8 @@ class DailyCheckinPlugin extends ManualPlugin
         })
             ->where('service', 'daily_checkin')
             ->whereIn('source_id', [
-                'daily_checkin_morning_' . $date,
-                'daily_checkin_afternoon_' . $date,
+                'daily_checkin_morning_'.$date,
+                'daily_checkin_afternoon_'.$date,
             ])
             ->with('blocks')
             ->get();
@@ -449,7 +449,10 @@ class DailyCheckinPlugin extends ManualPlugin
                             ->where('time', '<=', $instant);
                     });
             })
-            ->orderByDesc('event_metadata->acknowledged_at')
+            // NULLS LAST is required here: Postgres sorts NULL first in a DESC
+            // order by default, which would let a legacy event with no stamp
+            // outrank a newer, properly-stamped acknowledgement.
+            ->orderByRaw("(event_metadata->>'acknowledged_at') DESC NULLS LAST")
             ->orderByDesc('time')
             ->orderByDesc('id')
             ->first();
@@ -534,7 +537,7 @@ class DailyCheckinPlugin extends ManualPlugin
 
         return Event::create([
             'integration_id' => $integration->id,
-            'source_id' => 'daily_checkin_time_travel_' . Str::uuid(),
+            'source_id' => 'daily_checkin_time_travel_'.Str::uuid(),
             'time' => $acknowledgedAt,
             'service' => 'daily_checkin',
             'domain' => self::getDomain(),

--- a/app/Integrations/DailyCheckin/DailyCheckinPlugin.php
+++ b/app/Integrations/DailyCheckin/DailyCheckinPlugin.php
@@ -411,6 +411,9 @@ class DailyCheckinPlugin extends ManualPlugin
         })
             ->where('service', 'daily_checkin')
             ->where('action', 'time_travel')
+            // Order by the microsecond-precision metadata stamp; `time`/`created_at`
+            // are only second-precise and cannot disambiguate same-second events.
+            ->orderByDesc('event_metadata->acknowledged_at')
             ->orderByDesc('time')
             ->orderByDesc('id')
             ->first();
@@ -444,7 +447,7 @@ class DailyCheckinPlugin extends ManualPlugin
         return [
             'timezone' => $metadata['timezone'] ?? $user->getTimezone(),
             'source' => 'time_travel',
-            'acknowledged_at' => $event->time?->toIso8601String(),
+            'acknowledged_at' => $metadata['acknowledged_at'] ?? $event->time?->toIso8601String(),
             'event_id' => $event->id,
             'device_id' => $metadata['device_id'] ?? null,
         ];
@@ -484,10 +487,19 @@ class DailyCheckinPlugin extends ManualPlugin
             ]
         );
 
+        // The events table has no insertion-ordered column (its primary key is a
+        // random UUID) and Eloquent's date grammar truncates the `time`/`created_at`
+        // columns to whole seconds, so two acknowledgements within the same second
+        // cannot be ordered reliably by those columns. We therefore stamp a
+        // microsecond-precision `acknowledged_at` into the metadata and resolve the
+        // latest event by it — see getLatestTimezoneEvent(). The fixed-width format
+        // sorts lexicographically in chronological order.
+        $acknowledgedAt = now();
+
         return Event::create([
             'integration_id' => $integration->id,
             'source_id' => 'daily_checkin_time_travel_' . Str::uuid(),
-            'time' => now(),
+            'time' => $acknowledgedAt,
             'service' => 'daily_checkin',
             'domain' => self::getDomain(),
             'action' => 'time_travel',
@@ -496,6 +508,7 @@ class DailyCheckinPlugin extends ManualPlugin
                 'previous_timezone' => $previousTimezone,
                 'device_id' => $deviceId,
                 'source' => 'user_acknowledged',
+                'acknowledged_at' => $acknowledgedAt->utc()->format('Y-m-d\TH:i:s.u\Z'),
             ],
             'target_id' => $userObject->id,
             'actor_id' => $userObject->id,

--- a/app/Jobs/Flint/SendDigestNotificationJob.php
+++ b/app/Jobs/Flint/SendDigestNotificationJob.php
@@ -30,7 +30,9 @@ class SendDigestNotificationJob implements ShouldQueue
 
     public function __construct(
         public User $user,
-        public string $scheduleTime
+        public string $scheduleTime,
+        public ?string $period = null,
+        public ?string $digestEventId = null,
     ) {}
 
     public function handle(): void
@@ -52,7 +54,7 @@ class SendDigestNotificationJob implements ShouldQueue
         });
 
         try {
-            $period = $this->getDigestPeriod($this->scheduleTime);
+            $period = $this->period ?? $this->getDigestPeriod($this->scheduleTime);
 
             Log::info('Sending digest notification', [
                 'user_id' => $this->user->id,
@@ -70,15 +72,25 @@ class SendDigestNotificationJob implements ShouldQueue
             $localDate = app(EffectiveTimezoneResolver::class)->today($this->user)->toDateString();
             $dayStartUtc = Carbon::parse($localDate, 'UTC')->startOfDay();
             $dayEndUtc = Carbon::parse($localDate, 'UTC')->endOfDay();
+            $analysisStartUtc = Carbon::parse($localDate, app(EffectiveTimezoneResolver::class)->timezoneFor($this->user))->startOfDay()->utc();
+            $analysisEndUtc = Carbon::parse($localDate, app(EffectiveTimezoneResolver::class)->timezoneFor($this->user))->endOfDay()->utc();
 
             $digestBlock = Block::whereIn('block_type', ['flint_summarised_headline', 'flint_digest'])
-                ->whereHas('event', function ($query) use ($dayStartUtc, $dayEndUtc) {
+                ->when($this->digestEventId, fn ($query) => $query->where('event_id', $this->digestEventId))
+                ->whereHas('event', function ($query) use ($dayStartUtc, $dayEndUtc, $analysisStartUtc, $analysisEndUtc) {
                     $query->where('service', 'flint')
-                        ->whereIn('action', ['had_summary', 'had_analysis'])
                         ->whereHas('integration', function ($q) {
                             $q->where('user_id', $this->user->id);
                         })
-                        ->whereBetween('time', [$dayStartUtc, $dayEndUtc]);
+                        ->where(function ($query) use ($dayStartUtc, $dayEndUtc, $analysisStartUtc, $analysisEndUtc) {
+                            $query->where(function ($query) use ($dayStartUtc, $dayEndUtc) {
+                                $query->where('action', 'had_summary')
+                                    ->whereBetween('time', [$dayStartUtc, $dayEndUtc]);
+                            })->orWhere(function ($query) use ($analysisStartUtc, $analysisEndUtc) {
+                                $query->where('action', 'had_analysis')
+                                    ->whereBetween('time', [$analysisStartUtc, $analysisEndUtc]);
+                            });
+                        });
                 })
                 ->with(['event.target'])
                 ->orderBy('created_at', 'desc')

--- a/app/Jobs/Flint/SendDigestNotificationJob.php
+++ b/app/Jobs/Flint/SendDigestNotificationJob.php
@@ -6,6 +6,8 @@ use App\Models\Block;
 use App\Models\Event;
 use App\Models\User;
 use App\Notifications\DailyDigestReady;
+use App\Services\EffectiveTimezoneResolver;
+use Carbon\Carbon;
 use Exception;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -58,16 +60,25 @@ class SendDigestNotificationJob implements ShouldQueue
                 'period' => $period,
             ]);
 
-            // Find the most recent digest block for this user created today
-            $today = now()->startOfDay();
+            // Find the most recent digest block for this user's *effective-timezone*
+            // local day, not the server (UTC) day. The digest `had_summary` event is
+            // stored with `time` anchored at the local date's 00:00 UTC marker (see
+            // CreateFlintDigestTool), so we bound the query by that same local date in
+            // UTC. Using a server-tz day boundary would wrongly drop a far-west user's
+            // digest once UTC rolls past midnight. If that storage ever moves to a real
+            // `now()` instant, these bounds must be revisited.
+            $localDate = app(EffectiveTimezoneResolver::class)->today($this->user)->toDateString();
+            $dayStartUtc = Carbon::parse($localDate, 'UTC')->startOfDay();
+            $dayEndUtc = Carbon::parse($localDate, 'UTC')->endOfDay();
+
             $digestBlock = Block::whereIn('block_type', ['flint_summarised_headline', 'flint_digest'])
-                ->whereHas('event', function ($query) use ($today) {
+                ->whereHas('event', function ($query) use ($dayStartUtc, $dayEndUtc) {
                     $query->where('service', 'flint')
                         ->whereIn('action', ['had_summary', 'had_analysis'])
                         ->whereHas('integration', function ($q) {
                             $q->where('user_id', $this->user->id);
                         })
-                        ->where('time', '>=', $today);
+                        ->whereBetween('time', [$dayStartUtc, $dayEndUtc]);
                 })
                 ->with(['event.target'])
                 ->orderBy('created_at', 'desc')

--- a/app/Jobs/Flint/TriggerFlintDigestRoutineJob.php
+++ b/app/Jobs/Flint/TriggerFlintDigestRoutineJob.php
@@ -13,6 +13,7 @@ use Illuminate\Queue\SerializesModels;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\Log;
+use Throwable;
 
 /**
  * Fires the outbound webhook that asks the Claude Code Routine to generate a
@@ -56,7 +57,7 @@ class TriggerFlintDigestRoutineJob implements ShouldQueue
     {
         $markerKey = self::markerKey($this->user->id, $this->localDate, $this->period);
 
-        if (Cache::has($markerKey)) {
+        if (! Cache::add($markerKey, true, $this->markerTtlSeconds())) {
             Log::info('Flint routine trigger skipped (already triggered)', [
                 'user_id' => $this->user->id,
                 'period' => $this->period,
@@ -72,7 +73,6 @@ class TriggerFlintDigestRoutineJob implements ShouldQueue
                 'period' => $this->period,
                 'local_date' => $this->localDate,
             ]);
-            Cache::put($markerKey, true, $this->markerTtlSeconds());
 
             return;
         }
@@ -84,6 +84,7 @@ class TriggerFlintDigestRoutineJob implements ShouldQueue
                 'user_id' => $this->user->id,
                 'period' => $this->period,
             ]);
+            Cache::forget($markerKey);
 
             return;
         }
@@ -95,15 +96,22 @@ class TriggerFlintDigestRoutineJob implements ShouldQueue
             'timezone' => $this->timezone,
             'trigger_reason' => $this->triggerReason,
             'sleep_score_event_id' => $this->sleepScoreEventId,
+            'idempotency_key' => $markerKey,
         ];
 
-        $request = Http::withSentryTracing()->asJson();
+        $request = Http::withSentryTracing()->asJson()->timeout(20)->connectTimeout(5);
 
         if ($secret = config('services.flint_routine.secret')) {
             $request = $request->withToken($secret);
         }
 
-        $response = $request->post($url, $payload);
+        try {
+            $response = $request->post($url, $payload);
+        } catch (Throwable $exception) {
+            Cache::forget($markerKey);
+
+            throw $exception;
+        }
 
         if (! $response->successful()) {
             Log::error('Flint routine webhook returned a non-2xx response', [
@@ -112,10 +120,9 @@ class TriggerFlintDigestRoutineJob implements ShouldQueue
                 'status' => $response->status(),
             ]);
 
+            Cache::forget($markerKey);
             $response->throw();
         }
-
-        Cache::put($markerKey, true, $this->markerTtlSeconds());
 
         Log::info('Flint routine webhook triggered', [
             'user_id' => $this->user->id,

--- a/app/Jobs/Flint/TriggerFlintDigestRoutineJob.php
+++ b/app/Jobs/Flint/TriggerFlintDigestRoutineJob.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace App\Jobs\Flint;
+
+use App\Models\Event;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Fires the outbound webhook that asks the Claude Code Routine to generate a
+ * Flint digest. Spark owns the timing (resolved in the user's effective
+ * timezone); the routine owns generation and calls back via the
+ * create-flint-digest MCP tool.
+ *
+ * Idempotent per (user, local date, period): a Redis marker plus an
+ * existing-digest guard ensure the routine is only triggered once per slot.
+ */
+class TriggerFlintDigestRoutineJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 3;
+
+    public int $timeout = 30;
+
+    /** @var array<int, int> */
+    public array $backoff = [30, 120, 300];
+
+    public function __construct(
+        public User $user,
+        public string $period,
+        public string $localDate,
+        public string $timezone,
+        public string $triggerReason,
+        public ?string $sleepScoreEventId = null,
+    ) {}
+
+    /**
+     * Cache key marking that this user's digest for this local date + period has
+     * already been triggered.
+     */
+    public static function markerKey(int|string $userId, string $localDate, string $period): string
+    {
+        return "flint:digest-triggered:{$userId}:{$localDate}:{$period}";
+    }
+
+    public function handle(): void
+    {
+        $markerKey = self::markerKey($this->user->id, $this->localDate, $this->period);
+
+        if (Cache::has($markerKey)) {
+            Log::info('Flint routine trigger skipped (already triggered)', [
+                'user_id' => $this->user->id,
+                'period' => $this->period,
+                'local_date' => $this->localDate,
+            ]);
+
+            return;
+        }
+
+        if ($this->digestAlreadyExists()) {
+            Log::info('Flint routine trigger skipped (digest already exists)', [
+                'user_id' => $this->user->id,
+                'period' => $this->period,
+                'local_date' => $this->localDate,
+            ]);
+            Cache::put($markerKey, true, $this->markerTtlSeconds());
+
+            return;
+        }
+
+        $url = config('services.flint_routine.url');
+
+        if (empty($url)) {
+            Log::warning('Flint routine webhook URL not configured; skipping trigger', [
+                'user_id' => $this->user->id,
+                'period' => $this->period,
+            ]);
+
+            return;
+        }
+
+        $payload = [
+            'user_id' => (string) $this->user->id,
+            'period' => $this->period,
+            'local_date' => $this->localDate,
+            'timezone' => $this->timezone,
+            'trigger_reason' => $this->triggerReason,
+            'sleep_score_event_id' => $this->sleepScoreEventId,
+        ];
+
+        $request = Http::withSentryTracing()->asJson();
+
+        if ($secret = config('services.flint_routine.secret')) {
+            $request = $request->withToken($secret);
+        }
+
+        $response = $request->post($url, $payload);
+
+        if (! $response->successful()) {
+            Log::error('Flint routine webhook returned a non-2xx response', [
+                'user_id' => $this->user->id,
+                'period' => $this->period,
+                'status' => $response->status(),
+            ]);
+
+            $response->throw();
+        }
+
+        Cache::put($markerKey, true, $this->markerTtlSeconds());
+
+        Log::info('Flint routine webhook triggered', [
+            'user_id' => $this->user->id,
+            'period' => $this->period,
+            'local_date' => $this->localDate,
+            'timezone' => $this->timezone,
+            'trigger_reason' => $this->triggerReason,
+        ]);
+    }
+
+    /**
+     * Whether a Flint digest for this user/period/local date already exists,
+     * scoped to the user's own Flint integration(s).
+     */
+    private function digestAlreadyExists(): bool
+    {
+        $start = Carbon::parse($this->localDate, $this->timezone)->startOfDay()->utc();
+        $end = Carbon::parse($this->localDate, $this->timezone)->endOfDay()->utc();
+
+        return Event::query()
+            ->where('service', 'flint')
+            ->where('action', 'had_summary')
+            ->whereHas('integration', fn ($q) => $q->where('user_id', $this->user->id))
+            ->whereJsonContains('event_metadata->period', $this->period)
+            ->whereBetween('time', [$start, $end])
+            ->exists();
+    }
+
+    /**
+     * Seconds remaining until the end of the effective-local day, so the marker
+     * naturally expires once the slot has passed.
+     */
+    private function markerTtlSeconds(): int
+    {
+        $endOfDay = Carbon::parse($this->localDate, $this->timezone)->endOfDay();
+
+        return max(60, now()->diffInSeconds($endOfDay, false));
+    }
+}

--- a/app/Jobs/TaskPipeline/Tasks/DispatchMorningDigestOnSleepScoreTask.php
+++ b/app/Jobs/TaskPipeline/Tasks/DispatchMorningDigestOnSleepScoreTask.php
@@ -30,7 +30,7 @@ class DispatchMorningDigestOnSleepScoreTask extends BaseTaskJob
         }
 
         $settings = $user->settings['flint'] ?? [];
-        if (($settings['digests_enabled'] ?? false) === false) {
+        if (! ($settings['digests_enabled'] ?? false)) {
             return;
         }
 

--- a/app/Jobs/TaskPipeline/Tasks/DispatchMorningDigestOnSleepScoreTask.php
+++ b/app/Jobs/TaskPipeline/Tasks/DispatchMorningDigestOnSleepScoreTask.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace App\Jobs\TaskPipeline\Tasks;
+
+use App\Jobs\Flint\TriggerFlintDigestRoutineJob;
+use App\Jobs\TaskPipeline\BaseTaskJob;
+use App\Services\EffectiveTimezoneResolver;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Fires the morning Flint digest the moment the Oura sleep-score event lands,
+ * provided the morning slot has already passed. This realises the "later of the
+ * morning slot and the sleep event" barrier with low latency; the 15-minute
+ * dispatcher in routes/console.php is the backstop for the other cases (sleep
+ * arrived before the slot, or never arrived → fallback cutoff).
+ *
+ * Triggered on creation of an `oura/had_sleep_score` event.
+ */
+class DispatchMorningDigestOnSleepScoreTask extends BaseTaskJob
+{
+    protected function execute(): void
+    {
+        $event = $this->model;
+        $user = $event->integration?->user;
+
+        if (! $user) {
+            return;
+        }
+
+        $settings = $user->settings['flint'] ?? [];
+        if (($settings['digests_enabled'] ?? false) === false) {
+            return;
+        }
+
+        $resolver = app(EffectiveTimezoneResolver::class);
+        $tz = $resolver->timezoneFor($user);
+        $now = $resolver->now($user);
+        $today = $resolver->today($user)->toDateString();
+
+        // Only react to the sleep score for the day we are waking into; ignore
+        // historical back-fill (Oura pulls up to 7 days).
+        $sleepDay = $event->event_metadata['day'] ?? null;
+        if ($sleepDay !== $today) {
+            return;
+        }
+
+        $isWeekend = $now->isWeekend();
+        $morningTime = $isWeekend
+            ? ($settings['morning_time_weekend'] ?? config('services.flint_routine.morning_time_weekend'))
+            : ($settings['morning_time_weekday'] ?? config('services.flint_routine.morning_time_weekday'));
+
+        // Before the morning slot: let the dispatcher fire it at the slot instead.
+        if ($now->lt(Carbon::parse($morningTime, $tz))) {
+            return;
+        }
+
+        $marker = TriggerFlintDigestRoutineJob::markerKey($user->id, $today, 'morning');
+        if (Cache::has($marker)) {
+            return;
+        }
+
+        Log::info('Dispatching morning Flint digest on sleep-score arrival', [
+            'user_id' => $user->id,
+            'sleep_event_id' => $event->id,
+            'local_date' => $today,
+        ]);
+
+        dispatch(new TriggerFlintDigestRoutineJob($user, 'morning', $today, $tz, 'sleep_score', $event->id))
+            ->onQueue('flint');
+    }
+}

--- a/app/Jobs/TaskPipeline/Tasks/NotifyOnDigestReadyTask.php
+++ b/app/Jobs/TaskPipeline/Tasks/NotifyOnDigestReadyTask.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Jobs\TaskPipeline\Tasks;
+
+use App\Jobs\Flint\SendDigestNotificationJob;
+use App\Jobs\TaskPipeline\BaseTaskJob;
+use Illuminate\Support\Facades\Log;
+
+/**
+ * Sends the "digest ready" notification when a Flint digest is actually written,
+ * rather than on a fixed clock. Morning timing is now variable (it waits on the
+ * Oura sleep-score event), so notification must follow generation.
+ *
+ * Triggered on creation of a `flint/had_summary` event.
+ */
+class NotifyOnDigestReadyTask extends BaseTaskJob
+{
+    protected function execute(): void
+    {
+        $event = $this->model;
+        $user = $event->integration?->user;
+
+        if (! $user) {
+            return;
+        }
+
+        $period = $event->event_metadata['period'] ?? null;
+
+        // SendDigestNotificationJob infers the period from a schedule-time string;
+        // map the digest's period onto a representative time so it resolves the
+        // same period when it looks up today's digest blocks.
+        $scheduleTime = match ($period) {
+            'morning' => '08:00',
+            'afternoon' => '13:00',
+            default => '19:00',
+        };
+
+        Log::info('Dispatching digest notification on digest readiness', [
+            'user_id' => $user->id,
+            'event_id' => $event->id,
+            'period' => $period,
+        ]);
+
+        dispatch(new SendDigestNotificationJob($user, $scheduleTime))->onQueue('flint');
+    }
+}

--- a/app/Livewire/Day.php
+++ b/app/Livewire/Day.php
@@ -9,6 +9,8 @@ use App\Integrations\PluginRegistry;
 use App\Jobs\Outline\OutlinePullTodayDayNote;
 use App\Models\Event;
 use App\Models\Integration;
+use App\Models\User;
+use App\Services\EffectiveTimezoneResolver;
 use App\Traits\HasProgressiveLoading;
 use Carbon\Carbon;
 use Illuminate\Contracts\View\View;
@@ -67,20 +69,24 @@ class Day extends Component
 
     public function mount(): void
     {
-        // Initialize date from route
+        // Initialize date from route, using the user's effective timezone so the
+        // "today"/"yesterday"/"tomorrow" boundaries match what the user sees (CRX-682).
+        $user = auth()->guard('web')->user();
+        $today = user_today($user);
+
         try {
             if (request()->routeIs('today.*')) {
-                $this->date = Carbon::today()->format('Y-m-d');
+                $this->date = $today->format('Y-m-d');
             } elseif (request()->routeIs('day.yesterday')) {
-                $this->date = Carbon::yesterday()->format('Y-m-d');
+                $this->date = $today->copy()->subDay()->format('Y-m-d');
             } elseif (request()->routeIs('tomorrow')) {
-                $this->date = Carbon::tomorrow()->format('Y-m-d');
+                $this->date = $today->copy()->addDay()->format('Y-m-d');
             } else {
                 $param = request()->route('date');
-                $this->date = $param ? Carbon::parse($param)->format('Y-m-d') : Carbon::today()->format('Y-m-d');
+                $this->date = $param ? Carbon::parse($param)->format('Y-m-d') : $today->format('Y-m-d');
             }
         } catch (Throwable $e) {
-            $this->date = Carbon::today()->format('Y-m-d');
+            $this->date = $today->format('Y-m-d');
         }
 
         // Initialize collections
@@ -105,11 +111,18 @@ class Day extends Component
             return;
         }
 
+        $user = auth()->guard('web')->user();
+        $timezone = $user ? $this->timezoneForDate($user, $this->date) : 'UTC';
+
+        // Resolve the selected local day's bounds in the user's effective timezone,
+        // then convert to UTC for the (UTC-stored) `time` column query (CRX-682).
         try {
-            $selectedDate = Carbon::parse($this->date);
+            $dayStart = Carbon::parse($this->date, $timezone)->startOfDay();
         } catch (Throwable $e) {
-            $selectedDate = Carbon::today();
+            $dayStart = Carbon::today($timezone);
         }
+        $dayStartUtc = $dayStart->copy()->utc();
+        $dayEndUtc = $dayStart->copy()->endOfDay()->utc();
 
         // Load events with actor and target relationships
         // These are essential for display and must load together
@@ -135,7 +148,7 @@ class Day extends Component
                     $q->whereRaw('1 = 0');
                 }
             })
-            ->whereDate('time', $selectedDate)
+            ->whereBetween('time', [$dayStartUtc, $dayEndUtc])
             ->orderBy('time', 'desc');
 
         $this->allEvents = $query->get();
@@ -508,28 +521,31 @@ class Day extends Component
     public function navigateToDate(): void
     {
         try {
-            $selected = Carbon::parse($this->date)->startOfDay();
-            $today = Carbon::today();
+            // Compare calendar dates in the user's effective timezone (CRX-682),
+            // not absolute instants, so the "today/yesterday/tomorrow" routes resolve
+            // correctly for non-UTC users.
+            $selected = Carbon::parse($this->date)->format('Y-m-d');
+            $today = user_today(auth()->guard('web')->user());
 
-            if ($selected->equalTo($today)) {
+            if ($selected === $today->format('Y-m-d')) {
                 $this->redirect(route('today.main'), navigate: true);
 
                 return;
             }
 
-            if ($selected->equalTo($today->copy()->subDay())) {
+            if ($selected === $today->copy()->subDay()->format('Y-m-d')) {
                 $this->redirect(route('day.yesterday'), navigate: true);
 
                 return;
             }
 
-            if ($selected->equalTo($today->copy()->addDay())) {
+            if ($selected === $today->copy()->addDay()->format('Y-m-d')) {
                 $this->redirect(route('tomorrow'), navigate: true);
 
                 return;
             }
 
-            $this->redirect(route('day.show', ['date' => $selected->format('Y-m-d')]), navigate: true);
+            $this->redirect(route('day.show', ['date' => $selected]), navigate: true);
         } catch (Throwable $e) {
             // Ignore
         }
@@ -1030,5 +1046,30 @@ class Day extends Component
         ]);
 
         $this->filteredEvents = $filtered->values();
+    }
+
+    /**
+     * Resolve the IANA timezone to render a given local date in.
+     *
+     * The current and future days always use the live effective timezone, so
+     * "today" never regresses (CRX-682). Past days use point-in-time resolution —
+     * the timezone that was acknowledged on that date — probed at noon UTC of the
+     * target date to break the tz/day-boundary circularity at extreme offsets.
+     */
+    private function timezoneForDate(User $user, string $date): string
+    {
+        $resolver = app(EffectiveTimezoneResolver::class);
+
+        try {
+            $isPast = $date < $resolver->today($user)->toDateString();
+        } catch (Throwable $e) {
+            return $resolver->timezoneFor($user);
+        }
+
+        if (! $isPast) {
+            return $resolver->timezoneFor($user);
+        }
+
+        return $resolver->timezoneForAt($user, Carbon::parse($date, 'UTC')->setTime(12, 0));
     }
 }

--- a/app/Mcp/Tools/CreateFlintDigestTool.php
+++ b/app/Mcp/Tools/CreateFlintDigestTool.php
@@ -2,6 +2,7 @@
 
 namespace App\Mcp\Tools;
 
+use App\Jobs\Flint\SendDigestNotificationJob;
 use App\Models\Event;
 use App\Models\EventObject;
 use App\Models\Integration;
@@ -152,6 +153,9 @@ class CreateFlintDigestTool extends Tool
 
             $blockIds[] = $block->id;
         }
+
+        dispatch(new SendDigestNotificationJob($user, '00:00', $period, (string) $event->id))
+            ->onQueue('flint');
 
         return Response::text(json_encode([
             'event_id' => $event->id,

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -12,12 +12,13 @@ use App\Notifications\SparkNotification;
 use App\Observers\BlockObserver;
 use App\Observers\EventObjectObserver;
 use App\Observers\EventObserver;
+use App\Services\EffectiveTimezoneResolver;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Console\Events\ScheduledTaskFailed;
 use Illuminate\Console\Events\ScheduledTaskFinished;
 use Illuminate\Notifications\Events\NotificationSent;
-use Illuminate\Support\Facades\Event;
 /** @phpstan-ignore-next-line */
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Facades\Redis;
@@ -39,7 +40,10 @@ class AppServiceProvider extends ServiceProvider
      */
     public function register(): void
     {
-        //
+        // Memoize effective-timezone resolution within a single request or queued
+        // job. `scoped` (not `singleton`) so long-lived Horizon workers flush the
+        // memo between jobs and pick up a freshly acknowledged timezone.
+        $this->app->scoped(EffectiveTimezoneResolver::class);
     }
 
     /**

--- a/app/Providers/TaskPipelineServiceProvider.php
+++ b/app/Providers/TaskPipelineServiceProvider.php
@@ -277,24 +277,6 @@ class TaskPipelineServiceProvider extends ServiceProvider
             runOnUpdate: false,
         ));
 
-        // Digest notification - notify the user when a Flint digest is written,
-        // rather than on a fixed clock (morning timing is variable).
-        TaskRegistry::register(new TaskDefinition(
-            key: 'notify_on_digest_ready',
-            name: 'Notify on Digest Ready',
-            description: 'Send the daily digest notification when a Flint digest summary is created',
-            jobClass: NotifyOnDigestReadyTask::class,
-            appliesTo: ['event'],
-            conditions: [
-                'service' => 'flint',
-                'action' => 'had_summary',
-            ],
-            dependencies: [],
-            queue: 'tasks',
-            priority: 40,
-            runOnCreate: true,
-            runOnUpdate: false,
-        ));
     }
 
     /**

--- a/app/Providers/TaskPipelineServiceProvider.php
+++ b/app/Providers/TaskPipelineServiceProvider.php
@@ -257,6 +257,44 @@ class TaskPipelineServiceProvider extends ServiceProvider
             runOnCreate: true,
             runOnUpdate: false,
         ));
+
+        // Morning Flint digest trigger - fires the digest routine the moment the
+        // Oura sleep-score event lands (when the morning slot has already passed).
+        TaskRegistry::register(new TaskDefinition(
+            key: 'dispatch_morning_digest_on_sleep_score',
+            name: 'Dispatch Morning Digest on Sleep Score',
+            description: 'Trigger the morning Flint digest routine when the Oura sleep score arrives',
+            jobClass: DispatchMorningDigestOnSleepScoreTask::class,
+            appliesTo: ['event'],
+            conditions: [
+                'service' => 'oura',
+                'action' => 'had_sleep_score',
+            ],
+            dependencies: [],
+            queue: 'tasks',
+            priority: 40,
+            runOnCreate: true,
+            runOnUpdate: false,
+        ));
+
+        // Digest notification - notify the user when a Flint digest is written,
+        // rather than on a fixed clock (morning timing is variable).
+        TaskRegistry::register(new TaskDefinition(
+            key: 'notify_on_digest_ready',
+            name: 'Notify on Digest Ready',
+            description: 'Send the daily digest notification when a Flint digest summary is created',
+            jobClass: NotifyOnDigestReadyTask::class,
+            appliesTo: ['event'],
+            conditions: [
+                'service' => 'flint',
+                'action' => 'had_summary',
+            ],
+            dependencies: [],
+            queue: 'tasks',
+            priority: 40,
+            runOnCreate: true,
+            runOnUpdate: false,
+        ));
     }
 
     /**

--- a/app/Services/EffectiveTimezoneResolver.php
+++ b/app/Services/EffectiveTimezoneResolver.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace App\Services;
+
+use App\Integrations\DailyCheckin\DailyCheckinPlugin;
+use App\Models\User;
+use Carbon\Carbon;
+
+/**
+ * Resolves a user's effective timezone — the latest acknowledged "time travel"
+ * timezone (CRX-723), falling back to the profile timezone and finally UTC.
+ *
+ * Wraps {@see DailyCheckinPlugin::resolveEffectiveTimezone()} with per-process
+ * memoization so the rewired time helpers don't issue a query on every call.
+ * Registered as a singleton so the memo lives for the lifetime of the request
+ * or queue worker, and is naturally fresh between tests.
+ *
+ * Precedence: request context (explicit) → acknowledged time_travel → users.timezone → UTC.
+ */
+class EffectiveTimezoneResolver
+{
+    /** @var array<string, string> Memoized [userId => IANA timezone]. */
+    private array $memo = [];
+
+    /** @var array<string, string> Memoized [userId@unixTimestamp => IANA timezone] for point-in-time lookups. */
+    private array $pointInTimeMemo = [];
+
+    public function __construct(private DailyCheckinPlugin $plugin) {}
+
+    /**
+     * The user's effective IANA timezone identifier, or 'UTC' when no user.
+     */
+    public function timezoneFor(?User $user): string
+    {
+        if ($user === null) {
+            return 'UTC';
+        }
+
+        $key = (string) $user->id;
+
+        if (! array_key_exists($key, $this->memo)) {
+            $this->memo[$key] = $this->plugin->resolveEffectiveTimezone($user)['timezone'] ?? 'UTC';
+        }
+
+        return $this->memo[$key];
+    }
+
+    /**
+     * The user's effective IANA timezone identifier as of a given instant — the
+     * timezone acknowledged at-or-before `$instant`, falling back to the profile
+     * timezone and finally UTC. Used to render a historical day in the timezone
+     * that was in effect on that date.
+     *
+     * For the present instant this returns the same value as {@see timezoneFor()};
+     * it only diverges when an acknowledgement was made after `$instant`.
+     */
+    public function timezoneForAt(?User $user, Carbon $instant): string
+    {
+        if ($user === null) {
+            return 'UTC';
+        }
+
+        $key = $user->id . '@' . $instant->getTimestamp();
+
+        if (! array_key_exists($key, $this->pointInTimeMemo)) {
+            $event = $this->plugin->getLatestTimezoneEventAt($user->id, $instant);
+            $this->pointInTimeMemo[$key] = ($event?->event_metadata['timezone'] ?? null) ?? $user->getTimezone();
+        }
+
+        return $this->pointInTimeMemo[$key];
+    }
+
+    /**
+     * The current time in the user's effective timezone.
+     */
+    public function now(?User $user): Carbon
+    {
+        return Carbon::now($this->timezoneFor($user));
+    }
+
+    /**
+     * Today (midnight) in the user's effective timezone.
+     */
+    public function today(?User $user): Carbon
+    {
+        return Carbon::today($this->timezoneFor($user));
+    }
+
+    /**
+     * Convert a datetime into the user's effective timezone. Returns the value
+     * unchanged when no user is provided.
+     */
+    public function convert(Carbon $datetime, ?User $user): Carbon
+    {
+        if ($user === null) {
+            return $datetime;
+        }
+
+        return $datetime->copy()->setTimezone($this->timezoneFor($user));
+    }
+
+    /**
+     * Forget memoized timezone(s). Pass a user to bust a single entry, or null
+     * to clear everything (e.g. after acknowledging a new timezone in a test).
+     */
+    public function forget(?User $user = null): void
+    {
+        if ($user === null) {
+            $this->memo = [];
+            $this->pointInTimeMemo = [];
+
+            return;
+        }
+
+        unset($this->memo[(string) $user->id]);
+
+        foreach (array_keys($this->pointInTimeMemo) as $key) {
+            if (str_starts_with($key, $user->id . '@')) {
+                unset($this->pointInTimeMemo[$key]);
+            }
+        }
+    }
+}

--- a/app/Services/Mobile/ObjectLookup.php
+++ b/app/Services/Mobile/ObjectLookup.php
@@ -25,6 +25,7 @@ class ObjectLookup
         return EventObject::query()
             ->where('user_id', $user->id)
             ->where('id', $objectId)
+            ->with('tags')
             ->first();
     }
 

--- a/app/Support/helpers.php
+++ b/app/Support/helpers.php
@@ -4,6 +4,7 @@ use App\Integrations\PluginRegistry;
 use App\Models\Integration;
 use App\Models\IntegrationGroup;
 use App\Models\User;
+use App\Services\EffectiveTimezoneResolver;
 use App\Services\LoggingService;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
@@ -16,44 +17,35 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 
 if (! function_exists('user_now')) {
     /**
-     * Get the current time in the user's timezone.
+     * Get the current time in the user's effective timezone (latest acknowledged
+     * travel timezone, falling back to the profile timezone, then UTC).
      * If no user is provided, falls back to UTC.
      */
     function user_now(?User $user = null): Carbon
     {
-        $timezone = $user?->getTimezone() ?? 'UTC';
-
-        return Carbon::now($timezone);
+        return app(EffectiveTimezoneResolver::class)->now($user);
     }
 }
 
 if (! function_exists('user_today')) {
     /**
-     * Get today's date in the user's timezone.
+     * Get today's date in the user's effective timezone.
      * If no user is provided, falls back to UTC.
      */
     function user_today(?User $user = null): Carbon
     {
-        $timezone = $user?->getTimezone() ?? 'UTC';
-
-        return Carbon::today($timezone);
+        return app(EffectiveTimezoneResolver::class)->today($user);
     }
 }
 
 if (! function_exists('to_user_timezone')) {
     /**
-     * Convert a datetime to the user's timezone.
+     * Convert a datetime to the user's effective timezone.
      * If no user is provided, returns the datetime as-is.
      */
     function to_user_timezone(Carbon $datetime, ?User $user = null): Carbon
     {
-        if (! $user) {
-            return $datetime;
-        }
-
-        $timezone = $user->getTimezone();
-
-        return $datetime->copy()->setTimezone($timezone);
+        return app(EffectiveTimezoneResolver::class)->convert($datetime, $user);
     }
 }
 

--- a/config/services.php
+++ b/config/services.php
@@ -214,4 +214,16 @@ return [
         'cache_ttl_hours' => (int) env('METOFFICE_CACHE_TTL', 1),
     ],
 
+    // Claude Code Routine webhook that generates Flint morning/evening digests.
+    // Spark owns the timing (in the user's effective timezone) and POSTs to the
+    // routine, which calls back via the create-flint-digest MCP tool.
+    'flint_routine' => [
+        'url' => env('FLINT_ROUTINE_WEBHOOK_URL'),
+        'secret' => env('FLINT_ROUTINE_WEBHOOK_SECRET'),
+        'morning_time_weekday' => env('FLINT_MORNING_WEEKDAY', '07:30'),
+        'morning_time_weekend' => env('FLINT_MORNING_WEEKEND', '09:30'),
+        'evening_time' => env('FLINT_EVENING_TIME', '19:30'),
+        'morning_fallback' => env('FLINT_MORNING_FALLBACK', '11:00'),
+    ],
+
 ];

--- a/routes/console.php
+++ b/routes/console.php
@@ -4,14 +4,16 @@ use App\Jobs\CheckIntegrationUpdates;
 use App\Jobs\Fetch\CheckCookieExpiryJob;
 use App\Jobs\Fetch\RefreshExpiringCookies;
 use App\Jobs\Flint\RunPatternDetectionJob;
-use App\Jobs\Flint\RunPreDigestRefreshJob;
-use App\Jobs\Flint\SendDigestNotificationJob;
+use App\Jobs\Flint\TriggerFlintDigestRoutineJob;
 use App\Jobs\TaskPipeline\DispatchRetrospectiveAnomalyTasksJob;
 use App\Jobs\TaskPipeline\DispatchTrendDetectionTasksJob;
+use App\Models\Event;
 use App\Models\User;
+use App\Services\EffectiveTimezoneResolver;
 use Carbon\Carbon;
 use Illuminate\Foundation\Inspiring;
 use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schedule;
 use Laravel\Horizon\Console\SnapshotCommand;
@@ -68,81 +70,59 @@ Schedule::job(new RefreshExpiringCookies)
 // Flint digest dispatcher (runs every 15 minutes to check for scheduled digests)
 // New flow: -15min = agents run + digest generation, 0min = send notification
 Schedule::call(function () {
+    $resolver = app(EffectiveTimezoneResolver::class);
+
+    // The id of the user's Oura sleep-score event for a local wake date, or null
+    // if it hasn't been ingested yet. Used to gate the morning digest.
+    $sleepScoreEventIdFor = fn (User $user, string $localDate): ?string => Event::query()
+        ->where('service', 'oura')
+        ->where('action', 'had_sleep_score')
+        ->whereHas('integration', fn ($q) => $q->where('user_id', $user->id))
+        ->where('event_metadata->day', $localDate)
+        ->value('id');
+
     $users = User::whereNotNull('settings->flint->digests_enabled')
         ->where('settings->flint->digests_enabled', '!=', false)
         ->get();
 
-    $preDigestDispatched = 0;
-    $notificationDispatched = 0;
-
     foreach ($users as $user) {
-
-        Log::info('Checking digest for user', [
-            'user_id' => $user->id,
-        ]);
-
         $settings = $user->settings['flint'] ?? [];
 
-        // Get user's timezone (default to Europe/London)
-        $userTimezone = $settings['schedule_timezone'] ?? 'Europe/London';
-
-        // Check if it's a weekday or weekend in user's timezone
-        $now = now()->timezone($userTimezone);
+        // Schedule against the user's effective (acknowledged travel) timezone.
+        $tz = $resolver->timezoneFor($user);
+        $now = $resolver->now($user);
+        $today = $resolver->today($user)->toDateString();
         $isWeekend = $now->isWeekend();
 
-        // Get schedule times for this day type
-        $scheduleTimes = $isWeekend
-            ? ($settings['schedule_times_weekend'] ?? ['08:00', '19:00'])
-            : ($settings['schedule_times_weekday'] ?? ['06:00', '18:00']);
+        $morningTime = $isWeekend
+            ? ($settings['morning_time_weekend'] ?? config('services.flint_routine.morning_time_weekend'))
+            : ($settings['morning_time_weekday'] ?? config('services.flint_routine.morning_time_weekday'));
+        $eveningTime = $settings['evening_time'] ?? config('services.flint_routine.evening_time');
+        $fallbackTime = $settings['morning_fallback'] ?? config('services.flint_routine.morning_fallback');
 
-        foreach ($scheduleTimes as $scheduleTime) {
-            Log::info('Evaluating digest schedule', [
-                'user_id' => $user->id,
-                'schedule_time' => $scheduleTime,
-                'timezone' => $userTimezone,
-                'is_weekend' => $isWeekend,
-            ]);
-            // Parse schedule time (e.g., "06:00")
-            $scheduleCarbon = Carbon::parse($scheduleTime, $userTimezone);
-            $minutesUntil = $now->diffInMinutes($scheduleCarbon, false);
+        // Evening digest: pure time gate at the configured evening slot.
+        $eveningMarker = TriggerFlintDigestRoutineJob::markerKey($user->id, $today, 'evening');
+        if ($now->gte(Carbon::parse($eveningTime, $tz)) && ! Cache::has($eveningMarker)) {
+            dispatch(new TriggerFlintDigestRoutineJob($user, 'evening', $today, $tz, 'scheduled'))
+                ->onQueue('flint');
+        }
 
-            // If digest scheduled in the next 15 minutes or sooner, run pre-digest refresh
-            if ($minutesUntil >= 1 && $minutesUntil <= 15) {
-                Log::info('Dispatching pre-digest refresh (15 min before digest)', [
-                    'user_id' => $user->id,
-                    'schedule_time' => $scheduleTime,
-                    'timezone' => $userTimezone,
-                    'is_weekend' => $isWeekend,
-                ]);
+        // Morning digest: fire at the LATER of the morning slot and the Oura
+        // sleep-score event, with a hard fallback cutoff if sleep never arrives.
+        // (Low-latency firing when sleep lands after the slot is handled by
+        // DispatchMorningDigestOnSleepScoreTask; this is the backstop.)
+        $morningMarker = TriggerFlintDigestRoutineJob::markerKey($user->id, $today, 'morning');
+        if ($now->gte(Carbon::parse($morningTime, $tz)) && ! Cache::has($morningMarker)) {
+            $sleepEventId = $sleepScoreEventIdFor($user, $today);
 
-                dispatch(new RunPreDigestRefreshJob($user, $scheduleTime))->onQueue('flint');
-                // Job will auto-chain to RunDigestGenerationJob when agents complete
-
-                $preDigestDispatched++;
-            }
-
-            // If digest scheduled right now, send notification
-            // Allow a small window of -5 to 0 minutes to account for scheduling delays
-            if ($minutesUntil >= -5 && $minutesUntil <= 0) {
-                Log::info('Dispatching digest notification', [
-                    'user_id' => $user->id,
-                    'schedule_time' => $scheduleTime,
-                    'timezone' => $userTimezone,
-                    'is_weekend' => $isWeekend,
-                ]);
-
-                dispatch(new SendDigestNotificationJob($user, $scheduleTime))->onQueue('flint');
-
-                $notificationDispatched++;
+            if ($sleepEventId !== null) {
+                dispatch(new TriggerFlintDigestRoutineJob($user, 'morning', $today, $tz, 'scheduled', $sleepEventId))
+                    ->onQueue('flint');
+            } elseif ($now->gte(Carbon::parse($fallbackTime, $tz))) {
+                dispatch(new TriggerFlintDigestRoutineJob($user, 'morning', $today, $tz, 'fallback'))
+                    ->onQueue('flint');
             }
         }
-    }
-
-    if ($preDigestDispatched > 0 || $notificationDispatched > 0) {
-        Log::info('Flint digest jobs dispatched', [
-            'pre_digest_count' => $preDigestDispatched,
-            'notification_count' => $notificationDispatched,
-        ]);
     }
 })
     ->everyFifteenMinutes()

--- a/routes/mobile.php
+++ b/routes/mobile.php
@@ -79,17 +79,19 @@ Route::get('search', [SearchController::class, 'index'])->name('search.index');
 
 Route::get('tags', [TagsController::class, 'index'])->name('tags.index');
 Route::get('tags/suggest', [TagsController::class, 'suggest'])->name('tags.suggest');
-Route::get('tags/{id}', [TagsController::class, 'show'])->name('tags.show');
+Route::get('tags/{id}', [TagsController::class, 'show'])->whereNumber('id')->name('tags.show');
 Route::post('events/{id}/tags', [TagsController::class, 'storeEventTag'])
     ->middleware('ability:ios:write')
     ->name('events.tags.store');
 Route::delete('events/{id}/tags/{tagId}', [TagsController::class, 'destroyEventTag'])
+    ->whereNumber('tagId')
     ->middleware('ability:ios:write')
     ->name('events.tags.destroy');
 Route::post('objects/{id}/tags', [TagsController::class, 'storeObjectTag'])
     ->middleware('ability:ios:write')
     ->name('objects.tags.store');
 Route::delete('objects/{id}/tags/{tagId}', [TagsController::class, 'destroyObjectTag'])
+    ->whereNumber('tagId')
     ->middleware('ability:ios:write')
     ->name('objects.tags.destroy');
 

--- a/routes/mobile.php
+++ b/routes/mobile.php
@@ -164,6 +164,13 @@ Route::get('check-ins', [CheckInsController::class, 'index'])
 Route::get('check-ins/history', [CheckInsController::class, 'history'])
     ->name('check-ins.history');
 
+Route::get('check-ins/timezone', [CheckInsController::class, 'showTimezone'])
+    ->name('check-ins.timezone.show');
+
+Route::post('check-ins/timezone', [CheckInsController::class, 'storeTimezone'])
+    ->middleware('ability:ios:write')
+    ->name('check-ins.timezone.store');
+
 Route::post('check-ins', [CheckInsController::class, 'store'])
     ->middleware('ability:ios:write')
     ->name('check-ins.store');

--- a/routes/mobile.php
+++ b/routes/mobile.php
@@ -26,6 +26,7 @@ use App\Http\Controllers\Api\V1\Mobile\PingController;
 use App\Http\Controllers\Api\V1\Mobile\PlacesController;
 use App\Http\Controllers\Api\V1\Mobile\SearchController;
 use App\Http\Controllers\Api\V1\Mobile\SyncController;
+use App\Http\Controllers\Api\V1\Mobile\TagsController;
 use App\Http\Controllers\Api\V1\Mobile\UpToSpeedController;
 use App\Http\Controllers\Api\V1\Mobile\UpToSpeedReadController;
 use App\Http\Controllers\Api\V1\Mobile\WidgetsController;
@@ -75,6 +76,22 @@ Route::get('widgets/metrics/{metric}', [WidgetsController::class, 'metric'])->na
 Route::get('widgets/spend', [WidgetsController::class, 'spend'])->name('widgets.spend');
 
 Route::get('search', [SearchController::class, 'index'])->name('search.index');
+
+Route::get('tags', [TagsController::class, 'index'])->name('tags.index');
+Route::get('tags/suggest', [TagsController::class, 'suggest'])->name('tags.suggest');
+Route::get('tags/{id}', [TagsController::class, 'show'])->name('tags.show');
+Route::post('events/{id}/tags', [TagsController::class, 'storeEventTag'])
+    ->middleware('ability:ios:write')
+    ->name('events.tags.store');
+Route::delete('events/{id}/tags/{tagId}', [TagsController::class, 'destroyEventTag'])
+    ->middleware('ability:ios:write')
+    ->name('events.tags.destroy');
+Route::post('objects/{id}/tags', [TagsController::class, 'storeObjectTag'])
+    ->middleware('ability:ios:write')
+    ->name('objects.tags.store');
+Route::delete('objects/{id}/tags/{tagId}', [TagsController::class, 'destroyObjectTag'])
+    ->middleware('ability:ios:write')
+    ->name('objects.tags.destroy');
 
 Route::get('integrations', [IntegrationsController::class, 'index'])->name('integrations.index');
 Route::get('integrations/{id}', [IntegrationsController::class, 'show'])->name('integrations.show');

--- a/tests/Feature/Api/V1/Mobile/CheckInsControllerTest.php
+++ b/tests/Feature/Api/V1/Mobile/CheckInsControllerTest.php
@@ -295,6 +295,231 @@ class CheckInsControllerTest extends TestCase
     }
 
     // -------------------------------------------------------------------------
+    // GET /api/v1/mobile/check-ins/timezone
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function timezone_show_requires_authentication(): void
+    {
+        $this->getJson('/api/v1/mobile/check-ins/timezone')->assertStatus(401);
+    }
+
+    #[Test]
+    public function timezone_show_requires_read_ability(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:write']);
+
+        $this->getJson('/api/v1/mobile/check-ins/timezone')->assertStatus(403);
+    }
+
+    #[Test]
+    public function timezone_show_falls_back_to_profile_timezone(): void
+    {
+        $this->user->setTimezone('Europe/London');
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $this->getJson('/api/v1/mobile/check-ins/timezone')
+            ->assertStatus(200)
+            ->assertExactJson([
+                'timezone' => 'Europe/London',
+                'source' => 'profile',
+                'acknowledged_at' => null,
+                'event_id' => null,
+                'device_id' => null,
+            ]);
+    }
+
+    #[Test]
+    public function timezone_show_defaults_to_utc_without_profile_timezone(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $this->getJson('/api/v1/mobile/check-ins/timezone')
+            ->assertStatus(200)
+            ->assertJsonPath('timezone', 'UTC')
+            ->assertJsonPath('source', 'profile');
+    }
+
+    #[Test]
+    public function timezone_show_returns_latest_acknowledged_event(): void
+    {
+        $this->user->setTimezone('Europe/London');
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson('/api/v1/mobile/check-ins/timezone', [
+            'timezone' => 'America/New_York',
+        ])->assertStatus(201);
+
+        $response = $this->getJson('/api/v1/mobile/check-ins/timezone')->assertStatus(200);
+
+        $this->assertSame('America/New_York', $response->json('timezone'));
+        $this->assertSame('time_travel', $response->json('source'));
+        $this->assertNotNull($response->json('acknowledged_at'));
+        $this->assertNotNull($response->json('event_id'));
+    }
+
+    // -------------------------------------------------------------------------
+    // POST /api/v1/mobile/check-ins/timezone
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function timezone_store_requires_write_ability(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $this->postJson('/api/v1/mobile/check-ins/timezone', ['timezone' => 'America/New_York'])
+            ->assertStatus(403);
+    }
+
+    #[Test]
+    public function timezone_store_creates_single_time_travel_event(): void
+    {
+        $this->user->setTimezone('Europe/London');
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $response = $this->postJson('/api/v1/mobile/check-ins/timezone', [
+            'timezone' => 'America/New_York',
+        ])->assertStatus(201);
+
+        $response->assertJsonPath('timezone', 'America/New_York')
+            ->assertJsonPath('source', 'time_travel');
+
+        $this->assertSame(1, Event::where('service', 'daily_checkin')->where('action', 'time_travel')->count());
+
+        $event = Event::where('action', 'time_travel')->firstOrFail();
+        $this->assertSame('America/New_York', $event->event_metadata['timezone']);
+        $this->assertSame('Europe/London', $event->event_metadata['previous_timezone']);
+        $this->assertSame('user_acknowledged', $event->event_metadata['source']);
+    }
+
+    #[Test]
+    public function timezone_store_persists_device_id(): void
+    {
+        $this->user->setTimezone('Europe/London');
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson('/api/v1/mobile/check-ins/timezone', [
+            'timezone' => 'America/New_York',
+            'device_id' => 'device-123',
+        ])->assertStatus(201)
+            ->assertJsonPath('device_id', 'device-123');
+
+        $event = Event::where('action', 'time_travel')->firstOrFail();
+        $this->assertSame('device-123', $event->event_metadata['device_id']);
+    }
+
+    #[Test]
+    public function timezone_store_derives_previous_timezone_ignoring_client_value(): void
+    {
+        $this->user->setTimezone('Europe/London');
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson('/api/v1/mobile/check-ins/timezone', [
+            'timezone' => 'America/New_York',
+            'previous_timezone' => 'Asia/Tokyo', // contradictory but valid IANA
+        ])->assertStatus(201);
+
+        $event = Event::where('action', 'time_travel')->firstOrFail();
+        $this->assertSame('Europe/London', $event->event_metadata['previous_timezone']);
+    }
+
+    #[Test]
+    public function timezone_store_rejects_invalid_identifier(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson('/api/v1/mobile/check-ins/timezone', ['timezone' => 'Mars/Phobos'])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['timezone']);
+    }
+
+    #[Test]
+    public function timezone_store_rejects_utc_offset_only_value(): void
+    {
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson('/api/v1/mobile/check-ins/timezone', ['timezone' => '+05:00'])
+            ->assertStatus(422)
+            ->assertJsonValidationErrors(['timezone']);
+    }
+
+    #[Test]
+    public function timezone_store_is_idempotent_for_already_effective_zone(): void
+    {
+        $this->user->setTimezone('Europe/London');
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        // Submitting the already-effective profile timezone is a no-op.
+        $this->postJson('/api/v1/mobile/check-ins/timezone', ['timezone' => 'Europe/London'])
+            ->assertStatus(200)
+            ->assertJsonPath('source', 'profile');
+
+        $this->assertSame(0, Event::where('action', 'time_travel')->count());
+
+        // Acknowledge a real change, then re-submit the same zone — still no dupe.
+        $this->postJson('/api/v1/mobile/check-ins/timezone', ['timezone' => 'America/New_York'])
+            ->assertStatus(201);
+        $this->postJson('/api/v1/mobile/check-ins/timezone', ['timezone' => 'America/New_York'])
+            ->assertStatus(200);
+
+        $this->assertSame(1, Event::where('action', 'time_travel')->count());
+    }
+
+    #[Test]
+    public function timezone_store_records_subsequent_changes_with_latest_winning(): void
+    {
+        $this->user->setTimezone('Europe/London');
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson('/api/v1/mobile/check-ins/timezone', ['timezone' => 'America/New_York'])
+            ->assertStatus(201);
+        $this->postJson('/api/v1/mobile/check-ins/timezone', ['timezone' => 'Asia/Tokyo'])
+            ->assertStatus(201);
+
+        $this->assertSame(2, Event::where('action', 'time_travel')->count());
+
+        $this->getJson('/api/v1/mobile/check-ins/timezone')
+            ->assertStatus(200)
+            ->assertJsonPath('timezone', 'Asia/Tokyo');
+
+        // The second event's derived previous timezone is the first acknowledged zone.
+        $latest = Event::where('action', 'time_travel')->orderByDesc('time')->orderByDesc('id')->first();
+        $this->assertSame('America/New_York', $latest->event_metadata['previous_timezone']);
+    }
+
+    #[Test]
+    public function timezone_store_does_not_mutate_profile_timezone(): void
+    {
+        $this->user->setTimezone('Europe/London');
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson('/api/v1/mobile/check-ins/timezone', ['timezone' => 'America/New_York'])
+            ->assertStatus(201);
+
+        $this->assertSame('Europe/London', $this->user->fresh()->getTimezone());
+    }
+
+    #[Test]
+    public function timezone_state_is_scoped_to_the_authenticated_user(): void
+    {
+        $this->user->setTimezone('Europe/London');
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+        $this->postJson('/api/v1/mobile/check-ins/timezone', ['timezone' => 'America/New_York'])
+            ->assertStatus(201);
+
+        $other = User::factory()->create();
+        $other->setTimezone('Australia/Sydney');
+        Sanctum::actingAs($other, ['ios:read']);
+
+        // The other user sees only their own profile fallback, never the first
+        // user's acknowledged travel timezone.
+        $this->getJson('/api/v1/mobile/check-ins/timezone')
+            ->assertStatus(200)
+            ->assertJsonPath('timezone', 'Australia/Sydney')
+            ->assertJsonPath('source', 'profile');
+    }
+
+    // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
 

--- a/tests/Feature/Api/V1/Mobile/CheckInsControllerTest.php
+++ b/tests/Feature/Api/V1/Mobile/CheckInsControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\Api\V1\Mobile;
 
+use App\Integrations\DailyCheckin\DailyCheckinPlugin;
 use App\Models\Event;
 use App\Models\Integration;
 use App\Models\IntegrationGroup;
@@ -482,8 +483,9 @@ class CheckInsControllerTest extends TestCase
             ->assertStatus(200)
             ->assertJsonPath('timezone', 'Asia/Tokyo');
 
-        // The second event's derived previous timezone is the first acknowledged zone.
-        $latest = Event::where('action', 'time_travel')->orderByDesc('time')->orderByDesc('id')->first();
+        // The latest event's derived previous timezone is the first acknowledged zone.
+        $latest = (new DailyCheckinPlugin)->getLatestTimezoneEvent($this->user->id);
+        $this->assertSame('Asia/Tokyo', $latest->event_metadata['timezone']);
         $this->assertSame('America/New_York', $latest->event_metadata['previous_timezone']);
     }
 

--- a/tests/Feature/Api/V1/Mobile/TagsControllerTest.php
+++ b/tests/Feature/Api/V1/Mobile/TagsControllerTest.php
@@ -135,6 +135,7 @@ class TagsControllerTest extends TestCase
     {
         $object = EventObject::factory()->create(['user_id' => $this->user->id]);
         $tag = Tag::findOrCreate('person', 'spark');
+        $this->createEvent('Tagged')->attachTags([$tag]);
         Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
 
         $this->postJson("/api/v1/mobile/objects/{$object->id}/tags", [
@@ -145,6 +146,21 @@ class TagsControllerTest extends TestCase
         $this->getJson("/api/v1/mobile/objects/{$object->id}")
             ->assertOk()
             ->assertJsonPath('tags.0.id', (string) $tag->id);
+    }
+
+    #[Test]
+    public function cannot_attach_a_tag_that_is_not_visible_to_the_user(): void
+    {
+        $event = $this->createEvent('Tagged');
+        $hidden = Tag::findOrCreate('private-other-user-tag', 'spark');
+        $otherObject = EventObject::factory()->create(['user_id' => User::factory()->create()->id]);
+        $otherObject->attachTags([$hidden]);
+
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson("/api/v1/mobile/events/{$event->id}/tags", [
+            'tag_id' => $hidden->id,
+        ])->assertNotFound();
     }
 
     #[Test]

--- a/tests/Feature/Api/V1/Mobile/TagsControllerTest.php
+++ b/tests/Feature/Api/V1/Mobile/TagsControllerTest.php
@@ -1,0 +1,199 @@
+<?php
+
+namespace Tests\Feature\Api\V1\Mobile;
+
+use App\Models\Event;
+use App\Models\EventObject;
+use App\Models\Integration;
+use App\Models\IntegrationGroup;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use PHPUnit\Framework\Attributes\Test;
+use Spatie\Tags\Tag;
+use Tests\TestCase;
+
+class TagsControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $user;
+
+    protected Integration $integration;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config(['ios.mobile_api_enabled' => true]);
+        config(['app.enable_task_pipeline' => false]);
+
+        $this->user = User::factory()->create();
+        $group = IntegrationGroup::factory()->create([
+            'user_id' => $this->user->id,
+            'service' => 'test',
+        ]);
+        $this->integration = Integration::factory()->create([
+            'user_id' => $this->user->id,
+            'integration_group_id' => $group->id,
+            'service' => 'test',
+        ]);
+    }
+
+    #[Test]
+    public function browse_is_user_scoped_and_includes_counts(): void
+    {
+        $visible = Tag::findOrCreate('coffee', 'spark');
+        $hidden = Tag::findOrCreate('private-other-user-tag', 'spark');
+        $event = $this->createEvent('coffee meeting');
+        $event->attachTags([$visible]);
+
+        $other = User::factory()->create();
+        $otherObject = EventObject::factory()->create(['user_id' => $other->id]);
+        $otherObject->attachTags([$hidden]);
+
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $this->getJson('/api/v1/mobile/tags')
+            ->assertOk()
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', (string) $visible->id)
+            ->assertJsonPath('data.0.events_count', 1)
+            ->assertJsonPath('data.0.total_count', 1)
+            ->assertJsonMissing(['name' => 'private-other-user-tag']);
+    }
+
+    #[Test]
+    public function detail_returns_only_items_actually_tagged(): void
+    {
+        $tag = Tag::findOrCreate('coffee', 'spark');
+        $tagged = $this->createEvent('Tagged');
+        $tagged->attachTags([$tag]);
+        $this->createEvent('Coffee appears in text but is not tagged');
+
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $this->getJson("/api/v1/mobile/tags/{$tag->id}")
+            ->assertOk()
+            ->assertJsonPath('tag.id', (string) $tag->id)
+            ->assertJsonCount(1, 'data')
+            ->assertJsonPath('data.0.id', (string) $tagged->id)
+            ->assertJsonPath('data.0.kind', 'event');
+    }
+
+    #[Test]
+    public function suggest_prioritises_an_exact_existing_tag(): void
+    {
+        $exact = Tag::findOrCreate('coffee', 'spark');
+        $prefix = Tag::findOrCreate('coffee shop', 'spark');
+        $event = $this->createEvent('Tagged');
+        $event->attachTags([$exact, $prefix]);
+
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $this->getJson('/api/v1/mobile/tags/suggest?q=coffee')
+            ->assertOk()
+            ->assertJsonPath('data.0.id', (string) $exact->id);
+    }
+
+    #[Test]
+    public function write_endpoints_create_attach_remove_and_log_tags(): void
+    {
+        $event = $this->createEvent('Tagged');
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $created = $this->postJson("/api/v1/mobile/events/{$event->id}/tags", [
+            'name' => 'new tag',
+        ])->assertCreated()
+            ->assertJsonPath('tag.name', 'new tag')
+            ->assertJsonPath('tag.type', 'spark');
+
+        $tagId = $created->json('tag.id');
+        $this->assertTrue($event->fresh()->tags()->where('tags.id', $tagId)->exists());
+        $this->getJson("/api/v1/mobile/events/{$event->id}")
+            ->assertOk()
+            ->assertJsonPath('tags.0.id', $tagId)
+            ->assertJsonPath('tags.0.name', 'new tag');
+
+        $this->assertDatabaseHas('activity_log', [
+            'subject_id' => $event->id,
+            'event' => 'tag_added',
+        ]);
+
+        $this->deleteJson("/api/v1/mobile/events/{$event->id}/tags/{$tagId}")
+            ->assertOk()
+            ->assertJsonCount(0, 'tags');
+
+        $this->assertFalse($event->fresh()->tags()->where('tags.id', $tagId)->exists());
+        $this->assertDatabaseHas('activity_log', [
+            'subject_id' => $event->id,
+            'event' => 'tag_removed',
+        ]);
+    }
+
+    #[Test]
+    public function object_write_endpoints_attach_existing_tags(): void
+    {
+        $object = EventObject::factory()->create(['user_id' => $this->user->id]);
+        $tag = Tag::findOrCreate('person', 'spark');
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson("/api/v1/mobile/objects/{$object->id}/tags", [
+            'tag_id' => (string) $tag->id,
+        ])->assertCreated()
+            ->assertJsonPath('tags.0.id', (string) $tag->id);
+
+        $this->getJson("/api/v1/mobile/objects/{$object->id}")
+            ->assertOk()
+            ->assertJsonPath('tags.0.id', (string) $tag->id);
+    }
+
+    #[Test]
+    public function writes_require_the_write_ability(): void
+    {
+        $event = $this->createEvent('Tagged');
+        Sanctum::actingAs($this->user, ['ios:read']);
+
+        $this->postJson("/api/v1/mobile/events/{$event->id}/tags", [
+            'name' => 'nope',
+        ])->assertForbidden();
+    }
+
+    #[Test]
+    public function cannot_mutate_another_users_entity(): void
+    {
+        $other = User::factory()->create();
+        $group = IntegrationGroup::factory()->create([
+            'user_id' => $other->id,
+            'service' => 'other',
+        ]);
+        $integration = Integration::factory()->create([
+            'user_id' => $other->id,
+            'integration_group_id' => $group->id,
+            'service' => 'other',
+        ]);
+        $event = Event::factory()->create(['integration_id' => $integration->id]);
+
+        Sanctum::actingAs($this->user, ['ios:read', 'ios:write']);
+
+        $this->postJson("/api/v1/mobile/events/{$event->id}/tags", [
+            'name' => 'nope',
+        ])->assertNotFound();
+    }
+
+    private function createEvent(string $title): Event
+    {
+        $target = EventObject::factory()->create([
+            'user_id' => $this->user->id,
+            'title' => $title,
+        ]);
+
+        return Event::factory()->create([
+            'integration_id' => $this->integration->id,
+            'service' => 'test',
+            'domain' => 'knowledge',
+            'action' => 'created',
+            'target_id' => $target->id,
+            'time' => now(),
+        ]);
+    }
+}

--- a/tests/Feature/Flint/FlintDigestSchedulingTest.php
+++ b/tests/Feature/Flint/FlintDigestSchedulingTest.php
@@ -2,10 +2,8 @@
 
 namespace Tests\Feature\Flint;
 
-use App\Jobs\Flint\SendDigestNotificationJob;
 use App\Jobs\Flint\TriggerFlintDigestRoutineJob;
 use App\Jobs\TaskPipeline\Tasks\DispatchMorningDigestOnSleepScoreTask;
-use App\Jobs\TaskPipeline\Tasks\NotifyOnDigestReadyTask;
 use App\Models\Event;
 use App\Models\Integration;
 use App\Models\User;
@@ -151,26 +149,9 @@ class FlintDigestSchedulingTest extends TestCase
     }
 
     #[Test]
-    public function notify_task_dispatches_notification_on_digest_creation(): void
+    public function digest_notification_is_not_dispatched_from_summary_event_creation(): void
     {
-        Bus::fake();
-        $user = $this->newYorkUser();
-
-        $integration = Integration::factory()->create([
-            'user_id' => $user->id,
-            'service' => 'flint',
-        ]);
-        $digest = Event::factory()->create([
-            'integration_id' => $integration->id,
-            'service' => 'flint',
-            'action' => 'had_summary',
-            'event_metadata' => ['period' => 'morning'],
-        ]);
-
-        $task = TaskRegistry::getTask('notify_on_digest_ready');
-        (new NotifyOnDigestReadyTask($digest, $task))->handle();
-
-        Bus::assertDispatched(SendDigestNotificationJob::class, fn ($job) => $job->user->id === $user->id);
+        $this->assertNull(TaskRegistry::getTask('notify_on_digest_ready'));
     }
 
     #[Test]

--- a/tests/Feature/Flint/FlintDigestSchedulingTest.php
+++ b/tests/Feature/Flint/FlintDigestSchedulingTest.php
@@ -1,0 +1,274 @@
+<?php
+
+namespace Tests\Feature\Flint;
+
+use App\Jobs\Flint\SendDigestNotificationJob;
+use App\Jobs\Flint\TriggerFlintDigestRoutineJob;
+use App\Jobs\TaskPipeline\Tasks\DispatchMorningDigestOnSleepScoreTask;
+use App\Jobs\TaskPipeline\Tasks\NotifyOnDigestReadyTask;
+use App\Models\Event;
+use App\Models\Integration;
+use App\Models\User;
+use App\Services\TaskPipeline\TaskRegistry;
+use Carbon\Carbon;
+use Illuminate\Console\Scheduling\Schedule;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Bus;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionProperty;
+use Tests\TestCase;
+
+class FlintDigestSchedulingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+        parent::tearDown();
+    }
+
+    // June 2026 is EDT (UTC-4); 2026-06-15 is a Monday (weekday).
+
+    #[Test]
+    public function evening_digest_triggers_after_local_slot(): void
+    {
+        Bus::fake();
+        $user = $this->newYorkUser();
+
+        // 19:30 America/New_York == 23:30 UTC.
+        Carbon::setTestNow('2026-06-15 23:30:00');
+
+        $this->runDispatcher();
+
+        Bus::assertDispatched(TriggerFlintDigestRoutineJob::class, function ($job) use ($user) {
+            return $job->user->id === $user->id
+                && $job->period === 'evening'
+                && $job->localDate === '2026-06-15'
+                && $job->triggerReason === 'scheduled';
+        });
+    }
+
+    #[Test]
+    public function morning_digest_waits_when_no_sleep_and_before_fallback(): void
+    {
+        Bus::fake();
+        $this->newYorkUser();
+
+        // 08:00 NY: after the 07:30 weekday slot, before the 11:00 fallback, no sleep yet.
+        Carbon::setTestNow('2026-06-15 12:00:00');
+
+        $this->runDispatcher();
+
+        Bus::assertNotDispatched(TriggerFlintDigestRoutineJob::class, fn ($job) => $job->period === 'morning');
+    }
+
+    #[Test]
+    public function morning_digest_triggers_with_scheduled_reason_when_sleep_present(): void
+    {
+        Bus::fake();
+        $user = $this->newYorkUser();
+        $sleep = $this->seedSleepScore($user, '2026-06-15');
+
+        // 08:00 NY: after the morning slot, sleep already in.
+        Carbon::setTestNow('2026-06-15 12:00:00');
+
+        $this->runDispatcher();
+
+        Bus::assertDispatched(TriggerFlintDigestRoutineJob::class, function ($job) use ($user, $sleep) {
+            return $job->user->id === $user->id
+                && $job->period === 'morning'
+                && $job->triggerReason === 'scheduled'
+                && $job->sleepScoreEventId === $sleep->id;
+        });
+    }
+
+    #[Test]
+    public function morning_digest_triggers_with_fallback_reason_after_cutoff(): void
+    {
+        Bus::fake();
+        $this->newYorkUser();
+
+        // 11:30 NY: past the 11:00 fallback cutoff, still no sleep.
+        Carbon::setTestNow('2026-06-15 15:30:00');
+
+        $this->runDispatcher();
+
+        Bus::assertDispatched(TriggerFlintDigestRoutineJob::class, function ($job) {
+            return $job->period === 'morning' && $job->triggerReason === 'fallback';
+        });
+    }
+
+    #[Test]
+    public function sleep_task_fires_morning_digest_immediately_when_past_slot(): void
+    {
+        Bus::fake();
+        $user = $this->newYorkUser();
+        $sleep = $this->seedSleepScore($user, '2026-06-15');
+
+        // 08:00 NY: after the morning slot.
+        Carbon::setTestNow('2026-06-15 12:00:00');
+
+        $task = TaskRegistry::getTask('dispatch_morning_digest_on_sleep_score');
+        (new DispatchMorningDigestOnSleepScoreTask($sleep, $task))->handle();
+
+        Bus::assertDispatched(TriggerFlintDigestRoutineJob::class, function ($job) use ($sleep) {
+            return $job->period === 'morning'
+                && $job->triggerReason === 'sleep_score'
+                && $job->sleepScoreEventId === $sleep->id;
+        });
+    }
+
+    #[Test]
+    public function sleep_task_does_nothing_before_morning_slot(): void
+    {
+        Bus::fake();
+        $user = $this->newYorkUser();
+        $sleep = $this->seedSleepScore($user, '2026-06-15');
+
+        // 06:00 NY: before the 07:30 weekday slot.
+        Carbon::setTestNow('2026-06-15 10:00:00');
+
+        $task = TaskRegistry::getTask('dispatch_morning_digest_on_sleep_score');
+        (new DispatchMorningDigestOnSleepScoreTask($sleep, $task))->handle();
+
+        Bus::assertNotDispatched(TriggerFlintDigestRoutineJob::class);
+    }
+
+    #[Test]
+    public function sleep_task_ignores_historical_back_fill(): void
+    {
+        Bus::fake();
+        $user = $this->newYorkUser();
+        $sleep = $this->seedSleepScore($user, '2026-06-10'); // not today
+
+        Carbon::setTestNow('2026-06-15 12:00:00');
+
+        $task = TaskRegistry::getTask('dispatch_morning_digest_on_sleep_score');
+        (new DispatchMorningDigestOnSleepScoreTask($sleep, $task))->handle();
+
+        Bus::assertNotDispatched(TriggerFlintDigestRoutineJob::class);
+    }
+
+    #[Test]
+    public function notify_task_dispatches_notification_on_digest_creation(): void
+    {
+        Bus::fake();
+        $user = $this->newYorkUser();
+
+        $integration = Integration::factory()->create([
+            'user_id' => $user->id,
+            'service' => 'flint',
+        ]);
+        $digest = Event::factory()->create([
+            'integration_id' => $integration->id,
+            'service' => 'flint',
+            'action' => 'had_summary',
+            'event_metadata' => ['period' => 'morning'],
+        ]);
+
+        $task = TaskRegistry::getTask('notify_on_digest_ready');
+        (new NotifyOnDigestReadyTask($digest, $task))->handle();
+
+        Bus::assertDispatched(SendDigestNotificationJob::class, fn ($job) => $job->user->id === $user->id);
+    }
+
+    #[Test]
+    public function evening_slot_follows_the_latest_acknowledged_timezone(): void
+    {
+        Bus::fake();
+
+        // Profile is London, but the user acknowledges a move to New York mid-trip.
+        $user = User::factory()->create([
+            'settings' => [
+                'timezone' => 'Europe/London',
+                'flint' => ['digests_enabled' => true],
+            ],
+        ]);
+        $integration = Integration::factory()->create([
+            'user_id' => $user->id,
+            'service' => 'daily_checkin',
+        ]);
+        Event::factory()->create([
+            'integration_id' => $integration->id,
+            'service' => 'daily_checkin',
+            'action' => 'time_travel',
+            'event_metadata' => ['timezone' => 'Europe/London', 'acknowledged_at' => '2026-06-15T06:00:00.000000Z'],
+        ]);
+        Event::factory()->create([
+            'integration_id' => $integration->id,
+            'service' => 'daily_checkin',
+            'action' => 'time_travel',
+            'event_metadata' => ['timezone' => 'America/New_York', 'acknowledged_at' => '2026-06-15T12:00:00.000000Z'],
+        ]);
+
+        // 23:30 UTC == 19:30 New York (fires) but 00:30 London (would not). The
+        // later NY acknowledgement must move the evening slot.
+        Carbon::setTestNow('2026-06-15 23:30:00');
+
+        $this->runDispatcher();
+
+        Bus::assertDispatched(TriggerFlintDigestRoutineJob::class, function ($job) use ($user) {
+            return $job->user->id === $user->id
+                && $job->period === 'evening'
+                && $job->timezone === 'America/New_York';
+        });
+    }
+
+    /**
+     * Create a user with digests enabled whose effective timezone is New York.
+     */
+    private function newYorkUser(): User
+    {
+        $user = User::factory()->create([
+            'settings' => [
+                'timezone' => 'Europe/London',
+                'flint' => ['digests_enabled' => true],
+            ],
+        ]);
+
+        $integration = Integration::factory()->create([
+            'user_id' => $user->id,
+            'service' => 'daily_checkin',
+        ]);
+        Event::factory()->create([
+            'integration_id' => $integration->id,
+            'service' => 'daily_checkin',
+            'action' => 'time_travel',
+            'event_metadata' => [
+                'timezone' => 'America/New_York',
+                'acknowledged_at' => '2026-06-10T10:00:00.000000Z',
+            ],
+        ]);
+
+        return $user;
+    }
+
+    private function seedSleepScore(User $user, string $day): Event
+    {
+        $integration = Integration::factory()->create([
+            'user_id' => $user->id,
+            'service' => 'oura',
+        ]);
+
+        return Event::factory()->create([
+            'integration_id' => $integration->id,
+            'service' => 'oura',
+            'action' => 'had_sleep_score',
+            'event_metadata' => ['day' => $day],
+        ]);
+    }
+
+    private function runDispatcher(): void
+    {
+        $schedule = app(Schedule::class);
+        $event = collect($schedule->events())
+            ->first(fn ($e) => ($e->description ?? null) === 'flint-digest-dispatcher');
+
+        $this->assertNotNull($event, 'flint-digest-dispatcher schedule not found');
+
+        $property = new ReflectionProperty($event, 'callback');
+        $property->setAccessible(true);
+        app()->call($property->getValue($event));
+    }
+}

--- a/tests/Feature/Flint/NotificationTest.php
+++ b/tests/Feature/Flint/NotificationTest.php
@@ -198,7 +198,7 @@ class NotificationTest extends TestCase
             'concept' => 'day',
             'type' => 'day',
             'title' => $localDate,
-            'time' => Carbon::parse($localDate),
+            'time' => Carbon::parse($localDate, 'UTC'),
         ]);
 
         // Mirror production storage: the had_summary event's `time` is the
@@ -209,13 +209,13 @@ class NotificationTest extends TestCase
             'target_id' => $dayObject->id,
             'service' => 'flint',
             'action' => 'had_summary',
-            'time' => Carbon::parse($localDate), // 2026-06-14 00:00 UTC
+            'time' => Carbon::parse($localDate, 'UTC'), // 2026-06-14 00:00 UTC
         ]);
 
         Block::create([
             'event_id' => $flintEvent->id,
             'block_type' => 'flint_digest',
-            'time' => Carbon::parse($localDate),
+            'time' => Carbon::parse($localDate, 'UTC'),
             'metadata' => [
                 'headline' => 'Evening Digest',
                 'summary' => 'Far-west summary.',

--- a/tests/Feature/Flint/NotificationTest.php
+++ b/tests/Feature/Flint/NotificationTest.php
@@ -9,8 +9,10 @@ use App\Models\EventObject;
 use App\Models\Integration;
 use App\Models\User;
 use App\Notifications\DailyDigestReady;
+use Carbon\Carbon;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Notification;
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 class NotificationTest extends TestCase
@@ -36,9 +38,14 @@ class NotificationTest extends TestCase
         ]);
     }
 
-    /**
-     * @test
-     */
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
+    }
+
+    #[Test]
     public function sends_digest_notification_when_digest_exists(): void
     {
         Notification::fake();
@@ -96,9 +103,7 @@ class NotificationTest extends TestCase
         );
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function does_not_send_notification_when_no_digest_found(): void
     {
         Notification::fake();
@@ -111,9 +116,7 @@ class NotificationTest extends TestCase
         Notification::assertNothingSent();
     }
 
-    /**
-     * @test
-     */
+    #[Test]
     public function notification_contains_correct_digest_data(): void
     {
         Notification::fake();
@@ -169,6 +172,64 @@ class NotificationTest extends TestCase
                     && $notification->period === 'evening'
                     && count($notification->blocks) > 0;
             }
+        );
+    }
+
+    /**
+     * The digest block lookup must use the user's effective-timezone local day,
+     * not the server (UTC) day. A far-west user's digest is dated for their local
+     * day but stored at that date's 00:00 UTC marker (see CreateFlintDigestTool);
+     * once UTC has rolled past midnight, a server-tz `startOfDay()` bound would
+     * wrongly exclude it. Reproduces and guards the far-west day-boundary bug.
+     */
+    #[Test]
+    public function finds_digest_using_effective_timezone_local_day_for_far_west_user(): void
+    {
+        Notification::fake();
+
+        $this->user->setTimezone('Pacific/Honolulu'); // UTC-10, no time_travel event => profile tz
+
+        $localDate = '2026-06-14';
+
+        // The user is late in their local day; UTC has already rolled to the 15th.
+        Carbon::setTestNow(Carbon::parse("{$localDate} 22:00", 'Pacific/Honolulu')); // = 2026-06-15 08:00 UTC
+
+        $dayObject = EventObject::factory()->create([
+            'concept' => 'day',
+            'type' => 'day',
+            'title' => $localDate,
+            'time' => Carbon::parse($localDate),
+        ]);
+
+        // Mirror production storage: the had_summary event's `time` is the
+        // local_date anchored at 00:00 UTC (CreateFlintDigestTool:113), which is
+        // BEFORE now()->startOfDay() (= 2026-06-15 00:00 UTC) at this moment.
+        $flintEvent = Event::factory()->create([
+            'integration_id' => $this->flintIntegration->id,
+            'target_id' => $dayObject->id,
+            'service' => 'flint',
+            'action' => 'had_summary',
+            'time' => Carbon::parse($localDate), // 2026-06-14 00:00 UTC
+        ]);
+
+        Block::create([
+            'event_id' => $flintEvent->id,
+            'block_type' => 'flint_digest',
+            'time' => Carbon::parse($localDate),
+            'metadata' => [
+                'headline' => 'Evening Digest',
+                'summary' => 'Far-west summary.',
+            ],
+        ]);
+
+        $job = new SendDigestNotificationJob($this->user, '18:00');
+        $job->handle();
+
+        Notification::assertSentTo(
+            [$this->user],
+            DailyDigestReady::class,
+            fn ($notification) => $notification->digestObject->id === $dayObject->id
+                && $notification->period === 'evening'
         );
     }
 }

--- a/tests/Feature/Flint/TriggerFlintDigestRoutineJobTest.php
+++ b/tests/Feature/Flint/TriggerFlintDigestRoutineJobTest.php
@@ -44,7 +44,12 @@ class TriggerFlintDigestRoutineJobTest extends TestCase
                 && $request['local_date'] === '2026-06-14'
                 && $request['timezone'] === 'America/New_York'
                 && $request['trigger_reason'] === 'scheduled'
-                && $request['user_id'] === (string) $this->user->id;
+                && $request['user_id'] === (string) $this->user->id
+                && $request['idempotency_key'] === TriggerFlintDigestRoutineJob::markerKey(
+                    $this->user->id,
+                    '2026-06-14',
+                    'evening',
+                );
         });
 
         $this->assertTrue(Cache::has(
@@ -101,6 +106,23 @@ class TriggerFlintDigestRoutineJobTest extends TestCase
         Http::assertNothingSent();
         $this->assertFalse(Cache::has(
             TriggerFlintDigestRoutineJob::markerKey($this->user->id, '2026-06-14', 'evening')
+        ));
+    }
+
+    #[Test]
+    public function releases_the_marker_when_the_webhook_fails(): void
+    {
+        Http::fake(['*' => Http::response(['error' => 'unavailable'], 500)]);
+
+        try {
+            $this->runJob('morning');
+            $this->fail('Expected the webhook failure to be thrown.');
+        } catch (\Illuminate\Http\Client\RequestException) {
+            // Expected: the job should be retried by the queue.
+        }
+
+        $this->assertFalse(Cache::has(
+            TriggerFlintDigestRoutineJob::markerKey($this->user->id, '2026-06-14', 'morning')
         ));
     }
 

--- a/tests/Feature/Flint/TriggerFlintDigestRoutineJobTest.php
+++ b/tests/Feature/Flint/TriggerFlintDigestRoutineJobTest.php
@@ -7,6 +7,7 @@ use App\Models\Event;
 use App\Models\Integration;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Client\RequestException;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
 use PHPUnit\Framework\Attributes\Test;
@@ -117,7 +118,7 @@ class TriggerFlintDigestRoutineJobTest extends TestCase
         try {
             $this->runJob('morning');
             $this->fail('Expected the webhook failure to be thrown.');
-        } catch (\Illuminate\Http\Client\RequestException) {
+        } catch (RequestException) {
             // Expected: the job should be retried by the queue.
         }
 

--- a/tests/Feature/Flint/TriggerFlintDigestRoutineJobTest.php
+++ b/tests/Feature/Flint/TriggerFlintDigestRoutineJobTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Tests\Feature\Flint;
+
+use App\Jobs\Flint\TriggerFlintDigestRoutineJob;
+use App\Models\Event;
+use App\Models\Integration;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class TriggerFlintDigestRoutineJobTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private User $user;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = User::factory()->create();
+
+        config([
+            'services.flint_routine.url' => 'https://routine.example.test/hook',
+            'services.flint_routine.secret' => 'shh',
+        ]);
+    }
+
+    #[Test]
+    public function posts_to_the_routine_webhook_with_signed_payload(): void
+    {
+        Http::fake(['*' => Http::response(['ok' => true], 200)]);
+
+        $this->runJob('evening');
+
+        Http::assertSent(function ($request) {
+            return $request->url() === 'https://routine.example.test/hook'
+                && $request->hasHeader('Authorization', 'Bearer shh')
+                && $request['period'] === 'evening'
+                && $request['local_date'] === '2026-06-14'
+                && $request['timezone'] === 'America/New_York'
+                && $request['trigger_reason'] === 'scheduled'
+                && $request['user_id'] === (string) $this->user->id;
+        });
+
+        $this->assertTrue(Cache::has(
+            TriggerFlintDigestRoutineJob::markerKey($this->user->id, '2026-06-14', 'evening')
+        ));
+    }
+
+    #[Test]
+    public function is_idempotent_when_marker_already_set(): void
+    {
+        Http::fake(['*' => Http::response(['ok' => true], 200)]);
+
+        Cache::put(
+            TriggerFlintDigestRoutineJob::markerKey($this->user->id, '2026-06-14', 'evening'),
+            true,
+            3600
+        );
+
+        $this->runJob('evening');
+
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function skips_when_digest_already_exists(): void
+    {
+        Http::fake(['*' => Http::response(['ok' => true], 200)]);
+
+        $integration = Integration::factory()->create([
+            'user_id' => $this->user->id,
+            'service' => 'flint',
+        ]);
+        Event::factory()->create([
+            'integration_id' => $integration->id,
+            'service' => 'flint',
+            'action' => 'had_summary',
+            'time' => '2026-06-14 12:00:00', // within the NY local day
+            'event_metadata' => ['period' => 'evening'],
+        ]);
+
+        $this->runJob('evening');
+
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function no_op_when_webhook_url_missing(): void
+    {
+        config(['services.flint_routine.url' => null]);
+        Http::fake();
+
+        $this->runJob('evening');
+
+        Http::assertNothingSent();
+        $this->assertFalse(Cache::has(
+            TriggerFlintDigestRoutineJob::markerKey($this->user->id, '2026-06-14', 'evening')
+        ));
+    }
+
+    private function runJob(string $period = 'evening', string $reason = 'scheduled'): void
+    {
+        (new TriggerFlintDigestRoutineJob(
+            $this->user,
+            $period,
+            '2026-06-14',
+            'America/New_York',
+            $reason,
+        ))->handle();
+    }
+}

--- a/tests/Feature/Livewire/DayTimezoneTest.php
+++ b/tests/Feature/Livewire/DayTimezoneTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Feature\Livewire;
+
+use App\Livewire\Day;
+use App\Models\Event;
+use App\Models\Integration;
+use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Livewire\Livewire;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class DayTimezoneTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function tearDown(): void
+    {
+        Carbon::setTestNow();
+
+        parent::tearDown();
+    }
+
+    /**
+     * A past day must render in the timezone that was acknowledged on that date,
+     * not the user's current one (B4 / CRX-725). The user travelled to Tokyo on
+     * the 9th and returned to UTC on the 13th; viewing the 10th must use Tokyo,
+     * so an event at 00:30 Tokyo (15:30 UTC on the 9th) belongs to that day even
+     * though it falls on the previous UTC calendar day.
+     */
+    #[Test]
+    public function past_day_uses_the_timezone_acknowledged_on_that_date(): void
+    {
+        Carbon::setTestNow(Carbon::parse('2026-06-15 12:00', 'UTC'));
+
+        $user = User::factory()->create(['settings' => ['timezone' => 'UTC']]);
+
+        $checkin = Integration::factory()->create([
+            'user_id' => $user->id,
+            'service' => 'daily_checkin',
+        ]);
+
+        // Travelled to Tokyo before the target day, then back to UTC after it.
+        $this->makeTimezoneEvent($checkin, 'Asia/Tokyo', '2026-06-09T08:00:00.000000Z');
+        $this->makeTimezoneEvent($checkin, 'UTC', '2026-06-13T08:00:00.000000Z');
+
+        // 00:30 on the 10th in Tokyo == 15:30 on the 9th in UTC.
+        $integration = Integration::factory()->create([
+            'user_id' => $user->id,
+            'service' => 'monzo',
+        ]);
+        $event = Event::factory()->create([
+            'integration_id' => $integration->id,
+            'service' => 'monzo',
+            'action' => 'card_payment',
+            'time' => Carbon::parse('2026-06-09 15:30', 'UTC'),
+        ]);
+
+        $component = Livewire::actingAs($user, 'web')
+            ->test(Day::class)
+            ->set('coreEventsLoaded', false)
+            ->set('date', '2026-06-10')
+            ->call('loadCoreEvents');
+
+        $loaded = $component->get('allEvents');
+
+        $this->assertTrue(
+            $loaded->contains(fn ($e) => $e->id === $event->id),
+            'Expected the event to be included via the historical Tokyo timezone bounds.',
+        );
+    }
+
+    private function makeTimezoneEvent(Integration $integration, string $timezone, string $acknowledgedAt): Event
+    {
+        return Event::factory()->create([
+            'integration_id' => $integration->id,
+            'service' => 'daily_checkin',
+            'action' => 'time_travel',
+            'event_metadata' => [
+                'timezone' => $timezone,
+                'acknowledged_at' => $acknowledgedAt,
+            ],
+        ]);
+    }
+}

--- a/tests/Unit/Services/EffectiveTimezoneResolverTest.php
+++ b/tests/Unit/Services/EffectiveTimezoneResolverTest.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Tests\Unit\Services;
+
+use App\Models\Event;
+use App\Models\Integration;
+use App\Models\User;
+use App\Services\EffectiveTimezoneResolver;
+use Carbon\Carbon;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class EffectiveTimezoneResolverTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function falls_back_to_profile_timezone_when_no_event(): void
+    {
+        $user = User::factory()->create(['settings' => ['timezone' => 'Europe/London']]);
+
+        $this->assertSame('Europe/London', app(EffectiveTimezoneResolver::class)->timezoneFor($user));
+    }
+
+    #[Test]
+    public function returns_utc_when_no_user(): void
+    {
+        $this->assertSame('UTC', app(EffectiveTimezoneResolver::class)->timezoneFor(null));
+    }
+
+    #[Test]
+    public function uses_latest_acknowledged_timezone(): void
+    {
+        $user = User::factory()->create(['settings' => ['timezone' => 'Europe/London']]);
+        $this->makeTimezoneEvent($user, 'America/New_York', '2026-06-14T10:00:00.000000Z');
+
+        $this->assertSame('America/New_York', app(EffectiveTimezoneResolver::class)->timezoneFor($user));
+    }
+
+    #[Test]
+    public function helpers_reflect_effective_timezone(): void
+    {
+        $user = User::factory()->create(['settings' => ['timezone' => 'Europe/London']]);
+        $this->makeTimezoneEvent($user, 'America/New_York', '2026-06-14T10:00:00.000000Z');
+
+        $this->assertSame('America/New_York', user_now($user)->getTimezone()->getName());
+        $this->assertSame('America/New_York', user_today($user)->getTimezone()->getName());
+    }
+
+    #[Test]
+    public function forget_busts_the_memo(): void
+    {
+        $user = User::factory()->create(['settings' => ['timezone' => 'Europe/London']]);
+        $resolver = app(EffectiveTimezoneResolver::class);
+
+        $this->assertSame('Europe/London', $resolver->timezoneFor($user));
+
+        $this->makeTimezoneEvent($user, 'Asia/Tokyo', '2026-06-14T10:00:00.000000Z');
+
+        // Still memoized as the profile timezone until we forget it.
+        $this->assertSame('Europe/London', $resolver->timezoneFor($user));
+
+        $resolver->forget($user);
+        $this->assertSame('Asia/Tokyo', $resolver->timezoneFor($user));
+    }
+
+    #[Test]
+    public function point_in_time_returns_timezone_acknowledged_at_or_before_instant(): void
+    {
+        $user = User::factory()->create(['settings' => ['timezone' => 'Europe/London']]);
+        $this->makeTimezoneEvent($user, 'Asia/Tokyo', '2026-06-10T10:00:00.000000Z');
+
+        $resolver = app(EffectiveTimezoneResolver::class);
+
+        // An instant after the acknowledgement sees the travel timezone.
+        $this->assertSame('Asia/Tokyo', $resolver->timezoneForAt($user, Carbon::parse('2026-06-12 12:00', 'UTC')));
+
+        // An instant before the acknowledgement still sees the profile timezone.
+        $this->assertSame('Europe/London', $resolver->timezoneForAt($user, Carbon::parse('2026-06-08 12:00', 'UTC')));
+    }
+
+    #[Test]
+    public function point_in_time_picks_the_latest_acknowledgement_before_the_instant(): void
+    {
+        $user = User::factory()->create(['settings' => ['timezone' => 'Europe/London']]);
+        $this->makeTimezoneEvent($user, 'Asia/Tokyo', '2026-06-10T10:00:00.000000Z');
+        $this->makeTimezoneEvent($user, 'America/New_York', '2026-06-15T10:00:00.000000Z');
+
+        $resolver = app(EffectiveTimezoneResolver::class);
+
+        $this->assertSame('Asia/Tokyo', $resolver->timezoneForAt($user, Carbon::parse('2026-06-12 12:00', 'UTC')));
+        $this->assertSame('America/New_York', $resolver->timezoneForAt($user, Carbon::parse('2026-06-20 12:00', 'UTC')));
+    }
+
+    #[Test]
+    public function point_in_time_falls_back_to_time_for_legacy_event_without_acknowledged_at(): void
+    {
+        $user = User::factory()->create(['settings' => ['timezone' => 'Europe/London']]);
+        $this->makeLegacyTimezoneEvent($user, 'Asia/Tokyo', Carbon::parse('2026-06-10 10:00', 'UTC'));
+
+        $resolver = app(EffectiveTimezoneResolver::class);
+
+        $this->assertSame('Asia/Tokyo', $resolver->timezoneForAt($user, Carbon::parse('2026-06-12 12:00', 'UTC')));
+        $this->assertSame('Europe/London', $resolver->timezoneForAt($user, Carbon::parse('2026-06-08 12:00', 'UTC')));
+    }
+
+    #[Test]
+    public function point_in_time_at_now_matches_the_live_effective_timezone(): void
+    {
+        $resolver = app(EffectiveTimezoneResolver::class);
+
+        // No acknowledgement: both resolve to the profile timezone.
+        $noEvents = User::factory()->create(['settings' => ['timezone' => 'Europe/London']]);
+        $this->assertSame(
+            $resolver->timezoneFor($noEvents),
+            $resolver->timezoneForAt($noEvents, Carbon::now()),
+        );
+
+        // With a past acknowledgement: both resolve to the acknowledged timezone.
+        $travelled = User::factory()->create(['settings' => ['timezone' => 'Europe/London']]);
+        $this->makeTimezoneEvent($travelled, 'Asia/Tokyo', Carbon::now()->subDay()->format('Y-m-d\TH:i:s.u\Z'));
+        $this->assertSame(
+            $resolver->timezoneFor($travelled),
+            $resolver->timezoneForAt($travelled, Carbon::now()),
+        );
+    }
+
+    #[Test]
+    public function point_in_time_returns_utc_when_no_user(): void
+    {
+        $this->assertSame('UTC', app(EffectiveTimezoneResolver::class)->timezoneForAt(null, Carbon::now()));
+    }
+
+    private function makeTimezoneEvent(User $user, string $timezone, string $acknowledgedAt): Event
+    {
+        $integration = Integration::factory()->create([
+            'user_id' => $user->id,
+            'service' => 'daily_checkin',
+        ]);
+
+        return Event::factory()->create([
+            'integration_id' => $integration->id,
+            'service' => 'daily_checkin',
+            'action' => 'time_travel',
+            'event_metadata' => [
+                'timezone' => $timezone,
+                'acknowledged_at' => $acknowledgedAt,
+            ],
+        ]);
+    }
+
+    private function makeLegacyTimezoneEvent(User $user, string $timezone, Carbon $time): Event
+    {
+        $integration = Integration::factory()->create([
+            'user_id' => $user->id,
+            'service' => 'daily_checkin',
+        ]);
+
+        return Event::factory()->create([
+            'integration_id' => $integration->id,
+            'service' => 'daily_checkin',
+            'action' => 'time_travel',
+            'time' => $time,
+            'event_metadata' => [
+                'timezone' => $timezone,
+            ],
+        ]);
+    }
+}

--- a/tests/Unit/Services/EffectiveTimezoneResolverTest.php
+++ b/tests/Unit/Services/EffectiveTimezoneResolverTest.php
@@ -106,6 +106,19 @@ class EffectiveTimezoneResolverTest extends TestCase
     }
 
     #[Test]
+    public function point_in_time_prefers_a_newer_stamped_acknowledgement_over_a_legacy_event(): void
+    {
+        $user = User::factory()->create(['settings' => ['timezone' => 'Europe/London']]);
+        $this->makeLegacyTimezoneEvent($user, 'Asia/Tokyo', Carbon::parse('2026-06-10 10:00', 'UTC'));
+        $this->makeTimezoneEvent($user, 'America/New_York', '2026-06-12T10:00:00.000000Z');
+
+        $this->assertSame(
+            'America/New_York',
+            app(EffectiveTimezoneResolver::class)->timezoneForAt($user, Carbon::parse('2026-06-14 12:00', 'UTC')),
+        );
+    }
+
+    #[Test]
     public function point_in_time_at_now_matches_the_live_effective_timezone(): void
     {
         $resolver = app(EffectiveTimezoneResolver::class);


### PR DESCRIPTION
## Summary
- Add `EffectiveTimezoneResolver` to resolve a user's timezone from the latest acknowledged travel (`daily_checkin` `time_travel`) event, with point-in-time lookups so past days render in the timezone that was acknowledged on that date rather than the live one
- `Day.php` now uses effective-timezone-aware day boundaries for today/yesterday/tomorrow routing and event queries (CRX-682)
- Rework the Flint digest scheduler off a fixed clock: evening digests still fire on a time gate, but the morning digest now fires at the later of the morning slot and the Oura sleep-score event landing, with a fallback cutoff if sleep never arrives
- `TriggerFlintDigestRoutineJob` replaces the old pre-digest/notification split and posts a signed payload to the Claude Code routine webhook; `NotifyOnDigestReadyTask` sends the notification when the digest summary is actually written instead of guessing the timing
- Add a mobile Tags API (browse/detail/suggest/write) and include tag data in the compact event/object resources

## Test plan
- [x] `EffectiveTimezoneResolverTest` — point-in-time resolution, memoization, fallbacks
- [x] `DayTimezoneTest` — past day renders in the timezone acknowledged on that date
- [x] `FlintDigestSchedulingTest` — evening time gate, morning sleep-score gate, fallback cutoff
- [x] `TriggerFlintDigestRoutineJobTest` — signed webhook payload, idempotency, no-op cases
- [x] `NotificationTest` — digest notification resolves the correct local day
- [x] `TagsControllerTest` — browse/detail/suggest/write, ownership checks
- [x] `vendor/bin/sail bin duster fix` — no violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KuroKEsS1JS4HswrhTJFkS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added mobile tag browsing, search suggestions, details, and tagging for events and objects.
  - Added configurable Flint digest scheduling, including morning, evening, sleep-score, and fallback triggers.
  - Added digest notifications and secure routine delivery.

- **Improvements**
  - Event and object responses now include tag information consistently.
  - Dates, day views, and digest selection now respect effective historical and current time zones.

- **Bug Fixes**
  - Improved digest handling across local dates and time-zone changes.
  - Prevented duplicate digest dispatches and unauthorised tag changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->