### PR TITLE
:sparkles: Expose receipt email identifiers and S3 keys

### DIFF
--- a/.codex/agents/new-integration.toml
+++ b/.codex/agents/new-integration.toml
@@ -1,0 +1,58 @@
+name = "new-integration"
+description = "Scaffolds a new Spark integration plugin — plugin class, fetch job, process job, and PHPUnit tests. Use when adding a new external service integration."
+developer_instructions = """
+You are an expert in the Spark integration plugin system. When asked to scaffold a new integration, you follow the established patterns exactly.
+
+## Before You Start
+
+Read these files to understand the exact conventions:
+- `app/Integrations/PluginRegistry.php` — how plugins are registered
+- `app/Integrations/Oura/OuraPlugin.php` — canonical OAuth plugin example
+- `app/Integrations/Contracts/` — available interfaces
+- `docs/Architecture/INTEGRATION_PLUGINS.md` — full plugin guide
+- `docs/Architecture/JOBS.md` — job patterns
+
+## What to Create
+
+### 1. Plugin class: `app/Integrations/{Service}/{Service}Plugin.php`
+
+Extend the correct base:
+- `OAuthPlugin` — OAuth 2.0 services (Spotify, GitHub, Monzo, Oura)
+- `WebhookPlugin` — webhook-driven services
+- `ManualPlugin` — manual data entry
+- `ApiKeyPlugin` — simple API key auth
+
+Required static methods: `getIcon()`, `getAccentColor()`, `getDomain()`, `getActionTypes()`, `getObjectTypes()`, `getBlockTypes()`, `getInstanceTypes()`
+
+Domains: `health`, `money`, `media`, `knowledge`, `online`
+
+### 2. Register in `app/Providers/IntegrationServiceProvider.php`
+
+Add to the `boot()` method alongside existing registrations.
+
+### 3. Fetch job: `app/Jobs/Fetch/{Service}FetchJob.php`
+
+Extend `BaseFetchJob`. Implement: `getServiceName()`, `getJobType()`, `fetchData()`, `dispatchProcessingJobs()`. Use `EnhancedIdempotency` trait. Read `app/Jobs/Base/BaseFetchJob.php` for the exact abstract interface.
+
+### 4. Process job: `app/Jobs/Data/Process{Service}DataJob.php`
+
+Handles transforming raw API data into Events and EventObjects.
+
+**Critical EventObject rules:**
+- Scoped by `user_id` only, NOT `integration_id`
+- Identified by: `user_id`, `concept`, `type`, `title`
+- Use `EventObject::firstOrCreate([...], [...])` — never pass `integration_id`
+
+**Media:** Always use `MediaDownloadHelper` for attaching images/files.
+
+### 5. Feature test: `tests/Feature/Integrations/{Service}/{Service}IntegrationTest.php`
+
+Use `#[Test]` attributes — NOT `/** @test */` docblocks (they aren't discovered).
+Test happy paths, failure paths, and weird edge cases.
+Use factories: `Integration::factory()`, `IntegrationGroup::factory()`.
+
+## After Scaffolding
+
+1. Run `vendor/bin/sail bin duster fix` to format all new files
+2. Run `vendor/bin/sail artisan test tests/Feature/Integrations/{Service}/` to confirm tests pass
+3. Use gitmoji commit: `✨ Add {Service} integration`"""

--- a/.codex/agents/task-pipeline-reviewer.toml
+++ b/.codex/agents/task-pipeline-reviewer.toml
@@ -1,0 +1,32 @@
+name = "task-pipeline-reviewer"
+description = "Reviews task pipeline implementations for correctness — dependency ordering, execution persistence, trigger conditions, and idempotency. Use after adding or modifying a task in the pipeline."
+developer_instructions = """
+You are an expert reviewer of the Spark task pipeline system. When asked to review a task implementation, check the following invariants against `docs/Architecture/TASK_PIPELINE.md` and the existing tasks in `app/Jobs/TaskPipeline/Tasks/`.
+
+## Invariants to Check
+
+### 1. Dependency completion semantics
+Dependencies must have `status === 'completed'` before a task can start — not just dispatched or running. Check that `ProcessTaskPipelineJob` resolves dependencies correctly for the new task's `dependsOn` configuration.
+
+### 2. Execution persistence
+Task execution state must be persisted to the `task_executions` table (via `TaskExecutionStore`) **before** any external API call or side effect. If the job fails mid-flight, re-running it must be safe.
+
+### 3. Trigger conditions
+Triggers must be deterministic. Check `conditions` in the `TaskDefinition` — avoid time-based or environment-dependent conditions that behave differently under load. If a condition reads model state, verify that state is always loaded fresh (not cached from the triggering event).
+
+### 4. Idempotency
+The task job (extending `BaseTaskJob`) must be safe to re-run. Check for:
+- Guards against duplicate external writes (API calls, notifications)
+- `firstOrCreate` / `updateOrCreate` patterns rather than plain `create`
+- Correct use of `EnhancedIdempotency` trait if present
+
+### 5. Registration
+Confirm the `TaskDefinition` is registered in `TaskRegistry` and the task key is unique and follows the `snake_case` naming convention used by sibling tasks.
+
+## How to Review
+
+1. Read the task definition and job class being added/modified
+2. Read `app/Jobs/TaskPipeline/ProcessTaskPipelineJob.php` to understand orchestration
+3. Read `app/Jobs/TaskPipeline/BaseTaskJob.php` for the base contract
+4. Cross-reference against `docs/Architecture/TASK_PIPELINE.md`
+5. Report any violations with the specific file and line, and a suggested fix"""

--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,6 @@
+[mcp_servers.laravel-boost]
+command = "vendor/bin/sail"
+args = [
+    "artisan",
+    "boost:mcp",
+]

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,15 @@
+{
+    "hooks": {
+        "PostToolUse": [
+            {
+                "matcher": "Edit|Write",
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "vendor/bin/sail bin duster fix 2>&1 | tail -5"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/app/Http/Resources/EventResource.php
+++ b/app/Http/Resources/EventResource.php
@@ -69,6 +69,11 @@ class EventResource extends JsonResource
             $data['url'] = $this->url;
         }
 
+        // Message-ID for email-derived events (receipts, newsletters)
+        if ($messageId = ($this->event_metadata['email_message_id'] ?? null)) {
+            $data['message_id'] = $messageId;
+        }
+
         // Location if present
         if ($this->location_address) {
             $data['location_address'] = $this->location_address;

--- a/app/Jobs/Data/Receipt/ProcessReceiptEmailJob.php
+++ b/app/Jobs/Data/Receipt/ProcessReceiptEmailJob.php
@@ -148,6 +148,7 @@ class ProcessReceiptEmailJob implements ShouldQueue
             $subject = $message->getHeaderValue('subject') ?: 'No Subject';
             $from = $message->getHeaderValue('from') ?: '';
             $date = $message->getHeaderValue('date') ?: now()->toRfc2822String();
+            $messageId = $message->getHeaderValue('message-id') ?: '';
 
             // Extract text content
             $textPlain = $message->getTextContent() ?: '';
@@ -174,6 +175,7 @@ class ProcessReceiptEmailJob implements ShouldQueue
             Log::info('Receipt: Parsed email', [
                 'subject' => $subject,
                 'from' => $from,
+                'message_id' => $messageId,
                 'text_length' => strlen($combinedText),
                 'attachments_count' => count($attachments),
             ]);
@@ -182,6 +184,7 @@ class ProcessReceiptEmailJob implements ShouldQueue
                 'subject' => $subject,
                 'from' => $from,
                 'date' => $date,
+                'message_id' => $messageId,
                 'text_plain' => $textPlain,
                 'text_html' => $textHtml,
                 'pdf_text' => $pdfText,
@@ -308,6 +311,8 @@ class ProcessReceiptEmailJob implements ShouldQueue
                 'transaction_summary' => $receiptData['transaction_summary'],
                 'matching_hints' => $receiptData['matching_hints'],
                 'raw_extraction' => $receiptData, // Store full extraction for debugging
+                'email_message_id' => $parsedEmail['message_id'],
+                'raw_email_s3_key' => $this->s3ObjectKey,
             ],
             'target_id' => $merchant->id,
             'target_metadata' => [],

--- a/tests/Unit/Http/Resources/EventResourceTest.php
+++ b/tests/Unit/Http/Resources/EventResourceTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Tests\Unit\Http\Resources;
+
+use App\Http\Resources\EventResource;
+use App\Models\Event;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\Request;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class EventResourceTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function it_exposes_message_id_when_present_in_event_metadata()
+    {
+        $event = Event::factory()->create([
+            'service' => 'receipt',
+            'domain' => 'money',
+            'action' => 'had_receipt_from',
+            'event_metadata' => [
+                'email_message_id' => '<invoice-abc123@digitalocean.com>',
+            ],
+        ]);
+
+        $data = (new EventResource($event))->toArray(Request::create('/'));
+
+        $this->assertSame('<invoice-abc123@digitalocean.com>', $data['message_id']);
+    }
+
+    #[Test]
+    public function it_omits_message_id_when_not_present_in_event_metadata()
+    {
+        $event = Event::factory()->create([
+            'service' => 'oura',
+            'domain' => 'health',
+            'action' => 'had_sleep_score',
+            'event_metadata' => [],
+        ]);
+
+        $data = (new EventResource($event))->toArray(Request::create('/'));
+
+        $this->assertArrayNotHasKey('message_id', $data);
+    }
+}

--- a/tests/Unit/Jobs/ProcessReceiptEmailJobTest.php
+++ b/tests/Unit/Jobs/ProcessReceiptEmailJobTest.php
@@ -9,6 +9,8 @@ use App\Models\User;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Queue;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionMethod;
 use Tests\TestCase;
 
 class ProcessReceiptEmailJobTest extends TestCase
@@ -38,7 +40,7 @@ class ProcessReceiptEmailJobTest extends TestCase
         ]);
     }
 
-    /** @test */
+    #[Test]
     public function it_can_be_instantiated()
     {
         $job = new ProcessReceiptEmailJob(
@@ -49,7 +51,7 @@ class ProcessReceiptEmailJobTest extends TestCase
         $this->assertInstanceOf(ProcessReceiptEmailJob::class, $job);
     }
 
-    /** @test */
+    #[Test]
     public function it_has_correct_timeout()
     {
         $job = new ProcessReceiptEmailJob(
@@ -60,7 +62,7 @@ class ProcessReceiptEmailJobTest extends TestCase
         $this->assertEquals(300, $job->timeout);
     }
 
-    /** @test */
+    #[Test]
     public function it_has_correct_retry_settings()
     {
         $job = new ProcessReceiptEmailJob(
@@ -72,7 +74,7 @@ class ProcessReceiptEmailJobTest extends TestCase
         $this->assertEquals([60, 300, 900], $job->backoff);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_unique_id_based_on_integration_and_s3_key()
     {
         $s3Key = 'receipts/test-email-123.eml';
@@ -85,7 +87,7 @@ class ProcessReceiptEmailJobTest extends TestCase
         $this->assertStringContainsString(md5($s3Key), $uniqueId);
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_different_unique_ids_for_different_s3_keys()
     {
         $job1 = new ProcessReceiptEmailJob(
@@ -101,7 +103,7 @@ class ProcessReceiptEmailJobTest extends TestCase
         $this->assertNotEquals($job1->uniqueId(), $job2->uniqueId());
     }
 
-    /** @test */
+    #[Test]
     public function it_generates_different_unique_ids_for_different_integrations()
     {
         $anotherIntegration = Integration::factory()->create([
@@ -119,7 +121,7 @@ class ProcessReceiptEmailJobTest extends TestCase
         $this->assertNotEquals($job1->uniqueId(), $job2->uniqueId());
     }
 
-    /** @test */
+    #[Test]
     public function it_can_be_dispatched_to_queue()
     {
         Queue::fake();
@@ -135,7 +137,7 @@ class ProcessReceiptEmailJobTest extends TestCase
         });
     }
 
-    /** @test */
+    #[Test]
     public function it_stores_s3_object_key()
     {
         $s3Key = 'receipts/folder/subfolder/email-12345.eml';
@@ -144,7 +146,7 @@ class ProcessReceiptEmailJobTest extends TestCase
         $this->assertEquals($s3Key, $job->s3ObjectKey);
     }
 
-    /** @test */
+    #[Test]
     public function it_stores_integration_reference()
     {
         $job = new ProcessReceiptEmailJob(
@@ -157,7 +159,7 @@ class ProcessReceiptEmailJobTest extends TestCase
         $this->assertEquals('receipts', $job->integration->instance_type);
     }
 
-    /** @test */
+    #[Test]
     public function it_handles_s3_keys_with_special_characters()
     {
         $s3Key = 'receipts/2024/01/email with spaces & special+chars.eml';
@@ -167,7 +169,7 @@ class ProcessReceiptEmailJobTest extends TestCase
         $this->assertStringContainsString(md5($s3Key), $job->uniqueId());
     }
 
-    /** @test */
+    #[Test]
     public function it_implements_should_queue_interface()
     {
         $job = new ProcessReceiptEmailJob(
@@ -178,7 +180,7 @@ class ProcessReceiptEmailJobTest extends TestCase
         $this->assertInstanceOf(ShouldQueue::class, $job);
     }
 
-    /** @test */
+    #[Test]
     public function it_uses_enhanced_idempotency_trait()
     {
         $job = new ProcessReceiptEmailJob(
@@ -189,5 +191,54 @@ class ProcessReceiptEmailJobTest extends TestCase
         // EnhancedIdempotency trait provides uniqueId method
         $this->assertTrue(method_exists($job, 'uniqueId'));
         $this->assertNotEmpty($job->uniqueId());
+    }
+
+    #[Test]
+    public function it_captures_the_message_id_header_when_parsing_an_email()
+    {
+        $job = new ProcessReceiptEmailJob(
+            $this->integration,
+            'receipts/test-email.eml'
+        );
+
+        $rawEmail = <<<'EMAIL'
+        From: receipts@digitalocean.com
+        To: receipts@spark.cronx.co
+        Subject: Your DigitalOcean Invoice
+        Date: Sat, 01 Aug 2026 09:10:00 +0000
+        Message-ID: <invoice-abc123@digitalocean.com>
+        Content-Type: text/plain; charset=utf-8
+
+        Thanks for your payment.
+        EMAIL;
+
+        $parseEmail = new ReflectionMethod($job, 'parseEmail');
+        $result = $parseEmail->invoke($job, $rawEmail);
+
+        $this->assertSame('invoice-abc123@digitalocean.com', $result['message_id']);
+    }
+
+    #[Test]
+    public function it_returns_an_empty_message_id_when_the_header_is_missing()
+    {
+        $job = new ProcessReceiptEmailJob(
+            $this->integration,
+            'receipts/test-email.eml'
+        );
+
+        $rawEmail = <<<'EMAIL'
+        From: receipts@digitalocean.com
+        To: receipts@spark.cronx.co
+        Subject: Your DigitalOcean Invoice
+        Date: Sat, 01 Aug 2026 09:10:00 +0000
+        Content-Type: text/plain; charset=utf-8
+
+        Thanks for your payment.
+        EMAIL;
+
+        $parseEmail = new ReflectionMethod($job, 'parseEmail');
+        $result = $parseEmail->invoke($job, $rawEmail);
+
+        $this->assertSame('', $result['message_id']);
     }
 }


### PR DESCRIPTION
## Summary
- capture receipt email Message-ID and raw email S3 key in event metadata
- expose Message-ID through the event resource
- add receipt parsing and resource coverage
- add repository Codex hook, MCP, and agent configuration

## Validation
- `./vendor/bin/duster fix --dirty`
- PHP syntax checks passed
- focused tests are blocked locally because Docker/Podman and the `pgsql` test host are unavailable